### PR TITLE
Run tsc as a travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - npm install -g npm@5.1.0
 env:
   matrix:
+    - NPM_COMMAND=tsc
     - NPM_COMMAND=lint
     - NPM_COMMAND=test
 notifications:

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "lint": "tslint src/*.ts src/**/*.ts",
     "test": "gulp test",
     "build:docs": "jsdoc -c jsdoc.json",
+    "tsc": "tsc",
     "build": "gulp build",
     "prepublish": "npm run build",
     "coveralls": "gulp coveralls",


### PR DESCRIPTION
This will hard fail when there are semantic errors. Currently building does
not do this and we will merge these in as a result.