### PR TITLE
Support triggering tooltip callback using customizable delay.

### DIFF
--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -5,7 +5,7 @@
 
 import { IMouseZoneManager } from './input/Types';
 import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkMatcherValidationCallback, LineData, LinkHoverEventTypes, ILinkMatcherOptions, ITerminal, IBufferAccessor, ILinkifier, IElementAccessor } from './Types';
-import { MouseZone } from './input/MouseZoneManager';
+import { MouseZone, HOVER_DURATION } from './input/MouseZoneManager';
 import { EventEmitter } from './EventEmitter';
 
 const protocolClause = '(https?:\\/\\/)';
@@ -142,6 +142,10 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     if (this._nextLinkMatcherId !== HYPERTEXT_LINK_MATCHER_ID && !handler) {
       throw new Error('handler must be defined');
     }
+    let tooltipDelay = options.tooltipDelay;
+    if (tooltipDelay === undefined) {
+      tooltipDelay = HOVER_DURATION;
+    }
     const matcher: ILinkMatcher = {
       id: this._nextLinkMatcherId++,
       regex,
@@ -150,7 +154,8 @@ export class Linkifier extends EventEmitter implements ILinkifier {
       validationCallback: options.validationCallback,
       hoverTooltipCallback: options.tooltipCallback,
       hoverLeaveCallback: options.leaveCallback,
-      priority: options.priority || 0
+      priority: options.priority || 0,
+      tooltipDelay: tooltipDelay
     };
     this._addLinkMatcherToList(matcher);
     return matcher.id;
@@ -290,7 +295,8 @@ export class Linkifier extends EventEmitter implements ILinkifier {
         if (matcher.hoverLeaveCallback) {
           matcher.hoverLeaveCallback();
         }
-      }
+      },
+      matcher.tooltipDelay
     ));
   }
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -161,6 +161,7 @@ export interface ILinkMatcher {
   matchIndex?: number;
   validationCallback?: LinkMatcherValidationCallback;
   priority?: number;
+  tooltipDelay?: number;
 }
 
 export interface ICharset {
@@ -321,6 +322,11 @@ export interface ILinkMatcherOptions {
    * default value is 0.
    */
   priority?: number;
+  /**
+   * The amount of time to delay in milliseconds before triggering the tooltip
+   * callback.
+   */
+  tooltipDelay?: number;
 }
 
 export interface IBrowser {

--- a/src/input/MouseZoneManager.ts
+++ b/src/input/MouseZoneManager.ts
@@ -6,7 +6,7 @@
 import { ITerminal } from '../Types';
 import { IMouseZoneManager, IMouseZone } from './Types';
 
-const HOVER_DURATION = 500;
+export const HOVER_DURATION = 500;
 
 /**
  * The MouseZoneManager allows components to register zones within the terminal
@@ -130,7 +130,13 @@ export class MouseZoneManager implements IMouseZoneManager {
     }
 
     // Restart the tooltip timeout
-    this._tooltipTimeout = <number><any>setTimeout(() => this._onTooltip(e), HOVER_DURATION);
+    if (zone.tooltipDelay <= 0) {
+      // Trigger the tooltip immediately, don't queue it up into the event
+      // loop.
+      this._onTooltip(e);
+    } else {
+      this._tooltipTimeout = <number><any>setTimeout(() => this._onTooltip(e), zone.tooltipDelay);
+    }
   }
 
   private _onTooltip(e: MouseEvent): void {
@@ -191,7 +197,8 @@ export class MouseZone implements IMouseZone {
     public clickCallback: (e: MouseEvent) => any,
     public hoverCallback?: (e: MouseEvent) => any,
     public tooltipCallback?: (e: MouseEvent) => any,
-    public leaveCallback?: () => void
+    public leaveCallback?: () => void,
+    public tooltipDelay: number = HOVER_DURATION,
   ) {
   }
 }

--- a/src/input/Types.ts
+++ b/src/input/Types.ts
@@ -16,4 +16,5 @@ export interface IMouseZone {
   hoverCallback?: (e: MouseEvent) => any;
   tooltipCallback?: (e: MouseEvent) => any;
   leaveCallback?: () => any;
+  tooltipDelay?: number;
 }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -196,6 +196,12 @@ declare module 'xterm' {
      * default value is 0.
      */
     priority?: number;
+
+    /**
+     * The amount of time to delay in milliseconds before triggering the tooltip
+     * callback.
+     */
+    tooltipDelay?: number;
   }
 
   export interface IEventEmitter {


### PR DESCRIPTION
This will support an option for defining the delay to trigger the tooltip callback, or a delay less than or equal to 0 which means the tooltip callback will be triggered immediately. I also verified that not defining the new `tooltipDelay` option will set it to the original default delay.

The below shows what I need this for.
![atom-xterm-no-tooltip-delay](https://user-images.githubusercontent.com/86134/35419567-a0ec9a2c-0206-11e8-8ecd-0826d30817ec.gif)
