### PR TITLE
Move selection event emission to the terminal object

### DIFF
--- a/src/SelectionManager.test.ts
+++ b/src/SelectionManager.test.ts
@@ -14,6 +14,10 @@ import { BufferSet } from './BufferSet';
 import { MockTerminal } from './utils/TestUtils.test';
 import { LineData, CharData } from './Types';
 
+class TestMockTerminal extends MockTerminal {
+  emit(event: string, data: any): void {}
+}
+
 class TestSelectionManager extends SelectionManager {
   constructor(
     terminal: ITerminal,
@@ -48,7 +52,7 @@ describe('SelectionManager', () => {
     dom = new jsdom.JSDOM('');
     window = dom.window;
     document = window.document;
-    terminal = new MockTerminal();
+    terminal = new TestMockTerminal();
     terminal.cols = 80;
     terminal.rows = 2;
     terminal.options.scrollback = 100;

--- a/src/SelectionManager.ts
+++ b/src/SelectionManager.ts
@@ -255,7 +255,7 @@ export class SelectionManager extends EventEmitter implements ISelectionManager 
   public selectAll(): void {
     this._model.isSelectAllActive = true;
     this.refresh();
-    this.emit('selection');
+    this._terminal.emit('selection');
   }
 
   /**
@@ -544,7 +544,7 @@ export class SelectionManager extends EventEmitter implements ISelectionManager 
     this._removeMouseDownListeners();
 
     if (this.hasSelection)
-      this.emit('selection');
+      this._terminal.emit('selection');
   }
 
   /**


### PR DESCRIPTION
Currently, the 'selection' is fired on the SelectionManager instance so to listen to the selection event you have to do `term.selectionManager.on('selection')`. Seems like this event should be emitted by the terminal instead. Feel free to close if I am incorrect. 