### PR TITLE
Add rtty to the real-world uses section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ computational environment for Jupyter, supporting interactive data science and s
 - [**Kubebox**](https://github.com/astefanutti/kubebox): Terminal console for Kubernetes clusters.
 - [**Azure Cloud Shell**](https://shell.azure.com): Azure Cloud Shell is a Microsoft-managed admin machine built on Azure, for Azure.
 - [**atom-xterm**](https://atom.io/packages/atom-xterm): Atom plugin for providing terminals inside your Atom workspace.
+- [**rtty**](https://github.com/zhaojh329/rtty): A reverse proxy WebTTY. It is composed of the client and the server.
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
A reverse proxy WebTTY. It is composed of the client and the server.

Signed-off-by: Jianhui Zhao <jianhuizhao329@gmail.com>