### PR TITLE
Allow alt+backspace to delete a word

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1449,6 +1449,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
         if (ev.shiftKey) {
           result.key = C0.BS; // ^H
           break;
+        } else if (ev.altKey) {
+          result.key = C0.ESC + C0.DEL; // \e ^?
+          break;
         }
         result.key = C0.DEL; // ^?
         break;


### PR DESCRIPTION
Fixes #1179

---

Figured out the right thing to send by running this:

```
❯ bind -p | grep backward-kill-word
"\e\C-h": backward-kill-word
"\e\C-?": backward-kill-word
# shell-backward-kill-word (not bound)
```