### PR TITLE
Fix xterm.js in headless mode yields TypeError on resize

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1889,7 +1889,9 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
     this.rows = y;
     this.buffers.setupTabStops(this.cols);
 
-    this.charMeasure.measure(this.options);
+    if (this.charMeasure) {
+      this.charMeasure.measure(this.options);
+    }
 
     this.refresh(0, this.rows - 1);
     this.emit('resize', {cols: x, rows: y});


### PR DESCRIPTION
Related issue: https://github.com/xtermjs/xterm.js/issues/1278
Fix xterm.js in headless mode yields TypeError on resize.