### PR TITLE
Made SelectionManager use the terminal's buffer so it's buffer can not become stale

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1122,7 +1122,6 @@ export class InputHandler implements IInputHandler {
           // if (params[0] === 1049) {
           //   this.restoreCursor(params);
           // }
-          this._terminal.selectionManager.setBuffer(this._terminal.buffer.lines);
           this._terminal.refresh(0, this._terminal.rows - 1);
           this._terminal.viewport.syncScrollArea();
           this._terminal.showCursor();


### PR DESCRIPTION
Fixes issue with copy in VIM and other programs not working because the buffer was not updated. Instead of SelectionManager using it's own buffer, it works with what is being displayed on the screen. 

Fixes /Microsoft/vscode/issues/25000