### PR TITLE
adjust timeout to ensure right-click event has fired

### DIFF
--- a/src/handlers/Clipboard.ts
+++ b/src/handlers/Clipboard.ts
@@ -100,6 +100,7 @@ export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextA
   textarea.focus();
 
   // Reset the terminal textarea's styling
+  // Timeout needs to be long enough for click event to be handled.
   setTimeout(() => {
     textarea.style.position = null;
     textarea.style.width = null;
@@ -107,7 +108,7 @@ export function moveTextAreaUnderMouseCursor(ev: MouseEvent, textarea: HTMLTextA
     textarea.style.left = null;
     textarea.style.top = null;
     textarea.style.zIndex = null;
-  }, 4);
+  }, 200);
 }
 
 /**


### PR DESCRIPTION
As described in issues #418, #1039 and #1040, there appears to be a timing/race condition in the right-click handler that impacts Firefox on Windows. In the clipboard handler, the textarea element gets modified to be under the mouse cursor, and and then very quickly reset with a setTimeout method. 

In testing, a minimum value of 135ms consistently resolved the issue. However using 200ms gives a little extra buffer, and doesn't appear to have any negative impacts.

Tested on:
Firefox 58, Chrome 64, and Edge 41 on Windows 10
Firefox 58, Chrome 63, and Safari 11.0.2 on macOS HighSierra