### PR TITLE
Improved key mapping

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -89,13 +89,7 @@ function createTerminal() {
   term = new Terminal({
     cursorBlink: optionElements.cursorBlink.checked,
     scrollback: parseInt(optionElements.scrollback.value, 10),
-    tabStopWidth: parseInt(optionElements.tabstopwidth.value, 10),
-    translations: {
-      // XXX: only these are supported now
-      Home  : '\x1b[1~',
-      End   : '\x1b[4~',
-      Esc   : '\x1b[20~'
-    }
+    tabStopWidth: parseInt(optionElements.tabstopwidth.value, 10)
   });
   window.term = term;  // Expose `term` to window for debugging purposes
   term.on('resize', function (size) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -89,7 +89,13 @@ function createTerminal() {
   term = new Terminal({
     cursorBlink: optionElements.cursorBlink.checked,
     scrollback: parseInt(optionElements.scrollback.value, 10),
-    tabStopWidth: parseInt(optionElements.tabstopwidth.value, 10)
+    tabStopWidth: parseInt(optionElements.tabstopwidth.value, 10),
+    translations: {
+      // XXX: only these are supported now
+      Home  : '\x1b[1~',
+      End   : '\x1b[4~',
+      Esc   : '\x1b[20~'
+    }
   });
   window.term = term;  // Expose `term` to window for debugging purposes
   term.on('resize', function (size) {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -150,6 +150,7 @@ export interface ITerminalOptions {
   termName?: string;
   theme?: ITheme;
   useFlowControl?: boolean;
+  translations?: object;
 }
 
 export interface IBuffer {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -150,7 +150,7 @@ export interface ITerminalOptions {
   termName?: string;
   theme?: ITheme;
   useFlowControl?: boolean;
-  translations?: object;
+  keyMap?: object;
 }
 
 export interface IBuffer {

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -84,7 +84,8 @@ const DEFAULT_OPTIONS: ITerminalOptions = {
   disableStdin: false,
   useFlowControl: false,
   tabStopWidth: 8,
-  theme: null
+  theme: null,
+  translations: {}
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -1413,6 +1414,7 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
       scrollLines: undefined
     };
     const modifiers = (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0) | (ev.metaKey ? 8 : 0);
+    const translations = this.getOption('translations');
     switch (ev.keyCode) {
       case 0:
         if (ev.key === 'UIKeyInputUpArrow') {
@@ -1468,8 +1470,12 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 27:
         // escape
-        result.key = C0.ESC;
-        result.cancel = true;
+        if (translations['Esc'])
+          result.key = translations['Esc'];
+        else {
+          result.key = C0.ESC;
+          result.cancel = true;
+        }
         break;
       case 37:
         // left-arrow
@@ -1551,7 +1557,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 36:
         // home
-        if (modifiers)
+        if (translations['Home'])
+          result.key = translations['Home'];
+        else if (modifiers)
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'H';
         else if (this.applicationCursor)
           result.key = C0.ESC + 'OH';
@@ -1560,7 +1568,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 35:
         // end
-        if (modifiers)
+        if (translations['End'])
+          result.key = translations['End'];
+        else if (modifiers)
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'F';
         else if (this.applicationCursor)
           result.key = C0.ESC + 'OF';

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -85,7 +85,7 @@ const DEFAULT_OPTIONS: ITerminalOptions = {
   useFlowControl: false,
   tabStopWidth: 8,
   theme: null,
-  translations: {}
+  keyMap: {}
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -121,6 +121,8 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
 
   private sendDataQueue: string;
   private customKeyEventHandler: CustomKeyEventHandler;
+
+  private _keyMapCache: any;
 
   // modes
   public applicationKeypad: boolean;
@@ -303,6 +305,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
     if (this.selectionManager) {
       this.selectionManager.setBuffer(this.buffer);
     }
+
+    // Build keyMap cache
+    this._rebuildKeyMapCache();
   }
 
   /**
@@ -427,6 +432,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
       case 'tabStopWidth': this.buffers.setupTabStops(); break;
       case 'bellSound':
       case 'bellStyle': this.syncBellSound(); break;
+      case 'keyMap':
+        this._rebuildKeyMapCache();
+        break;
     }
     // Inform renderer of changes
     if (this.renderer) {
@@ -1397,6 +1405,62 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
   }
 
   /**
+   * Returns an object that contains keyName and numeric representative of modifiers
+   * included in the input string.
+   * The input string can be: 'Control+Alt-F1' hence '+' and '-' delimiters are allowed
+   * and it is not order sensitive.
+   * @param keyWithModStr The key binding string.
+   */
+  protected _parseKeyWithModsString(keyWithModStr: string): {mods: number, key: string} {
+    const keys = keyWithModStr.toUpperCase().split(/\+|-/);
+    let [len, mods, key] = [keys.length, 0, null];
+    while (len--) {
+      switch (keys[len]) {
+        case 'S':
+        case 'SHIFT':
+          mods |= 1;
+          break;
+        case 'A':
+        case 'ALT':
+          mods |= 2;
+          break;
+        case 'C':
+        case 'CTRL':
+        case 'CONTROL':
+          mods |= 4;
+          break;
+        case 'M':
+        case 'META':
+          mods |= 8;
+          break;
+        default:
+          if (key) throw Error('Invariant: more than one non-modified key: ' + keyWithModStr);
+          key = keys[len];
+          break;
+      }
+    }
+    return { mods, key };
+  }
+
+  protected _rebuildKeyMapCache(): void {
+    const keyMap = this.getOption('keyMap');
+    let result = {};
+    Object.keys (keyMap).forEach ((keyWithModStr) => {
+      const keyProps = this._parseKeyWithModsString (keyWithModStr);
+      // NOTE: This could be a single number if we could resolve key back to its keyCode.
+      // The question is if it is cheaper to build a code<=>name conversion table or to
+      // keep _keyMapCache as a two-dimensional string-number indexed array rather than
+      // one dimensional number indexed one.
+      // If we had this table, we could also have faster getKeyMapping calls and call
+      // it once per key!
+      result[keyProps.key] = result[keyProps.key] || {};
+      result[keyProps.key][keyProps.mods] = keyMap [keyWithModStr];
+    });
+    this._keyMapCache = result;
+    console.log (this._keyMapCache);
+  }
+
+  /**
    * Returns an object that determines how a KeyboardEvent should be handled. The key of the
    * returned value is the new key code to pass to the PTY.
    *
@@ -1414,7 +1478,7 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
       scrollLines: undefined
     };
     const modifiers = (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0) | (ev.metaKey ? 8 : 0);
-    const translations = this.getOption('translations');
+    const getKeyMapping = (keyName) => this._keyMapCache[keyName.toUpperCase()][modifiers];
     switch (ev.keyCode) {
       case 0:
         if (ev.key === 'UIKeyInputUpArrow') {
@@ -1470,8 +1534,8 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 27:
         // escape
-        if (translations['Esc'])
-          result.key = translations['Esc'];
+        if (getKeyMapping('Esc'))
+          result.key = getKeyMapping('Esc');
         else {
           result.key = C0.ESC;
           result.cancel = true;
@@ -1541,7 +1605,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 45:
         // insert
-        if (!ev.shiftKey && !ev.ctrlKey) {
+        if (getKeyMapping('Insert'))
+          result.key = getKeyMapping('Insert');
+        else if (!ev.shiftKey && !ev.ctrlKey) {
           // <Ctrl> or <Shift> + <Insert> are used to
           // copy-paste on some systems.
           result.key = C0.ESC + '[2~';
@@ -1557,8 +1623,8 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 36:
         // home
-        if (translations['Home'])
-          result.key = translations['Home'];
+        if (getKeyMapping('Home'))
+          result.key = getKeyMapping('Home');
         else if (modifiers)
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'H';
         else if (this.applicationCursor)
@@ -1568,8 +1634,8 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         break;
       case 35:
         // end
-        if (translations['End'])
-          result.key = translations['End'];
+        if (getKeyMapping('End'))
+          result.key = getKeyMapping('End');
         else if (modifiers)
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'F';
         else if (this.applicationCursor)
@@ -1593,86 +1659,233 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
           result.key = C0.ESC + '[6~';
         }
         break;
+      case 93:
+        // Select
+        if (getKeyMapping('Select'))
+          result.key = getKeyMapping('Select');
+        // XXX: default behaviour?
+        break;
+      case 96:
+        // KP_0
+        if (getKeyMapping('KP_0'))
+          result.key = getKeyMapping('KP_0');
+        else
+          result.key = '0';
+        break;
+      case 97:
+        // KP_1
+        if (getKeyMapping('KP_1'))
+          result.key = getKeyMapping('KP_1');
+        else
+          result.key = '1';
+        break;
+      case 98:
+        // KP_2
+        if (getKeyMapping('KP_2'))
+          result.key = getKeyMapping('KP_2');
+        else
+          result.key = '2';
+        break;
+      case 99:
+        // KP_3
+        if (getKeyMapping('KP_3'))
+          result.key = getKeyMapping('KP_3');
+        else
+          result.key = '3';
+        break;
+      case 100:
+        // KP_4
+        if (getKeyMapping('KP_4'))
+          result.key = getKeyMapping('KP_4');
+        else
+          result.key = '4';
+        break;
+      case 101:
+        // KP_5
+        if (getKeyMapping('KP_5'))
+          result.key = getKeyMapping('KP_5');
+        else
+          result.key = '5';
+        break;
+      case 102:
+        // KP_6
+        if (getKeyMapping('KP_6'))
+          result.key = getKeyMapping('KP_6');
+        else
+          result.key = '6';
+        break;
+      case 103:
+        // KP_7
+        if (getKeyMapping('KP_7'))
+          result.key = getKeyMapping('KP_7');
+        else
+          result.key = '7';
+        break;
+      case 104:
+        // KP_8
+        if (getKeyMapping('KP_8'))
+          result.key = getKeyMapping('KP_8');
+        else
+          result.key = '8';
+        break;
+      case 105:
+        // KP_9
+        if (getKeyMapping('KP_9'))
+          result.key = getKeyMapping('KP_9');
+        else
+          result.key = '9';
+        break;
+      case 106:
+        // KP_Multiply
+        if (getKeyMapping('KP_Multiply'))
+          result.key = getKeyMapping('KP_Multiply');
+        else
+          result.key = '*';
+        break;
+      case 107:
+        // KP_Add
+        if (getKeyMapping('KP_Add'))
+          result.key = getKeyMapping('KP_Add');
+        else
+          result.key = '+';
+        break;
+      case 109:
+        // KP_Subtract
+        if (getKeyMapping('KP_Subtract'))
+          result.key = getKeyMapping('KP_Subtract');
+        else
+          result.key = '-';
+        break;
+      case 110:
+        // KP_Decimal
+        if (getKeyMapping('KP_Decimal'))
+          result.key = getKeyMapping('KP_Decimal');
+        else
+          result.key = '.';
+        break;
+      case 111:
+        // KP_Divide
+        if (getKeyMapping('KP_Divide'))
+          result.key = getKeyMapping('KP_Divide');
+        else
+          result.key = '/';
+        break;
+      case 144:
+        // NumLock
+        if (getKeyMapping('NumLock'))
+          result.key = getKeyMapping('NumLock');
+        // XXX: default behaviour?
+        break;
+      case 144:
+        // ScrollLock
+        if (getKeyMapping('ScrollLock'))
+          result.key = getKeyMapping('ScrollLock');
+        // XXX: default behaviour?
+        break;
       case 112:
         // F1-F12
-        if (modifiers) {
+        if (getKeyMapping('F1'))
+          result.key = getKeyMapping('F1');
+        else if (modifiers) {
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'P';
         } else {
           result.key = C0.ESC + 'OP';
         }
         break;
       case 113:
-        if (modifiers) {
+        if (getKeyMapping('F2'))
+          result.key = getKeyMapping('F2');
+        else if (modifiers) {
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'Q';
         } else {
           result.key = C0.ESC + 'OQ';
         }
         break;
       case 114:
-        if (modifiers) {
+        if (getKeyMapping('F3'))
+          result.key = getKeyMapping('F3');
+        else if (modifiers) {
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'R';
         } else {
           result.key = C0.ESC + 'OR';
         }
         break;
       case 115:
-        if (modifiers) {
+        if (getKeyMapping('F4'))
+          result.key = getKeyMapping('F4');
+        else if (modifiers) {
           result.key = C0.ESC + '[1;' + (modifiers + 1) + 'S';
         } else {
           result.key = C0.ESC + 'OS';
         }
         break;
       case 116:
-        if (modifiers) {
+        if (getKeyMapping('F5'))
+          result.key = getKeyMapping('F5');
+        else if (modifiers) {
           result.key = C0.ESC + '[15;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[15~';
         }
         break;
       case 117:
-        if (modifiers) {
+        if (getKeyMapping('F6'))
+          result.key = getKeyMapping('F6');
+        else if (modifiers) {
           result.key = C0.ESC + '[17;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[17~';
         }
         break;
       case 118:
-        if (modifiers) {
+        if (getKeyMapping('F7'))
+          result.key = getKeyMapping('F7');
+        else if (modifiers) {
           result.key = C0.ESC + '[18;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[18~';
         }
         break;
       case 119:
-        if (modifiers) {
+        if (getKeyMapping('F8'))
+          result.key = getKeyMapping('F8');
+        else if (modifiers) {
           result.key = C0.ESC + '[19;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[19~';
         }
         break;
       case 120:
-        if (modifiers) {
+        if (getKeyMapping('F9'))
+          result.key = getKeyMapping('F9');
+        else if (modifiers) {
           result.key = C0.ESC + '[20;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[20~';
         }
         break;
       case 121:
-        if (modifiers) {
+        if (getKeyMapping('F10'))
+          result.key = getKeyMapping('F10');
+        else if (modifiers) {
           result.key = C0.ESC + '[21;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[21~';
         }
         break;
       case 122:
-        if (modifiers) {
+        if (getKeyMapping('F11'))
+          result.key = getKeyMapping('F11');
+        else if (modifiers) {
           result.key = C0.ESC + '[23;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[23~';
         }
         break;
       case 123:
-        if (modifiers) {
+        if (getKeyMapping('F12'))
+          result.key = getKeyMapping('F12');
+        else if (modifiers) {
           result.key = C0.ESC + '[24;' + (modifiers + 1) + '~';
         } else {
           result.key = C0.ESC + '[24~';

--- a/src/utils/KeyMap.test.ts
+++ b/src/utils/KeyMap.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { C0 } from '../EscapeSequences';
+import { KeyMap, IKeyMap, IKeyMapEnv, IKeyHandlerResult, IKeyboardEvent, MODIFIERS } from './KeyMap';
+
+const keyMapEnv: IKeyMapEnv = {
+  browser: {
+    isNode: true,
+    userAgent: 'curl',
+    platform: 'Linux',
+    isFirefox: false,
+    isMSIE: false,
+    isMac: false,
+    isIpad: false,
+    isIphone: false,
+    isMSWindows: false
+  },
+  applicationCursor: false,
+  rows: 24,
+  cols: 80
+};
+
+describe('KeyMap', () => {
+  describe('no options passed, key name/code resolution', () => {
+    it('try to resolve some keys by name', () => {
+      const keyMap = new KeyMap({});
+      assert.equal(keyMap.getKeyCodeByName('Enter'), 13);
+      assert.equal(keyMap.getKeyCodeByName('KP1'),   97);
+      assert.equal(keyMap.getKeyCodeByName('F4'),   115);
+    });
+    it('try to resolve some keys by code', () => {
+      const keyMap = new KeyMap({});
+      assert.deepEqual(keyMap.getKeyNamesByCode(13).sort(), ['Enter', 'Return'].sort());
+      assert.deepEqual(keyMap.getKeyNamesByCode(99).sort(), ['KP3', 'KP_3'].sort());
+    });
+  });
+  describe('check mapping', () => {
+    it('plain mapping w/o modifiers', () => {
+      const keyMap = new KeyMap({ 'F1' : 'functionKey1' });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('F1', keyMapEnv);
+      assert.equal(result.key, 'functionKey1');
+    });
+    it('plain mapping from KeyboardEvent', () => {
+      const keyMap: IKeyMap = new KeyMap({ 'F1' : 'functionKey1' });
+      const ev: IKeyboardEvent = {
+        keyCode   : 112,
+        shiftKey  : false,
+        altKey    : false,
+        ctrlKey   : false,
+        metaKey   : false
+      };
+      const result: IKeyHandlerResult = keyMap.mapFromKeyboardEvent(ev, keyMapEnv);
+      assert.equal(result.key, 'functionKey1');
+    });
+    it('advanced object mapping w/o modifiers', () => {
+      const keyMap = new KeyMap({ 'F1' : { key: 'functionKey1', cancel: true } });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('F1', keyMapEnv);
+      assert.equal(result.key, 'functionKey1');
+      assert.equal(result.cancel, true);
+      assert.equal(result.scrollLines, undefined);
+    });
+    it('Control-F5 retrieved as Control-F5', () => {
+      const keyMap = new KeyMap({ 'Control-F5' : 'functionKey5WithControl' });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('Control-F5', keyMapEnv);
+      assert.equal(result.key, 'functionKey5WithControl');
+    });
+    it('Control-F5 retrieved as Control+F5', () => {
+      const keyMap = new KeyMap({ 'Control-F5' : 'functionKey5WithControl' });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('Control+F5', keyMapEnv);
+      assert.equal(result.key, 'functionKey5WithControl');
+    });
+    it('Control-F5 retrieved as C-F5', () => {
+      const keyMap = new KeyMap({ 'Control-F5' : 'functionKey5WithControl' });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('C-F5', keyMapEnv);
+      assert.equal(result.key, 'functionKey5WithControl');
+    });
+    it('Home retrieved as HOME', () => {
+      const keyMap = new KeyMap({ 'Home' : 'HOME_KEY_BINDING' });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('HOME', keyMapEnv);
+      assert.equal(result.key, 'HOME_KEY_BINDING');
+    });
+    it('DELETE retrieved as Del', () => {
+      const keyMap = new KeyMap({ 'Home' : 'HOME_KEY_BINDING' });
+      const result: IKeyHandlerResult = keyMap.mapFromKeyCombinationName('HOME', keyMapEnv);
+      assert.equal(result.key, 'HOME_KEY_BINDING');
+    });
+    it('multiple mappings, last wins', () => {
+      const keyMap = new KeyMap({
+        'M-A-C-S-F1' : 'MACSF1',
+        'M-A-C-F1'   : 'MACF1',
+        'M-A-F1'     : 'MAF1',
+        'M-F1'       : 'MF1',
+        // The same mappings redefined -- last entry wins !
+        'F1-S-C-A-M' : 'F1SCAM',
+        'F1-C-A-M'   : 'F1CAM',
+        'F1-A-M'     : 'F1AM',
+        'F1-M'       : 'F1M'
+      });
+      assert.equal(keyMap.mapFromKeyCombinationName('Meta-Alt-Control-Shift-F1', keyMapEnv).key, 'F1SCAM');
+      assert.equal(keyMap.mapFromKeyCombinationName('Meta-Alt-Control-F1', keyMapEnv).key, 'F1CAM');
+      assert.equal(keyMap.mapFromKeyCombinationName('M+ALT+F1', keyMapEnv).key, 'F1AM');
+      assert.equal(keyMap.mapFromKeyCombinationName('META-F1', keyMapEnv).key, 'F1M');
+    });
+    it('verify default mapping for F5', () => {
+      const keyMap = new KeyMap({});
+      const F5 = keyMap.mapFromKeyCombinationName('F5', keyMapEnv).key.replace(C0.ESC, '^');
+      const F5seq = '^[15~';
+      assert.equal(F5, F5seq);
+    });
+    it('verify default mapping for C-F5', () => {
+      const keyMap = new KeyMap({});
+      const ctrlF5 = keyMap.mapFromKeyCombinationName('C-F5', keyMapEnv).key.replace(C0.ESC, '^');
+      const ctrlF5seq = '^[15;5~';
+      assert.equal(ctrlF5, ctrlF5seq);
+    });
+    it('C-F5 override even if F5 main handler is set', () => {
+      const keyMap = new KeyMap({ 'Control+F5': 'overrideF5' });
+      const ctrlF5 = keyMap.mapFromKeyCombinationName('C-F5', keyMapEnv).key.replace(C0.ESC, '^');
+      assert.equal(ctrlF5, 'overrideF5');
+    });
+    it('multiple non-modifier keys invariant', () => {
+      const keyMap = new KeyMap({});
+      assert.throws(() => {
+        keyMap.mapFromKeyCombinationName('F1+F2+F3', keyMapEnv);
+      }, /Invariant: more than one non-modifier keys are not allowed/);
+    });
+    it('unsupported keys invariant', () => {
+      const keyMap = new KeyMap({});
+      assert.throws(() => {
+        keyMap.mapFromKeyCombinationName('Compose+PF1', keyMapEnv);
+      }, /Invariant: unsupported key name/);
+    });
+    it('invalid mapping invariant for invalid binding value (number)', () => {
+      // neither string nor object!
+      assert.throws(() => {
+        new KeyMap({ 'F1': 1234 });
+      }, /Invariant: KeyMap entry must map key combinations to IKeyHandlerResult/);
+    });
+    it('invalid mapping invariant for callback with modifiers', () => {
+      // function can be passed only to F1, not to Control+F1!
+      assert.throws(() => {
+        new KeyMap({ 'Control+F1': () => ({ key: 'myF1Mapping' }) });
+      }, /Invariant: generic key handler function can be defined only for a fallback key without modifiers/);
+    });
+  });
+  describe('check default mapping', () => {
+    const keyMap = new KeyMap({});
+    for (let i = 0; i < 256; i++) {
+      let names = keyMap.getKeyNamesByCode(i);
+      if (!names) continue; // undefined key
+      for (let mods = 0; mods < 16; mods++) {
+        let ev: IKeyboardEvent = {
+          keyCode   : i,
+          shiftKey  : !!(mods & MODIFIERS.SHIFT),
+          altKey    : !!(mods & MODIFIERS.ALT),
+          ctrlKey   : !!(mods & MODIFIERS.CONTROL),
+          metaKey   : !!(mods & MODIFIERS.META)
+        };
+        let strMods = [
+          ev.shiftKey? '+Shift' : '',
+          ev.altKey?   '+Alt'   : '',
+          ev.ctrlKey?  '+Ctrl'  : '',
+          ev.metaKey?  '+Meta'  : ''
+        ].join('');
+        for (let k = 0; k < 4; k++) {
+          let myEnv = {
+            ...keyMapEnv,
+            applicationCursor: !(k & 1),
+            browser: { ...keyMapEnv.browser, isMac: !(k & 2) }
+          };
+          let checkName = 'check ' + names.join('/') + ' [' + i + '] ' + strMods +
+            ' appCursor=' + (myEnv.applicationCursor? 'on' : 'off') +
+            ' isMac=' + (myEnv.browser.isMac? 'on' : 'off');
+          it(checkName, () => {
+            const result: IKeyHandlerResult = keyMap.mapFromKeyboardEvent(ev, myEnv);
+            const defaultResult: IKeyHandlerResult = getDefaultMapping (keyMap, ev, myEnv);
+            assert.equal(result? result.key : undefined, defaultResult? defaultResult.key : undefined);
+          });
+        }
+      }
+    }
+  });
+});
+
+const getDefaultMapping = (keyMap: IKeyMap, ev: IKeyboardEvent, env: IKeyMapEnv) => {
+  const result: IKeyHandlerResult = {
+    // Whether to cancel event propogation (NOTE: this may not be needed since the event is
+    // canceled at the end of keyDown
+    cancel: false,
+    // The new key even to emit
+    key: undefined,
+    // The number of characters to scroll, if this is defined it will cancel the event
+    scrollLines: undefined
+  };
+  const modifiers = keyMap.modifiersFromKeyboardEvent(ev);
+  switch (ev.keyCode) {
+      case 8:
+        // backspace
+        if (ev.shiftKey) {
+          result.key = C0.BS; // ^H
+          break;
+        }
+        result.key = C0.DEL; // ^?
+        break;
+      case 9:
+        // tab
+        if (ev.shiftKey) {
+          result.key = C0.ESC + '[Z';
+          break;
+        }
+        result.key = C0.HT;
+        result.cancel = true;
+        break;
+      case 13:  // main enter/return
+      case 176: // keypad enter
+        // return/enter
+        result.key = C0.CR;
+        result.cancel = true;
+        break;
+      case 27:
+        // escape
+        result.key = C0.ESC;
+        result.cancel = true;
+        break;
+      case 37:
+        // left-arrow
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'D';
+          // HACK: Make Alt + left-arrow behave like Ctrl + left-arrow: move one word backwards
+          // http://unix.stackexchange.com/a/108106
+          // macOS uses different escape sequences than linux
+          if (result.key === C0.ESC + '[1;3D') {
+            result.key = (env.browser.isMac) ? C0.ESC + 'b' : C0.ESC + '[1;5D';
+          }
+        } else if (env.applicationCursor) {
+          result.key = C0.ESC + 'OD';
+        } else {
+          result.key = C0.ESC + '[D';
+        }
+        break;
+      case 39:
+        // right-arrow
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'C';
+          // HACK: Make Alt + right-arrow behave like Ctrl + right-arrow: move one word forward
+          // http://unix.stackexchange.com/a/108106
+          // macOS uses different escape sequences than linux
+          if (result.key === C0.ESC + '[1;3C') {
+            result.key = (env.browser.isMac) ? C0.ESC + 'f' : C0.ESC + '[1;5C';
+          }
+        } else if (env.applicationCursor) {
+          result.key = C0.ESC + 'OC';
+        } else {
+          result.key = C0.ESC + '[C';
+        }
+        break;
+      case 38:
+        // up-arrow
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'A';
+          // HACK: Make Alt + up-arrow behave like Ctrl + up-arrow
+          // http://unix.stackexchange.com/a/108106
+          if (result.key === C0.ESC + '[1;3A') {
+            result.key = C0.ESC + '[1;5A';
+          }
+        } else if (env.applicationCursor) {
+          result.key = C0.ESC + 'OA';
+        } else {
+          result.key = C0.ESC + '[A';
+        }
+        break;
+      case 40:
+        // down-arrow
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'B';
+          // HACK: Make Alt + down-arrow behave like Ctrl + down-arrow
+          // http://unix.stackexchange.com/a/108106
+          if (result.key === C0.ESC + '[1;3B') {
+            result.key = C0.ESC + '[1;5B';
+          }
+        } else if (env.applicationCursor) {
+          result.key = C0.ESC + 'OB';
+        } else {
+          result.key = C0.ESC + '[B';
+        }
+        break;
+      case 45:
+        // insert
+        if (!ev.shiftKey && !ev.ctrlKey) {
+          // <Ctrl> or <Shift> + <Insert> are used to
+          // copy-paste on some systems.
+          result.key = C0.ESC + '[2~';
+        }
+        break;
+      case 46:
+        // delete
+        if (modifiers) {
+          result.key = C0.ESC + '[3;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[3~';
+        }
+        break;
+      case 36:
+        // home
+        if (modifiers)
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'H';
+        else if (env.applicationCursor)
+          result.key = C0.ESC + 'OH';
+        else
+          result.key = C0.ESC + '[H';
+        break;
+      case 35:
+        // end
+        if (modifiers)
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'F';
+        else if (env.applicationCursor)
+          result.key = C0.ESC + 'OF';
+        else
+          result.key = C0.ESC + '[F';
+        break;
+      case 33:
+        // page up
+        if (ev.shiftKey) {
+          result.scrollLines = -(env.rows - 1);
+        } else {
+          result.key = C0.ESC + '[5~';
+        }
+        break;
+      case 34:
+        // page down
+        if (ev.shiftKey) {
+          result.scrollLines = env.rows - 1;
+        } else {
+          result.key = C0.ESC + '[6~';
+        }
+        break;
+      case 96:
+        // KP_0
+        result.key = '0';
+        break;
+      case 97:
+        // KP_1
+        result.key = '1';
+        break;
+      case 98:
+        // KP_2
+        result.key = '2';
+        break;
+      case 99:
+        // KP_3
+        result.key = '3';
+        break;
+      case 100:
+        // KP_4
+        result.key = '4';
+        break;
+      case 101:
+        // KP_5
+        result.key = '5';
+        break;
+      case 102:
+        // KP_6
+        result.key = '6';
+        break;
+      case 103:
+        // KP_7
+        result.key = '7';
+        break;
+      case 104:
+        // KP_8
+        result.key = '8';
+        break;
+      case 105:
+        // KP_9
+        result.key = '9';
+        break;
+      case 106:
+        // KP_Multiply
+        result.key = '*';
+        break;
+      case 107:
+        // KP_Add
+        result.key = '+';
+        break;
+      case 109:
+        // KP_Subtract
+        result.key = '-';
+        break;
+      case 110:
+        // KP_Decimal
+        result.key = '.';
+        break;
+      case 111:
+        // KP_Divide
+        result.key = '/';
+        break;
+      case 112:
+        // F1-F12
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'P';
+        } else {
+          result.key = C0.ESC + 'OP';
+        }
+        break;
+      case 113:
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'Q';
+        } else {
+          result.key = C0.ESC + 'OQ';
+        }
+        break;
+      case 114:
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'R';
+        } else {
+          result.key = C0.ESC + 'OR';
+        }
+        break;
+      case 115:
+        if (modifiers) {
+          result.key = C0.ESC + '[1;' + (modifiers + 1) + 'S';
+        } else {
+          result.key = C0.ESC + 'OS';
+        }
+        break;
+      case 116:
+        if (modifiers) {
+          result.key = C0.ESC + '[15;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[15~';
+        }
+        break;
+      case 117:
+        if (modifiers) {
+          result.key = C0.ESC + '[17;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[17~';
+        }
+        break;
+      case 118:
+        if (modifiers) {
+          result.key = C0.ESC + '[18;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[18~';
+        }
+        break;
+      case 119:
+        if (modifiers) {
+          result.key = C0.ESC + '[19;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[19~';
+        }
+        break;
+      case 120:
+        if (modifiers) {
+          result.key = C0.ESC + '[20;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[20~';
+        }
+        break;
+      case 121:
+        if (modifiers) {
+          result.key = C0.ESC + '[21;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[21~';
+        }
+        break;
+      case 122:
+        if (modifiers) {
+          result.key = C0.ESC + '[23;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[23~';
+        }
+        break;
+      case 123:
+        if (modifiers) {
+          result.key = C0.ESC + '[24;' + (modifiers + 1) + '~';
+        } else {
+          result.key = C0.ESC + '[24~';
+        }
+        break;
+      case 144: // numlock
+        break;
+      case 93: // select
+        break;
+  }
+  return result;
+};

--- a/src/utils/KeyMap.test.ts
+++ b/src/utils/KeyMap.test.ts
@@ -161,10 +161,10 @@ describe('KeyMap', () => {
           metaKey   : !!(mods & MODIFIERS.META)
         };
         let strMods = [
-          ev.shiftKey? '+Shift' : '',
-          ev.altKey?   '+Alt'   : '',
-          ev.ctrlKey?  '+Ctrl'  : '',
-          ev.metaKey?  '+Meta'  : ''
+          ev.shiftKey ? '+Shift' : '',
+          ev.altKey   ? '+Alt'   : '',
+          ev.ctrlKey  ? '+Ctrl'  : '',
+          ev.metaKey  ? '+Meta'  : ''
         ].join('');
         for (let k = 0; k < 4; k++) {
           let myEnv = {
@@ -173,12 +173,12 @@ describe('KeyMap', () => {
             browser: { ...keyMapEnv.browser, isMac: !(k & 2) }
           };
           let checkName = 'check ' + names.join('/') + ' [' + i + '] ' + strMods +
-            ' appCursor=' + (myEnv.applicationCursor? 'on' : 'off') +
-            ' isMac=' + (myEnv.browser.isMac? 'on' : 'off');
+            ' appCursor=' + (myEnv.applicationCursor ? 'on' : 'off') +
+            ' isMac=' + (myEnv.browser.isMac ? 'on' : 'off');
           it(checkName, () => {
             const result: IKeyHandlerResult = keyMap.mapFromKeyboardEvent(ev, myEnv);
             const defaultResult: IKeyHandlerResult = getDefaultMapping (keyMap, ev, myEnv);
-            assert.equal(result? result.key : undefined, defaultResult? defaultResult.key : undefined);
+            assert.equal(result ? result.key : undefined, defaultResult ? defaultResult.key : undefined);
           });
         }
       }

--- a/src/utils/KeyMap.ts
+++ b/src/utils/KeyMap.ts
@@ -1,0 +1,292 @@
+
+import { C0 } from '../EscapeSequences';
+import { IBrowser } from '../Interfaces';
+
+export interface IKeyHandlerResult {
+  cancel: boolean;
+  key: string;
+  scrollLines: number;
+}
+
+export interface IKeyMap {
+  getKeyCodeByName(keyName: string): number;
+  getKeyNamesByCode(keyCode: number): string [];
+  mapFromKeyCombinationName(keyCombName: string, env: IKeyMapEnv): IKeyHandlerResult | undefined;
+  mapFromKeyboardEvent(ev: IKeyboardEvent, env: IKeyMapEnv): IKeyHandlerResult | undefined;
+  modifiersFromKeyboardEvent(ev: IKeyboardEvent): number;
+}
+
+export interface IKeyboardEvent {
+  keyCode: number;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+export interface IKeyMapEnv {
+  browser: IBrowser,
+  applicationCursor: boolean;
+  rows: number;
+  cols: number;
+}
+
+export const MODIFIERS = {
+  SHIFT   : 1,
+  ALT     : 2,
+  CONTROL : 4,
+  META    : 8
+};
+
+const KEYCODES = {
+  8   : 'Backspace',
+  9   : 'Tab',
+  13  : 'Enter|Return',
+  27  : 'Esc|Escape',
+  33  : 'PgUp|PageUp',
+  34  : 'PgDown|PageDown',
+  35  : 'End',
+  36  : 'Home',
+  37  : 'Left',
+  38  : 'Up',
+  39  : 'Right',
+  40  : 'Down',
+  45  : 'Insert',
+  46  : 'Delete|Del',
+  93  : 'Select',
+  96  : 'KP_0|KP0',
+  97  : 'KP_1|KP1',
+  98  : 'KP_2|KP2',
+  99  : 'KP_3|KP3',
+  100 : 'KP_4|KP4',
+  101 : 'KP_5|KP5',
+  102 : 'KP_6|KP6',
+  103 : 'KP_7|KP7',
+  104 : 'KP_8|KP8',
+  105 : 'KP_9|KP9',
+  106 : 'KP_Multiply|Multiply',
+  107 : 'KP_Add|Add',
+  109 : 'KP_Subtract|Subtract',
+  110 : 'KP_Decimal|Decimal',
+  111 : 'KP_Divide|Divide',
+  176 : 'KP_Enter|KP_Return',
+  144 : 'NumLock|NumLk|Gold',
+  112 : 'F1',
+  113 : 'F2',
+  114 : 'F3',
+  115 : 'F4',
+  116 : 'F5',
+  117 : 'F6',
+  118 : 'F7',
+  119 : 'F8',
+  120 : 'F9',
+  121 : 'F10',
+  122 : 'F11',
+  123 : 'F12'
+};
+
+const arrowHelper = (stdSuffix, macSuffix, mods, env) => {
+  let res = '';
+  if (mods) {
+    res = C0.ESC + '[1;' + (mods + 1) + stdSuffix;
+    // HACK: Make Alt + <direction>-arrow behave like Ctrl + <direction>-arrow
+    // http://unix.stackexchange.com/a/108106
+    // macOS uses different escape sequences than linux
+    if (res === C0.ESC + '[1;3' + stdSuffix) {
+      res = (env.browser.isMac && macSuffix) ? C0.ESC + macSuffix : C0.ESC + '[1;5' + stdSuffix;
+    }
+  } else if (env.applicationCursor) {
+    res = C0.ESC + 'O' + stdSuffix;
+  } else {
+    res = C0.ESC + '[' + stdSuffix;
+  }
+  return { key: res };
+};
+
+/* NOTE: defining Backspace=C0.DEL and Shift+Backspace=C0.BS is not enough
+ * as for example for Control+Shift+Backspace, we fall back to Backspace,
+ * not to Shift+Backspace
+ * So Shift+Backspace would handle exactly Shift+Backspace and nothing else!
+ */
+const DEFAULT_DEFINITIONS = {
+  "Backspace"           : (mods) => ({ key: !!(mods & MODIFIERS.SHIFT)? C0.BS : C0.DEL }),
+  "Tab"                 : (mods) => (!!(mods & MODIFIERS.SHIFT)? { key: (C0.ESC + '[Z'), cancel: true } : { key: C0.HT }),
+  "Enter"               : { key: C0.CR, cancel: true },
+  "Escape"              : { key: C0.ESC, cancel: true },
+  "Left"                : (mods, env) => arrowHelper('D', 'b', mods, env),
+  "Right"               : (mods, env) => arrowHelper('C', 'f', mods, env),
+  "Up"                  : (mods, env) => arrowHelper('A', null, mods, env),
+  "Down"                : (mods, env) => arrowHelper('B', null, mods, env),
+  "Insert"              : (mods) => ((!(mods & (MODIFIERS.SHIFT | MODIFIERS.CONTROL))) ? { key: C0.ESC + '[2~' } : undefined),
+  "Delete"              : (mods) => ({ key: C0.ESC + '[3' + (mods? (';' + (mods + 1)) : '') + '~' }),
+  "Home"                : (mods, env) => ({
+    key: C0.ESC + (mods? ('[1;' + (mods + 1)) : (env.applicationCursor? 'O' : '[')) + 'H'
+  }),
+  "End"                 : (mods, env) => ({
+    key: C0.ESC + (mods? ('[1;' + (mods + 1)) : (env.applicationCursor? 'O' : '[')) + 'F'
+  }),
+  "PageUp"              : (mods, env) => (!(mods & MODIFIERS.SHIFT)? { key: C0.ESC + '[5~' } : { scrollLines: -(env.rows - 1) }),
+  "PageDown"            : (mods, env) => (!(mods & MODIFIERS.SHIFT)? { key: C0.ESC + '[6~' } : { scrollLines: env.rows - 1 }),
+  "KP0"                 : '0',
+  "KP1"                 : '1',
+  "KP2"                 : '2',
+  "KP3"                 : '3',
+  "KP4"                 : '4',
+  "KP5"                 : '5',
+  "KP6"                 : '6',
+  "KP7"                 : '7',
+  "KP8"                 : '8',
+  "KP9"                 : '9',
+  "KP_Multiply"         : '*',
+  "KP_Add"              : '+',
+  "KP_Subtract"         : '-',
+  "KP_Decimal"          : '.',
+  "KP_Divide"           : '/',
+  "KP_Enter"            : { key: C0.CR, cancel: true },
+  "F1"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'P' }),
+  "F2"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'Q' }),
+  "F3"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'R' }),
+  "F4"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'S' }),
+  "F5"                  : (mods) => ({ key: C0.ESC + ('[15' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F6"                  : (mods) => ({ key: C0.ESC + ('[17' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F7"                  : (mods) => ({ key: C0.ESC + ('[18' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F8"                  : (mods) => ({ key: C0.ESC + ('[19' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F9"                  : (mods) => ({ key: C0.ESC + ('[20' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F10"                 : (mods) => ({ key: C0.ESC + ('[21' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F11"                 : (mods) => ({ key: C0.ESC + ('[23' + (mods? (';' + (mods + 1)) : '') + '~') }),
+  "F12"                 : (mods) => ({ key: C0.ESC + ('[24' + (mods? (';' + (mods + 1)) : '') + '~') })
+};
+
+export class KeyMap implements IKeyMap {
+
+  private definitions     = {};
+  private cache           = {};
+  private indexCode2Names = KEYCODES;
+  private indexName2Code  = {};
+
+  // XXX: formalize definitions? how to define { keyCombinationString => IKeyHandlerResult } structure?
+  constructor(definitions: any) {
+    this.definitions = { ...DEFAULT_DEFINITIONS, ...definitions };
+    this.buildIndices();
+    this.buildCache();
+  }
+
+  public getKeyCodeByName(keyName: string): number {
+    return this.indexName2Code[keyName.toUpperCase()];
+  }
+
+  public getKeyNamesByCode(keyCode: number): string [] {
+    const names = this.indexCode2Names[keyCode];
+    return names ? names.split(/\|/) : undefined;
+  }
+
+  public mapFromKeyCombinationName(keyCombName: string, env: IKeyMapEnv): IKeyHandlerResult | undefined {
+    const hash = this.hashKeyBindingString(keyCombName);
+    return this.getKeyHandlerResultByHash(hash, env);
+  }
+
+  public mapFromKeyboardEvent(ev: IKeyboardEvent, env: IKeyMapEnv): IKeyHandlerResult | undefined {
+    const hash = this.hashKeyboardEvent(ev);
+    return this.getKeyHandlerResultByHash(hash, env);
+  }
+
+  public modifiersFromKeyboardEvent(ev: IKeyboardEvent): number {
+    return (ev.shiftKey ? MODIFIERS.SHIFT   : 0)
+         | (ev.altKey   ? MODIFIERS.ALT     : 0)
+         | (ev.ctrlKey  ? MODIFIERS.CONTROL : 0)
+         | (ev.metaKey  ? MODIFIERS.META    : 0);
+  }
+
+  private hashKeyboardEvent(ev: IKeyboardEvent): number {
+    return ((ev.keyCode << 4) | this.modifiersFromKeyboardEvent(ev));
+  }
+
+  private getKeyHandlerResultByHash(hash: number, env: IKeyMapEnv) {
+    const base  = hash >> 4 << 4;
+    const mods  = hash ^ base;
+    const entry = this.cache[hash] || this.cache[base];
+    return (typeof (entry) === 'function')? entry (mods, env) : entry;
+  }
+
+  /**
+   * Returns a numeric representation of the key and modifiers in the input string.
+   * The input string can be: 'Control+Alt-F1' hence '+' and '-' delimiters are
+   * allowed and it is not order sensitive.
+   * @param keyWithModStr The key binding string.
+   */
+  private hashKeyBindingString(keyWithModStr: string): number {
+    const keys = keyWithModStr.toUpperCase().split(/\+|-/);
+    let [len, result, key] = [keys.length, 0, null];
+    while (len--) {
+      switch (keys[len]) {
+        case 'S':
+        case 'SHIFT':
+          result |= MODIFIERS.SHIFT;
+          break;
+        case 'A':
+        case 'ALT':
+          result |= MODIFIERS.ALT;
+          break;
+        case 'C':
+        case 'CTRL':
+        case 'CONTROL':
+          result |= MODIFIERS.CONTROL;
+          break;
+        case 'M':
+        case 'META':
+          result |= MODIFIERS.META;
+          break;
+        default:
+          // We already have a key
+          if (result >> 4) throw Error('Invariant: more than one non-modifier keys are not allowed: ' + keyWithModStr);
+          let keyCode = this.getKeyCodeByName(keys[len]);
+          if (!keyCode) throw Error('Invariant: unsupported key name: ' + keys[len]);
+          result |= (keyCode << 4);
+          break;
+      }
+    }
+    // XXX: do we want to throw an exception if there modifiers only?!
+    return result;
+  }
+
+  private buildCache(): void {
+    let result = {};
+    Object.keys (this.definitions).forEach ((keyWithModStr) => {
+      const keyHash: number = this.hashKeyBindingString(keyWithModStr);
+      const keyBinding = this.definitions[keyWithModStr];
+      const keyBindingType = typeof (keyBinding);
+      const base  = keyHash >> 4 << 4;
+      const mods  = keyHash ^ base;
+      const hasMods = (mods > 0);
+      if (keyBindingType === 'string')
+        result[keyHash] = {
+          key: keyBinding,
+          cancel: false,
+          scrollLines: undefined
+        };
+      else if (keyBindingType === 'object') {
+        result[keyHash] = {
+          key          : keyBinding.key || undefined,
+          cancel       : keyBinding.cancel || false,
+          scrollLines  : keyBinding.scrollLines || undefined
+        };
+      }
+      else if (keyBindingType === 'function') {
+        if (hasMods)
+          throw Error('Invariant: generic key handler function can be defined only for a fallback key without modifiers');
+        else result[keyHash] = keyBinding;
+      }
+      else throw Error('Invariant: KeyMap entry must map key combinations to IKeyHandlerResult');
+    });
+    this.cache = result;
+  }
+
+  private buildIndices(): void {
+    this.indexCode2Names = KEYCODES;
+    Object.keys (this.indexCode2Names).forEach (code => {
+      const keyNameString = this.indexCode2Names[code];
+      const keyNames = keyNameString.toUpperCase().split(/\|/);
+      keyNames.forEach (name => { this.indexName2Code[name] = code; });
+    });
+  }
+}

--- a/src/utils/KeyMap.ts
+++ b/src/utils/KeyMap.ts
@@ -25,7 +25,7 @@ export interface IKeyboardEvent {
 }
 
 export interface IKeyMapEnv {
-  browser: IBrowser,
+  browser: IBrowser;
   applicationCursor: boolean;
   rows: number;
   cols: number;
@@ -109,52 +109,52 @@ const arrowHelper = (stdSuffix, macSuffix, mods, env) => {
  * So Shift+Backspace would handle exactly Shift+Backspace and nothing else!
  */
 const DEFAULT_DEFINITIONS = {
-  "Backspace"           : (mods) => ({ key: !!(mods & MODIFIERS.SHIFT)? C0.BS : C0.DEL }),
-  "Tab"                 : (mods) => (!!(mods & MODIFIERS.SHIFT)? { key: (C0.ESC + '[Z'), cancel: true } : { key: C0.HT }),
-  "Enter"               : { key: C0.CR, cancel: true },
-  "Escape"              : { key: C0.ESC, cancel: true },
-  "Left"                : (mods, env) => arrowHelper('D', 'b', mods, env),
-  "Right"               : (mods, env) => arrowHelper('C', 'f', mods, env),
-  "Up"                  : (mods, env) => arrowHelper('A', null, mods, env),
-  "Down"                : (mods, env) => arrowHelper('B', null, mods, env),
-  "Insert"              : (mods) => ((!(mods & (MODIFIERS.SHIFT | MODIFIERS.CONTROL))) ? { key: C0.ESC + '[2~' } : undefined),
-  "Delete"              : (mods) => ({ key: C0.ESC + '[3' + (mods? (';' + (mods + 1)) : '') + '~' }),
-  "Home"                : (mods, env) => ({
-    key: C0.ESC + (mods? ('[1;' + (mods + 1)) : (env.applicationCursor? 'O' : '[')) + 'H'
+  'Backspace'           : (mods) => ({ key: !!(mods & MODIFIERS.SHIFT) ? C0.BS : C0.DEL }),
+  'Tab'                 : (mods) => (!!(mods & MODIFIERS.SHIFT) ? { key: (C0.ESC + '[Z'), cancel: true } : { key: C0.HT }),
+  'Enter'               : { key: C0.CR, cancel: true },
+  'Escape'              : { key: C0.ESC, cancel: true },
+  'Left'                : (mods, env) => arrowHelper('D', 'b', mods, env),
+  'Right'               : (mods, env) => arrowHelper('C', 'f', mods, env),
+  'Up'                  : (mods, env) => arrowHelper('A', null, mods, env),
+  'Down'                : (mods, env) => arrowHelper('B', null, mods, env),
+  'Insert'              : (mods) => ((!(mods & (MODIFIERS.SHIFT | MODIFIERS.CONTROL))) ? { key: C0.ESC + '[2~' } : undefined),
+  'Delete'              : (mods) => ({ key: C0.ESC + '[3' + (mods ? (';' + (mods + 1)) : '') + '~' }),
+  'Home'                : (mods, env) => ({
+    key: C0.ESC + (mods ? ('[1;' + (mods + 1)) : (env.applicationCursor ? 'O' : '[')) + 'H'
   }),
-  "End"                 : (mods, env) => ({
-    key: C0.ESC + (mods? ('[1;' + (mods + 1)) : (env.applicationCursor? 'O' : '[')) + 'F'
+  'End'                 : (mods, env) => ({
+    key: C0.ESC + (mods ? ('[1;' + (mods + 1)) : (env.applicationCursor ? 'O' : '[')) + 'F'
   }),
-  "PageUp"              : (mods, env) => (!(mods & MODIFIERS.SHIFT)? { key: C0.ESC + '[5~' } : { scrollLines: -(env.rows - 1) }),
-  "PageDown"            : (mods, env) => (!(mods & MODIFIERS.SHIFT)? { key: C0.ESC + '[6~' } : { scrollLines: env.rows - 1 }),
-  "KP0"                 : '0',
-  "KP1"                 : '1',
-  "KP2"                 : '2',
-  "KP3"                 : '3',
-  "KP4"                 : '4',
-  "KP5"                 : '5',
-  "KP6"                 : '6',
-  "KP7"                 : '7',
-  "KP8"                 : '8',
-  "KP9"                 : '9',
-  "KP_Multiply"         : '*',
-  "KP_Add"              : '+',
-  "KP_Subtract"         : '-',
-  "KP_Decimal"          : '.',
-  "KP_Divide"           : '/',
-  "KP_Enter"            : { key: C0.CR, cancel: true },
-  "F1"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'P' }),
-  "F2"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'Q' }),
-  "F3"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'R' }),
-  "F4"                  : (mods) => ({ key: C0.ESC + (mods? ('[1;' + (mods + 1)) : 'O') + 'S' }),
-  "F5"                  : (mods) => ({ key: C0.ESC + ('[15' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F6"                  : (mods) => ({ key: C0.ESC + ('[17' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F7"                  : (mods) => ({ key: C0.ESC + ('[18' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F8"                  : (mods) => ({ key: C0.ESC + ('[19' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F9"                  : (mods) => ({ key: C0.ESC + ('[20' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F10"                 : (mods) => ({ key: C0.ESC + ('[21' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F11"                 : (mods) => ({ key: C0.ESC + ('[23' + (mods? (';' + (mods + 1)) : '') + '~') }),
-  "F12"                 : (mods) => ({ key: C0.ESC + ('[24' + (mods? (';' + (mods + 1)) : '') + '~') })
+  'PageUp'              : (mods, env) => (!(mods & MODIFIERS.SHIFT) ? { key: C0.ESC + '[5~' } : { scrollLines: -(env.rows - 1) }),
+  'PageDown'            : (mods, env) => (!(mods & MODIFIERS.SHIFT) ? { key: C0.ESC + '[6~' } : { scrollLines: env.rows - 1 }),
+  'KP0'                 : '0',
+  'KP1'                 : '1',
+  'KP2'                 : '2',
+  'KP3'                 : '3',
+  'KP4'                 : '4',
+  'KP5'                 : '5',
+  'KP6'                 : '6',
+  'KP7'                 : '7',
+  'KP8'                 : '8',
+  'KP9'                 : '9',
+  'KP_Multiply'         : '*',
+  'KP_Add'              : '+',
+  'KP_Subtract'         : '-',
+  'KP_Decimal'          : '.',
+  'KP_Divide'           : '/',
+  'KP_Enter'            : { key: C0.CR, cancel: true },
+  'F1'                  : (mods) => ({ key: C0.ESC + (mods ? ('[1;' + (mods + 1)) : 'O') + 'P' }),
+  'F2'                  : (mods) => ({ key: C0.ESC + (mods ? ('[1;' + (mods + 1)) : 'O') + 'Q' }),
+  'F3'                  : (mods) => ({ key: C0.ESC + (mods ? ('[1;' + (mods + 1)) : 'O') + 'R' }),
+  'F4'                  : (mods) => ({ key: C0.ESC + (mods ? ('[1;' + (mods + 1)) : 'O') + 'S' }),
+  'F5'                  : (mods) => ({ key: C0.ESC + ('[15' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F6'                  : (mods) => ({ key: C0.ESC + ('[17' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F7'                  : (mods) => ({ key: C0.ESC + ('[18' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F8'                  : (mods) => ({ key: C0.ESC + ('[19' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F9'                  : (mods) => ({ key: C0.ESC + ('[20' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F10'                 : (mods) => ({ key: C0.ESC + ('[21' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F11'                 : (mods) => ({ key: C0.ESC + ('[23' + (mods ? (';' + (mods + 1)) : '') + '~') }),
+  'F12'                 : (mods) => ({ key: C0.ESC + ('[24' + (mods ? (';' + (mods + 1)) : '') + '~') })
 };
 
 export class KeyMap implements IKeyMap {
@@ -201,11 +201,11 @@ export class KeyMap implements IKeyMap {
     return ((ev.keyCode << 4) | this.modifiersFromKeyboardEvent(ev));
   }
 
-  private getKeyHandlerResultByHash(hash: number, env: IKeyMapEnv) {
+  private getKeyHandlerResultByHash(hash: number, env: IKeyMapEnv): IKeyHandlerResult | undefined {
     const base  = hash >> 4 << 4;
     const mods  = hash ^ base;
     const entry = this.cache[hash] || this.cache[base];
-    return (typeof (entry) === 'function')? entry (mods, env) : entry;
+    return (typeof (entry) === 'function') ? entry (mods, env) : entry;
   }
 
   /**


### PR DESCRIPTION
After some experimenting, I ended up doing this. Is it something you'd like to use? Tests should cover the original code behaviour, only mapping is much easier and can be done as follows (may need some documentation later):
```
  term = new Terminal({
    debug: true,
    cursorBlink: true,
    cols: 80,
    rows: 24,
    scrollback: 2048,
    tabStopWidth: 10,
    fontSize: 18,
    keyMap: {
      /**
       * A mapping typical for DEC VT4xx/VT5xx friendly applications
       * Map value can be string, IKeyHandlerResult-compatible object or function (only for non-modified keys -- such a function would handle modifiers and other context specific behaviour)
       * Key format is case insensitive, uses '-' or '+' delimiters and the following are equivalents C=Ctrl=Control, A=Alt, M=Meta, S=Shift.
       */
      'Home'        : '\x1b[1~',   // Find
      'End'         : '\x1b[4~',   // Select
      'Esc'         : '\x1b[20~',
      'Insert'      : '\x1b[2~',
      'F1'          : '\x1b[28~',  // Help
      'F11'         : '\x1bOP',    // PF1
      'F12'         : '\x1b[4~',   // Select
      'C-F3'        : '\x1b[25~',  // F13
      'C-F4'        : '\x1b[26~',  // F14
      'C-F5'        : '\x1b[28~',  // F15
      'C-F6'        : '\x1b[29~',  // F16
      'C-F7'        : '\x1b[31~',  // F17
      'C-F8'        : '\x1b[32~',  // F18
      'C-F9'        : '\x1b[33~',  // F19
      'C-F10'       : '\x1b[34~',  // F20
      'KP_Divide'   : '\x1bOP',
      'KP_Multiply' : '\x1b[29~',
      'KP_Enter'    : '\x1bOM',
      'KP_Subtract' : '\x1bOm',
      'KP_Add'      : '\x1bOl',
      'KP_Decimal'  : '\x1bOn',
      'KP_0'        : '\x1bOp',
      'KP_1'        : '\x1bOq',
      'KP_2'        : '\x1bOr',
      'KP_3'        : '\x1bOs',
      'KP_4'        : '\x1bOt',
      'KP_5'        : '\x1bOu'
    }
  });
```