### PR TITLE
Fix cursor on focus

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -441,6 +441,7 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
    * Binds the desired focus behavior on a given terminal object.
    */
   private _onTextAreaFocus(): void {
+    this.refresh(this.buffer.y, this.buffer.y);
     if (this.sendFocus) {
       this.send(C0.ESC + '[I');
     }


### PR DESCRIPTION
In case of multiple terms in same document, cursor is not refreshed when focusing.
To fix that, this PR adds same refresh mechanism as blur.