### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It enables applications to provide fully featured terminals to their users and c
 First you need to install the module, we ship exclusively through [npm](https://www.npmjs.com/) so you need that installed and then add xterm.js as a dependency by running:
 
 ```
-npm install
+npm install xterm
 ```
 
 To start using xterm.js on your browser, add the `xterm.js` and `xterm.css` to the head of your html page. Then create a `<div id="terminal"></div>` onto which xterm can attach itself.


### PR DESCRIPTION
In `Getting Started` section we read `npm install` only. Shouldn't be `npm install xterm`?