### PR TITLE
Merge ICharAtlasRequest with ICharAtlasConfig

### DIFF
--- a/src/renderer/Types.ts
+++ b/src/renderer/Types.ts
@@ -5,6 +5,7 @@
 
 import { ITerminal } from '../Types';
 import { IEventEmitter, ITheme } from 'xterm';
+import { IColorSet } from '../shared/Types';
 
 /**
  * Flags used to render terminal text properly.
@@ -39,14 +40,8 @@ export interface IColorManager {
   colors: IColorSet;
 }
 
-export interface IColorSet {
-  foreground: string;
-  background: string;
-  cursor: string;
-  cursorAccent: string;
-  selection: string;
-  ansi: string[];
-}
+// TODO: We should probably rewrite the imports for IColorSet, but there's a lot of them
+export { IColorSet };
 
 export interface IRenderDimensions {
   scaledCharWidth: number;

--- a/src/renderer/atlas/CharAtlas.ts
+++ b/src/renderer/atlas/CharAtlas.ts
@@ -5,9 +5,9 @@
 
 import { ITerminal } from '../../Types';
 import { IColorSet } from '../Types';
-import { ICharAtlasConfig } from './Types';
+import { ICharAtlasConfig } from '../../shared/atlas/Types';
 import { isFirefox } from '../../shared/utils/Browser';
-import { generateCharAtlas, ICharAtlasRequest } from '../../shared/atlas/CharAtlasGenerator';
+import { generateCharAtlas } from '../../shared/atlas/CharAtlasGenerator';
 import { generateConfig, configEquals } from './CharAtlasUtils';
 
 interface ICharAtlasCacheEntry {
@@ -63,22 +63,8 @@ export function acquireCharAtlas(terminal: ITerminal, colors: IColorSet, scaledC
     return canvas;
   };
 
-  const charAtlasConfig: ICharAtlasRequest = {
-    scaledCharWidth,
-    scaledCharHeight,
-    fontSize: terminal.options.fontSize,
-    fontFamily: terminal.options.fontFamily,
-    fontWeight: terminal.options.fontWeight,
-    fontWeightBold: terminal.options.fontWeightBold,
-    background: colors.background,
-    foreground: colors.foreground,
-    ansiColors: colors.ansi,
-    devicePixelRatio: window.devicePixelRatio,
-    allowTransparency: terminal.options.allowTransparency
-  };
-
   const newEntry: ICharAtlasCacheEntry = {
-    bitmap: generateCharAtlas(window, canvasFactory, charAtlasConfig),
+    bitmap: generateCharAtlas(window, canvasFactory, newConfig),
     config: newConfig,
     ownedBy: [terminal]
   };

--- a/src/renderer/atlas/CharAtlasUtils.ts
+++ b/src/renderer/atlas/CharAtlasUtils.ts
@@ -6,7 +6,7 @@
 import { ITerminal } from '../../Types';
 import { ITheme } from 'xterm';
 import { IColorSet } from '../Types';
-import { ICharAtlasConfig } from './Types';
+import { ICharAtlasConfig } from '../../shared/atlas/Types';
 
 export function generateConfig(scaledCharWidth: number, scaledCharHeight: number, terminal: ITerminal, colors: IColorSet): ICharAtlasConfig {
   const clonedColors = {
@@ -18,6 +18,7 @@ export function generateConfig(scaledCharWidth: number, scaledCharHeight: number
     ansi: colors.ansi.slice(0, 16)
   };
   return {
+    devicePixelRatio: window.devicePixelRatio,
     scaledCharWidth,
     scaledCharHeight,
     fontFamily: terminal.options.fontFamily,
@@ -35,7 +36,8 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
       return false;
     }
   }
-  return a.fontFamily === b.fontFamily &&
+  return a.devicePixelRatio === b.devicePixelRatio &&
+      a.fontFamily === b.fontFamily &&
       a.fontSize === b.fontSize &&
       a.fontWeight === b.fontWeight &&
       a.fontWeightBold === b.fontWeightBold &&

--- a/src/renderer/atlas/Types.ts
+++ b/src/renderer/atlas/Types.ts
@@ -3,19 +3,5 @@
  * @license MIT
  */
 
-import { FontWeight } from 'xterm';
-import { IColorSet } from '../Types';
-
 export const INVERTED_DEFAULT_COLOR = -1;
 export const DIM_OPACITY = 0.5;
-
-export interface ICharAtlasConfig {
-  fontSize: number;
-  fontFamily: string;
-  fontWeight: FontWeight;
-  fontWeightBold: FontWeight;
-  scaledCharWidth: number;
-  scaledCharHeight: number;
-  allowTransparency: boolean;
-  colors: IColorSet;
-}

--- a/src/shared/Types.ts
+++ b/src/shared/Types.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+export interface IColorSet {
+  foreground: string;
+  background: string;
+  cursor: string;
+  cursorAccent: string;
+  selection: string;
+  ansi: string[];
+}

--- a/src/shared/atlas/Types.ts
+++ b/src/shared/atlas/Types.ts
@@ -3,4 +3,19 @@
  * @license MIT
  */
 
+import { FontWeight } from 'xterm';
+import { IColorSet } from '../Types';
+
 export const CHAR_ATLAS_CELL_SPACING = 1;
+
+export interface ICharAtlasConfig {
+  devicePixelRatio: number;
+  fontSize: number;
+  fontFamily: string;
+  fontWeight: FontWeight;
+  fontWeightBold: FontWeight;
+  scaledCharWidth: number;
+  scaledCharHeight: number;
+  allowTransparency: boolean;
+  colors: IColorSet;
+}


### PR DESCRIPTION
`ICharAtlasRequest` and `ICharAtlasConfig` need almost exactly the same set of information, so it's simpler if we just merge the two types.

As an added bonus, this also adds `devicePixelRatio` to the `config`, which helps guarantee that we won't ever accidentally end up with an atlas using a different pixel ratio than we need.