### PR TITLE
Upgrade node-pty to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdoc": "3.4.3",
     "jsdom": "^11.1.0",
     "merge-stream": "^1.0.1",
-    "node-pty": "^0.4.1",
+    "node-pty": "^0.7.2",
     "nodemon": "1.10.2",
     "sorcery": "^0.10.0",
     "tslint": "^4.0.2",


### PR DESCRIPTION
I exposed the missing API again in node-pty so that we can upgrade, this greatly improves Windows support in the demo and also supports binary output. See https://github.com/Tyriar/node-pty/issues/153

/cc @FGasper 