### PR TITLE
Add winptyCompat addon

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -12,6 +12,7 @@
         <script src="/build/addons/fit/fit.js" ></script>
         <script src="/build/addons/fullscreen/fullscreen.js" ></script>
         <script src="/build/addons/search/search.js" ></script>
+        <script src="/build/addons/winptyCompat/winptyCompat.js" ></script>
     </head>
     <body>
         <h1>xterm.js: xterm, in the browser</h1>

--- a/demo/main.js
+++ b/demo/main.js
@@ -91,6 +91,7 @@ function createTerminal() {
 
   term.open(terminalContainer);
   term.fit();
+  term.winptyCompatInit();
 
   // fit is called within a setTimeout, cols and rows need this.
   setTimeout(function () {

--- a/fixtures/typings-test/typings-test.ts
+++ b/fixtures/typings-test/typings-test.ts
@@ -41,6 +41,7 @@ namespace static_methods {
     Terminal.loadAddon('fullscreen');
     Terminal.loadAddon('search');
     Terminal.loadAddon('terminado');
+    Terminal.loadAddon('winptyCompat');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdoc": "3.4.3",
     "jsdom": "^11.1.0",
     "merge-stream": "^1.0.1",
-    "node-pty": "^0.4.1",
+    "node-pty": "^0.6.0",
     "nodemon": "1.10.2",
     "sorcery": "^0.10.0",
     "tslint": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdoc": "3.4.3",
     "jsdom": "^11.1.0",
     "merge-stream": "^1.0.1",
-    "node-pty": "^0.6.0",
+    "node-pty": "^0.7.2",
     "nodemon": "1.10.2",
     "sorcery": "^0.10.0",
     "tslint": "^4.0.2",

--- a/src/addons/winptyCompat/tsconfig.json
+++ b/src/addons/winptyCompat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "rootDir": ".",
+    "outDir": "../../../lib/addons/winptyCompat/",
+    "sourceMap": true,
+    "removeComments": true
+  }
+}

--- a/src/addons/winptyCompat/winptyCompat.ts
+++ b/src/addons/winptyCompat/winptyCompat.ts
@@ -43,7 +43,7 @@ declare var define: any;
     // wrapped.
     this.on('lineFeed', () => {
       const line = this.buffer.lines.get(this.buffer.ybase + this.buffer.y - 1);
-      const lastChar = line[line.length - 1];
+      const lastChar = line[this.cols - 1];
       if (lastChar[3] !== 32 /* ' ' */) {
         const nextLine = this.buffer.lines.get(this.buffer.ybase + this.buffer.y);
         (<any>nextLine).isWrapped = true;

--- a/src/addons/winptyCompat/winptyCompat.ts
+++ b/src/addons/winptyCompat/winptyCompat.ts
@@ -4,10 +4,7 @@
  */
 
 declare var exports: any;
-declare var module: any;
 declare var define: any;
-declare var require: any;
-declare var window: any;
 
 (function (addon) {
   if (typeof window !== 'undefined' && 'Terminal' in window) {

--- a/src/addons/winptyCompat/winptyCompat.ts
+++ b/src/addons/winptyCompat/winptyCompat.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+declare var exports: any;
+declare var module: any;
+declare var define: any;
+declare var require: any;
+declare var window: any;
+
+(function (addon) {
+  if (typeof window !== 'undefined' && 'Terminal' in window) {
+    /**
+     * Plain browser environment
+     */
+    addon((<any>window).Terminal);
+  } else if (typeof exports === 'object' && typeof module === 'object') {
+    /**
+     * CommonJS environment
+     */
+    module.exports = addon(require('../../Terminal').Terminal);
+  } else if (typeof define === 'function') {
+    /**
+     * Require.js is available
+     */
+    define(['../../xterm'], addon);
+  }
+})((Terminal: any) => {
+  Terminal.prototype.winptyCompatInit = function(): void {
+    // Don't do anything when the platform is not Windows
+    const isWindows = ['Windows', 'Win16', 'Win32', 'WinCE'].indexOf(navigator.platform) >= 0;
+    if (!isWindows) {
+      return;
+    }
+
+    // Winpty does not support wraparound mode which means that lines will never
+    // be marked as wrapped. This causes issues for things like copying a line
+    // retaining the wrapped new line characters or if consumers are listening
+    // in on the data stream.
+    //
+    // The workaround for this is to listen to every incoming line feed and mark
+    // the line as wrapped if the last character in the previous line is not a
+    // space. This is certainly not without its problems, but generally on
+    // Windows when text reaches the end of the terminal it's likely going to be
+    // wrapped.
+    this.on('lineFeed', () => {
+      const line = this.buffer.lines.get(this.buffer.ybase + this.buffer.y - 1);
+      const lastChar = line[line.length - 1];
+      if (lastChar[3] !== 32 /* ' ' */) {
+        const nextLine = this.buffer.lines.get(this.buffer.ybase + this.buffer.y);
+        (<any>nextLine).isWrapped = true;
+      }
+    });
+  };
+});

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -513,6 +513,6 @@ declare module 'xterm' {
      * available to all newly created Terminals.
      * @param addon The addon to load.
      */
-    static loadAddon(addon: 'attach' | 'fit' | 'fullscreen' | 'search' | 'terminado'): void;
+    static loadAddon(addon: 'attach' | 'fit' | 'fullscreen' | 'search' | 'terminado' | 'winptyCompat'): void;
   }
 }


### PR DESCRIPTION
Fixes #1095

---

This addon provides a workaround for wraparound mode not working in winpty. It works by flagging lines as wrapped when the last character in the terminal is not empty. See https://github.com/Microsoft/vscode/issues/32042 and the comments in the addon itself for more details on how it works.