### PR TITLE
Ship the declaration files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,9 +51,14 @@ gulp.task('tsc', function () {
 
     let tsProjectAddon = ts.createProject(`./src/addons/${addon}/tsconfig.json`);
     let tsResultAddon = tsProjectAddon.src().pipe(sourcemaps.init()).pipe(tsProjectAddon());
-    let tscAddon = tsResultAddon.js
-      .pipe(sourcemaps.write('.', {includeContent: false, sourceRoot: ''}))
-      .pipe(gulp.dest(`${outDir}/addons/${addon}`));
+    let tscAddon = merge(
+      tsResultAddon.js
+        .pipe(sourcemaps.write('.', {includeContent: false, sourceRoot: ''}))
+        .pipe(gulp.dest(`${outDir}/addons/${addon}`)),
+      tsResultAddon.dts
+        .pipe(sourcemaps.write('.', {includeContent: false, sourceRoot: ''}))
+        .pipe(gulp.dest(`${outDir}/addons/${addon}`))
+    )
 
     return tscAddon;
   });

--- a/src/addons/attach/tsconfig.json
+++ b/src/addons/attach/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/attach/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/src/addons/fit/tsconfig.json
+++ b/src/addons/fit/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/fit/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/src/addons/fullscreen/tsconfig.json
+++ b/src/addons/fullscreen/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/fullscreen/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/src/addons/search/tsconfig.json
+++ b/src/addons/search/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/search/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/src/addons/terminado/tsconfig.json
+++ b/src/addons/terminado/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/terminado/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/src/addons/winptyCompat/tsconfig.json
+++ b/src/addons/winptyCompat/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/winptyCompat/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/src/addons/zmodem/tsconfig.json
+++ b/src/addons/zmodem/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "../../../lib/addons/zmodem/",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "outDir": "lib",
     "sourceMap": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Fixes #1196.

I verified locally that the following works from a TypeScript consumer using the `.d.ts` files produced by this PR:

```javascript
import {
  fit
} from 'xterm/lib/addons/fit';
```

cf https://github.com/jupyterlab/jupyterlab/pull/3553 if you're interested in the JupyterLab migration from 2.x -> 3.x


  