### PR TITLE
Fix deleteChars not updating the view

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -497,6 +497,7 @@ export class InputHandler implements IInputHandler {
       this._terminal.buffer.lines.get(row).splice(this._terminal.buffer.x, 1);
       this._terminal.buffer.lines.get(row).push(ch);
     }
+    this._terminal.updateRange(this._terminal.buffer.y);
   }
 
   /**


### PR DESCRIPTION
When deleting a character in a line and moving the cursor to
another line afterwards, the deletion is not rendered.

This commit adds the line where the character was deleted
to the refresh range to enforce an update.

Fixes https://github.com/xtermjs/xterm.js/issues/1110