### PR TITLE
Modularize the character atlas system, add a LRU-cache based dynamic character atlas

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -53,6 +53,15 @@
           <p>
             <label>tabStopWidth <input type="number" id="option-tabstopwidth" value="8" /></label>
           </p>
+          <p>
+            <label>
+              experimentalCharAtlas
+              <select id="option-experimental-char-atlas">
+                <option value="static" selected>static</option>
+                <option value="none">none</option>
+              </select>
+            </label>
+          </p>
           <div>
           	<h3>Size</h3>
             <div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,6 +27,9 @@
             <label><input type="checkbox" id="option-mac-option-is-meta"> macOptionIsMeta</label>
           </p>
           <p>
+            <label><input type="checkbox" id="option-transparency"> transparency</label>
+          </p>
+          <p>
             <label>
               cursorStyle
               <select id="option-cursor-style">

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,7 @@
               experimentalCharAtlas
               <select id="option-experimental-char-atlas">
                 <option value="static" selected>static</option>
+                <option value="dynamic">dynamic</option>
                 <option value="none">none</option>
               </select>
             </label>

--- a/demo/main.js
+++ b/demo/main.js
@@ -32,6 +32,7 @@ var terminalContainer = document.getElementById('terminal-container'),
       macOptionIsMeta: document.querySelector('#option-mac-option-is-meta'),
       scrollback: document.querySelector('#option-scrollback'),
       tabstopwidth: document.querySelector('#option-tabstopwidth'),
+      experimentalCharAtlas: document.querySelector('#option-experimental-char-atlas'),
       bellStyle: document.querySelector('#option-bell-style'),
       screenReaderMode: document.querySelector('#option-screen-reader-mode')
     },
@@ -88,6 +89,9 @@ optionElements.scrollback.addEventListener('change', function () {
 });
 optionElements.tabstopwidth.addEventListener('change', function () {
   term.setOption('tabStopWidth', parseInt(optionElements.tabstopwidth.value, 10));
+});
+optionElements.experimentalCharAtlas.addEventListener('change', function () {
+  term.setOption('experimentalCharAtlas', optionElements.experimentalCharAtlas.value);
 });
 optionElements.screenReaderMode.addEventListener('change', function () {
   term.setOption('screenReaderMode', optionElements.screenReaderMode.checked);

--- a/demo/main.js
+++ b/demo/main.js
@@ -31,6 +31,7 @@ var terminalContainer = document.getElementById('terminal-container'),
       cursorStyle: document.querySelector('#option-cursor-style'),
       macOptionIsMeta: document.querySelector('#option-mac-option-is-meta'),
       scrollback: document.querySelector('#option-scrollback'),
+      transparency: document.querySelector('#option-transparency'),
       tabstopwidth: document.querySelector('#option-tabstopwidth'),
       experimentalCharAtlas: document.querySelector('#option-experimental-char-atlas'),
       bellStyle: document.querySelector('#option-bell-style'),
@@ -75,14 +76,19 @@ actionElements.findPrevious.addEventListener('keypress', function (e) {
 optionElements.cursorBlink.addEventListener('change', function () {
   term.setOption('cursorBlink', optionElements.cursorBlink.checked);
 });
+optionElements.macOptionIsMeta.addEventListener('change', function () {
+  term.setOption('macOptionIsMeta', optionElements.macOptionIsMeta.checked);
+});
+optionElements.transparency.addEventListener('change', function () {
+  var checked = optionElements.transparency.checked;
+  term.setOption('allowTransparency', checked);
+  term.setOption('theme', checked ? {background: 'rgba(0, 0, 0, .5)'} : {});
+});
 optionElements.cursorStyle.addEventListener('change', function () {
   term.setOption('cursorStyle', optionElements.cursorStyle.value);
 });
 optionElements.bellStyle.addEventListener('change', function () {
   term.setOption('bellStyle', optionElements.bellStyle.value);
-});
-optionElements.macOptionIsMeta.addEventListener('change', function () {
-  term.setOption('macOptionIsMeta', optionElements.macOptionIsMeta.checked);
 });
 optionElements.scrollback.addEventListener('change', function () {
   term.setOption('scrollback', parseInt(optionElements.scrollback.value, 10));

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -102,6 +102,7 @@ const DEFAULT_OPTIONS: ITerminalOptions = {
   bellSound: DEFAULT_BELL_SOUND,
   bellStyle: 'none',
   enableBold: true,
+  experimentalCharAtlas: 'static',
   fontFamily: 'courier-new, courier, monospace',
   fontSize: 15,
   fontWeight: 'normal',
@@ -454,6 +455,7 @@ export class Terminal extends EventEmitter implements ITerminal, IInputHandlingT
           this.charMeasure.measure(this.options);
         }
         break;
+      case 'experimentalCharAtlas':
       case 'enableBold':
       case 'letterSpacing':
       case 'lineHeight':

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -20,7 +20,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
   private _scaledCharLeft: number = 0;
   private _scaledCharTop: number = 0;
 
-  private _charAtlas: BaseCharAtlas;
+  protected _charAtlas: BaseCharAtlas;
 
   constructor(
     private _container: HTMLElement,

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -240,7 +240,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
   protected drawChar(terminal: ITerminal, char: string, code: number, width: number, x: number, y: number, fg: number, bg: number, bold: boolean, dim: boolean): void {
     const atlasDidDraw = this._charAtlas && this._charAtlas.draw(
       this._ctx,
-      {char, bg, fg, bold: bold && terminal.options.enableBold, dim},
+      {char, code, bg, fg, bold: bold && terminal.options.enableBold, dim},
       x * this._scaledCellWidth + this._scaledCharLeft,
       y * this._scaledCellHeight + this._scaledCharTop
     );

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -150,6 +150,7 @@ export class Renderer extends EventEmitter implements IRenderer {
   }
 
   public onOptionsChanged(): void {
+    this.colorManager.allowTransparency = this._terminal.options.allowTransparency;
     this._runOperation(l => l.onOptionsChanged(this._terminal));
   }
 

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -54,6 +54,8 @@ export class TextRenderLayer extends BaseRenderLayer {
       return;
     }
 
+    this._charAtlas.beginFrame();
+
     for (let y = startRow; y <= endRow; y++) {
       const row = y + terminal.buffer.ydisp;
       const line = terminal.buffer.lines.get(row);

--- a/src/renderer/atlas/BaseCharAtlas.ts
+++ b/src/renderer/atlas/BaseCharAtlas.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { IGlyphIdentifier } from './Types';
+
+export default abstract class BaseCharAtlas {
+  private _didWarmUp: Promise<any>;
+
+  /**
+   * Perform any work needed to warm the cache before it can be used. May be called multiple times.
+   * Implement _doWarmUp instead if you only want to get called once.
+   */
+  public warmUp(): Promise<any> {
+    if (this._didWarmUp == null) {
+      this._didWarmUp = this._doWarmUp();
+    }
+    return this._didWarmUp;
+  }
+
+  /**
+   * Perform any work needed to warm the cache before it can be used. Used by the default
+   * implementation of warmUp(), and will only be called once.
+   */
+  protected _doWarmUp(): Promise<any> {
+    return Promise.resolve();
+  }
+
+  /**
+   * May be called before warmUp finishes, however it is okay for the implementation to
+   * do nothing and return false in that case.
+   *
+   * @param ctx Where to draw the character onto.
+   * @param glyph Information about what to draw
+   * @param x The position on the context to start drawing at
+   * @param y The position on the context to start drawing at
+   * @returns The success state. True if we drew the character.
+   */
+  public abstract draw(
+    ctx: CanvasRenderingContext2D,
+    glyph: IGlyphIdentifier,
+    x: number,
+    y: number,
+  ): boolean;
+}

--- a/src/renderer/atlas/BaseCharAtlas.ts
+++ b/src/renderer/atlas/BaseCharAtlas.ts
@@ -6,26 +6,24 @@
 import { IGlyphIdentifier } from './Types';
 
 export default abstract class BaseCharAtlas {
-  private _didWarmUp: Promise<any>;
+  private _didWarmUp: boolean = false;
 
   /**
    * Perform any work needed to warm the cache before it can be used. May be called multiple times.
    * Implement _doWarmUp instead if you only want to get called once.
    */
-  public warmUp(): Promise<any> {
-    if (this._didWarmUp == null) {
-      this._didWarmUp = this._doWarmUp();
+  public warmUp(): void {
+    if (!this._didWarmUp) {
+      this._doWarmUp();
+      this._didWarmUp = true;
     }
-    return this._didWarmUp;
   }
 
   /**
    * Perform any work needed to warm the cache before it can be used. Used by the default
    * implementation of warmUp(), and will only be called once.
    */
-  protected _doWarmUp(): Promise<any> {
-    return Promise.resolve();
-  }
+  protected _doWarmUp(): void { }
 
   /**
    * May be called before warmUp finishes, however it is okay for the implementation to

--- a/src/renderer/atlas/BaseCharAtlas.ts
+++ b/src/renderer/atlas/BaseCharAtlas.ts
@@ -26,6 +26,15 @@ export default abstract class BaseCharAtlas {
   protected _doWarmUp(): void { }
 
   /**
+   * Called when we start drawing a new frame.
+   *
+   * TODO: We rely on this getting called by TextRenderLayer. This should really be called by
+   * Renderer instead, but we need to make Renderer the source-of-truth for the char atlas, instead
+   * of BaseRenderLayer.
+   */
+  public beginFrame(): void { }
+
+  /**
    * May be called before warmUp finishes, however it is okay for the implementation to
    * do nothing and return false in that case.
    *

--- a/src/renderer/atlas/CharAtlasCache.ts
+++ b/src/renderer/atlas/CharAtlasCache.ts
@@ -8,12 +8,14 @@ import { IColorSet } from '../Types';
 import { ICharAtlasConfig } from '../../shared/atlas/Types';
 import { generateConfig, configEquals } from './CharAtlasUtils';
 import BaseCharAtlas from './BaseCharAtlas';
+import DynamicCharAtlas from './DynamicCharAtlas';
 import NoneCharAtlas from './NoneCharAtlas';
 import StaticCharAtlas from './StaticCharAtlas';
 
 const charAtlasImplementations = {
   'none': NoneCharAtlas,
   'static': StaticCharAtlas,
+  'dynamic': DynamicCharAtlas,
 };
 
 interface ICharAtlasCacheEntry {

--- a/src/renderer/atlas/CharAtlasCache.ts
+++ b/src/renderer/atlas/CharAtlasCache.ts
@@ -4,11 +4,17 @@
  */
 
 import { ITerminal } from '../../Types';
-import BaseCharAtlas from './BaseCharAtlas';
-import StaticCharAtlas from './StaticCharAtlas';
 import { IColorSet } from '../Types';
 import { ICharAtlasConfig } from '../../shared/atlas/Types';
 import { generateConfig, configEquals } from './CharAtlasUtils';
+import BaseCharAtlas from './BaseCharAtlas';
+import NoneCharAtlas from './NoneCharAtlas';
+import StaticCharAtlas from './StaticCharAtlas';
+
+const charAtlasImplementations = {
+  'none': NoneCharAtlas,
+  'static': StaticCharAtlas,
+};
 
 interface ICharAtlasCacheEntry {
   atlas: BaseCharAtlas;
@@ -64,7 +70,7 @@ export function acquireCharAtlas(
   }
 
   const newEntry: ICharAtlasCacheEntry = {
-    atlas: new StaticCharAtlas(
+    atlas: new charAtlasImplementations[terminal.options.experimentalCharAtlas](
       document,
       newConfig,
     ),

--- a/src/renderer/atlas/CharAtlasUtils.ts
+++ b/src/renderer/atlas/CharAtlasUtils.ts
@@ -17,6 +17,7 @@ export function generateConfig(scaledCharWidth: number, scaledCharHeight: number
     ansi: colors.ansi.slice(0, 16)
   };
   return {
+    type: terminal.options.experimentalCharAtlas,
     devicePixelRatio: window.devicePixelRatio,
     scaledCharWidth,
     scaledCharHeight,
@@ -35,7 +36,8 @@ export function configEquals(a: ICharAtlasConfig, b: ICharAtlasConfig): boolean 
       return false;
     }
   }
-  return a.devicePixelRatio === b.devicePixelRatio &&
+  return a.type === b.type &&
+      a.devicePixelRatio === b.devicePixelRatio &&
       a.fontFamily === b.fontFamily &&
       a.fontSize === b.fontSize &&
       a.fontWeight === b.fontWeight &&

--- a/src/renderer/atlas/CharAtlasUtils.ts
+++ b/src/renderer/atlas/CharAtlasUtils.ts
@@ -8,13 +8,16 @@ import { IColorSet } from '../Types';
 import { ICharAtlasConfig } from '../../shared/atlas/Types';
 
 export function generateConfig(scaledCharWidth: number, scaledCharHeight: number, terminal: ITerminal, colors: IColorSet): ICharAtlasConfig {
+  // null out some fields that don't matter
   const clonedColors = {
     foreground: colors.foreground,
     background: colors.background,
     cursor: null,
     cursorAccent: null,
     selection: null,
-    ansi: colors.ansi.slice(0, 16)
+    // For the static char atlas, we only use the first 16 colors, but we need all 256 for the
+    // dynamic character atlas.
+    ansi: colors.ansi,
   };
   return {
     type: terminal.options.experimentalCharAtlas,

--- a/src/renderer/atlas/CharAtlasUtils.ts
+++ b/src/renderer/atlas/CharAtlasUtils.ts
@@ -17,7 +17,7 @@ export function generateConfig(scaledCharWidth: number, scaledCharHeight: number
     selection: null,
     // For the static char atlas, we only use the first 16 colors, but we need all 256 for the
     // dynamic character atlas.
-    ansi: colors.ansi,
+    ansi: colors.ansi.slice(0, 16),
   };
   return {
     type: terminal.options.experimentalCharAtlas,

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { DIM_OPACITY, IGlyphIdentifier, INVERTED_DEFAULT_COLOR } from './Types';
+import { ICharAtlasConfig } from '../../shared/atlas/Types';
+import BaseCharAtlas from './BaseCharAtlas';
+import { clearColor } from '../../shared/atlas/CharAtlasGenerator';
+
+// In practice we're probably never going to exhaust a texture this large. For debugging purposes,
+// however, it can be useful to set this to a really tiny value, to verify that LRU eviction works.
+const TEXTURE_WIDTH = 1024;
+const TEXTURE_HEIGHT = 1024;
+
+type GlyphCacheKey = string;
+
+/**
+ * Removes and returns the oldest element in a map.
+ */
+function mapShift<K, V>(map: Map<K, V>): [K, V] {
+  // Map guarantees insertion-order iteration.
+  const entry = map.entries().next().value;
+  if (entry === undefined) {
+    return undefined;
+  }
+  map.delete(entry[0]);
+  return entry;
+}
+
+function getGlyphCacheKey(glyph: IGlyphIdentifier): GlyphCacheKey {
+  return `${glyph.bg}_${glyph.fg}_${glyph.bold ? 0 : 1}${glyph.dim ? 0 : 1}${glyph.char}`;
+}
+
+export default class DynamicCharAtlas extends BaseCharAtlas {
+  // An ordered map that we're using to keep track of where each glyph is in the atlas texture.
+  // It's ordered so that we can determine when to remove the old entries.
+  private _cacheMap: Map<GlyphCacheKey, number> = new Map();
+
+  // The texture that the atlas is drawn to
+  private _cacheCanvas: HTMLCanvasElement;
+  private _cacheCtx: CanvasRenderingContext2D;
+
+  // A temporary canvas that glyphs are drawn to before being transfered over to the atlas.
+  private _tmpCanvas: HTMLCanvasElement;
+  private _tmpCtx: CanvasRenderingContext2D;
+
+  // The number of characters stored in the atlas by width/height
+  private _capacity: number;
+  private _width: number;
+  private _height: number;
+
+  constructor(document: Document, private _config: ICharAtlasConfig) {
+    super();
+    this._cacheCanvas = document.createElement('canvas');
+    this._cacheCanvas.width = TEXTURE_WIDTH;
+    this._cacheCanvas.height = TEXTURE_HEIGHT;
+    // The canvas needs alpha because we use clearColor to convert the background color to alpha.
+    this._cacheCtx = this._cacheCanvas.getContext('2d', {alpha: true});
+
+    this._tmpCanvas = document.createElement('canvas');
+    this._tmpCanvas.width = this._config.scaledCharWidth;
+    this._tmpCanvas.height = this._config.scaledCharHeight;
+    this._tmpCtx = this._tmpCanvas.getContext('2d', {alpha: true});
+
+    this._width = Math.floor(TEXTURE_WIDTH / this._config.scaledCharWidth);
+    this._height = Math.floor(TEXTURE_HEIGHT / this._config.scaledCharHeight);
+    this._capacity = this._width * this._height;
+
+    // This is useful for debugging
+    // document.body.appendChild(this._cacheCanvas);
+  }
+
+  public draw(
+    ctx: CanvasRenderingContext2D,
+    glyph: IGlyphIdentifier,
+    x: number,
+    y: number,
+  ): boolean {
+    const glyphKey = getGlyphCacheKey(glyph);
+    const index = this._cacheMap.get(glyphKey);
+    if (index != null) {
+      // move to end of insertion order, so this can behave like an LRU cache
+      this._cacheMap.delete(glyphKey);
+      this._cacheMap.set(glyphKey, index);
+      this._drawFromCache(ctx, index, x, y);
+      return true;
+    } else if (this._canCache(glyph)) {
+      let index;
+      if (this._cacheMap.size < this._capacity) {
+        index = this._cacheMap.size;
+      } else {
+        index = mapShift(this._cacheMap)[1];
+      }
+      this._drawToCache(glyph, index);
+      this._cacheMap.set(glyphKey, index);
+      this._drawFromCache(ctx, index, x, y);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private _canCache(glyph: IGlyphIdentifier): boolean {
+    // Only cache ascii and extended characters for now, to be safe. In the future, we could do
+    // something more complicated to determine the expected width of a character.
+    //
+    // If we switch the renderer over to webgl at some point, we may be able to use blending modes
+    // to draw overlapping glyphs from the atlas:
+    // https://github.com/servo/webrender/issues/464#issuecomment-255632875
+    // https://webglfundamentals.org/webgl/lessons/webgl-text-texture.html
+    return glyph.char.charCodeAt(0) < 256;
+  }
+
+  private _toCoordinates(index: number): [number, number] {
+    return [
+      (index % this._width) * this._config.scaledCharWidth,
+      Math.floor(index / this._width) * this._config.scaledCharHeight
+    ];
+  }
+
+  private _drawFromCache(
+    ctx: CanvasRenderingContext2D,
+    index: number,
+    x: number,
+    y: number
+  ): void {
+    const [cacheX, cacheY] = this._toCoordinates(index);
+    ctx.drawImage(
+      this._cacheCanvas,
+      cacheX,
+      cacheY,
+      this._config.scaledCharWidth,
+      this._config.scaledCharHeight,
+      x,
+      y,
+      this._config.scaledCharWidth,
+      this._config.scaledCharHeight,
+    );
+  }
+
+  // TODO: We do this (or something similar) in multiple places. We should split this off
+  // into a shared function.
+  private _drawToCache(glyph: IGlyphIdentifier, index: number): void {
+    this._tmpCtx.save();
+    // no need to clear _tmpCtx, since we're going to draw a fully opaque background
+
+    // draw the background
+    let backgroundColor = this._config.colors.background;
+    if (glyph.bg === INVERTED_DEFAULT_COLOR) {
+      backgroundColor = this._config.colors.foreground;
+    } else if (glyph.bg < 256) {
+      backgroundColor = this._config.colors.ansi[glyph.bg];
+    }
+    this._tmpCtx.fillStyle = backgroundColor.css;
+    this._tmpCtx.fillRect(0, 0, this._config.scaledCharWidth, this._config.scaledCharHeight);
+
+    // draw the foreground/glyph
+    this._tmpCtx.font =
+      `${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
+    if (glyph.bold) {
+      this._tmpCtx.font = `bold ${this._tmpCtx.font}`;
+    }
+    this._tmpCtx.textBaseline = 'top';
+
+    if (glyph.fg === INVERTED_DEFAULT_COLOR) {
+      this._tmpCtx.fillStyle = this._config.colors.background.css;
+    } else if (glyph.fg < 256) {
+      // 256 color support
+      this._tmpCtx.fillStyle = this._config.colors.ansi[glyph.fg].css;
+    } else {
+      this._tmpCtx.fillStyle = this._config.colors.foreground.css;
+    }
+
+    // Apply alpha to dim the character
+    if (glyph.dim) {
+      this._tmpCtx.globalAlpha = DIM_OPACITY;
+    }
+    // Draw the character
+    this._tmpCtx.fillText(glyph.char, 0, 0);
+    this._tmpCtx.restore();
+
+    // clear the background from the character to avoid issues with drawing over the previous
+    // character if it extends past it's bounds
+    const imageData = this._tmpCtx.getImageData(
+      0, 0, this._config.scaledCharWidth, this._config.scaledCharHeight,
+    );
+    clearColor(imageData, backgroundColor);
+
+    // copy the data from _tmpCanvas to _cacheCanvas
+    const [x, y] = this._toCoordinates(index);
+    // putImageData doesn't do any blending, so it will overwrite any existing cache entry for us
+    this._cacheCtx.putImageData(imageData, x, y);
+  }
+}

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -14,6 +14,11 @@ import LRUMap from './LRUMap';
 const TEXTURE_WIDTH = 1024;
 const TEXTURE_HEIGHT = 1024;
 
+const TRANSPARENT_COLOR = {
+  css: 'rgba(0, 0, 0, 0)',
+  rgba: 0,
+}
+
 interface IGlyphCacheValue {
   index: number;
   isEmpty: boolean;
@@ -137,7 +142,6 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
   // into a shared function.
   private _drawToCache(glyph: IGlyphIdentifier, index: number): IGlyphCacheValue {
     this._tmpCtx.save();
-    // no need to clear _tmpCtx, since we're going to draw a fully opaque background
 
     // draw the background
     let backgroundColor = this._config.colors.background;
@@ -146,8 +150,25 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     } else if (glyph.bg < 256) {
       backgroundColor = this._config.colors.ansi[glyph.bg];
     }
+
+    let backgroundIsTransparent = false;
+    if ((backgroundColor.rgba & 0xFF) !== 0xFF) {
+      // The background color has some transparency, so we need to render it as fully transparent
+      // in the atlas. Otherwise we'd end up drawing the transparent background twice around the
+      // anti-aliased edges of the glyph, and it would look too dark.
+      //
+      // This has the side-effect of disabling RGB subpixel antialiasing, but most compositors will
+      // disable that anyways on a partially transparent background for similar reasons.
+      backgroundColor = TRANSPARENT_COLOR;
+      backgroundIsTransparent = true;
+    }
+
+    // Use a 'copy' composite operation to clear any existing glyph out of _tmpCtx, regardless of
+    // transparency in backgroundColor
+    this._tmpCtx.globalCompositeOperation = 'copy';
     this._tmpCtx.fillStyle = backgroundColor.css;
     this._tmpCtx.fillRect(0, 0, this._config.scaledCharWidth, this._config.scaledCharHeight);
+    this._tmpCtx.globalCompositeOperation = 'source-over';
 
     // draw the foreground/glyph
     this._tmpCtx.font =
@@ -179,7 +200,10 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     const imageData = this._tmpCtx.getImageData(
       0, 0, this._config.scaledCharWidth, this._config.scaledCharHeight,
     );
-    const isEmpty = clearColor(imageData, backgroundColor);
+    let isEmpty = false;
+    if (!backgroundIsTransparent) {
+      isEmpty = clearColor(imageData, backgroundColor);
+    }
 
     // copy the data from _tmpCanvas to _cacheCanvas
     const [x, y] = this._toCoordinates(index);

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -25,7 +25,7 @@ const TRANSPARENT_COLOR = {
 //
 // This helps to limit the amount of damage a program can do when it would otherwise thrash the
 // cache.
-const DRAW_TO_CACHE_LIMIT = 100;
+const FRAME_CACHE_DRAW_LIMIT = 100;
 
 interface IGlyphCacheValue {
   index: number;
@@ -94,7 +94,7 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     if (cacheValue != null) {
       this._drawFromCache(ctx, cacheValue, x, y);
       return true;
-    } else if (this._canCache(glyph) && this._drawToCacheCount < DRAW_TO_CACHE_LIMIT) {
+    } else if (this._canCache(glyph) && this._drawToCacheCount < FRAME_CACHE_DRAW_LIMIT) {
       let index;
       if (this._cacheMap.size < this._cacheMap.capacity) {
         index = this._cacheMap.size;

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -121,7 +121,7 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     // to draw overlapping glyphs from the atlas:
     // https://github.com/servo/webrender/issues/464#issuecomment-255632875
     // https://webglfundamentals.org/webgl/lessons/webgl-text-texture.html
-    return glyph.char.charCodeAt(0) < 256;
+    return glyph.code < 256;
   }
 
   private _toCoordinates(index: number): [number, number] {

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -205,8 +205,9 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     this._tmpCtx.globalCompositeOperation = 'source-over';
 
     // draw the foreground/glyph
+    const fontWeight = glyph.bold ? this._config.fontWeightBold : this._config.fontWeight;
     this._tmpCtx.font =
-      `${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
+      `${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
     if (glyph.bold) {
       this._tmpCtx.font = `bold ${this._tmpCtx.font}`;
     }

--- a/src/renderer/atlas/LRUMap.test.ts
+++ b/src/renderer/atlas/LRUMap.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import LRUMap from './LRUMap';
+
+describe('LRUMap', () => {
+  it('can be used to store and retrieve values', () => {
+    const map = new LRUMap(10);
+    map.set('keya', 'valuea');
+    map.set('keyb', 'valueb');
+    map.set('keyc', 'valuec');
+    assert.strictEqual(map.get('keya'), 'valuea');
+    assert.strictEqual(map.get('keyb'), 'valueb');
+    assert.strictEqual(map.get('keyc'), 'valuec');
+  });
+
+  it('maintains a size from insertions', () => {
+    const map = new LRUMap(10);
+    assert.strictEqual(map.size, 0);
+    map.set('a', 'value');
+    assert.strictEqual(map.size, 1);
+    map.set('b', 'value');
+    assert.strictEqual(map.size, 2);
+  });
+
+  it('deletes the oldest entry when the capacity is exceeded', () => {
+    const map = new LRUMap(4);
+    map.set('a', 'value');
+    map.set('b', 'value');
+    map.set('c', 'value');
+    map.set('d', 'value');
+    map.set('e', 'value');
+    assert.isNull(map.get('a'));
+    assert.isNotNull(map.get('b'));
+    assert.isNotNull(map.get('c'));
+    assert.isNotNull(map.get('d'));
+    assert.isNotNull(map.get('e'));
+    assert.strictEqual(map.size, 4);
+  });
+
+  it('prevents a recently accessed entry from getting deleted', () => {
+    const map = new LRUMap(2);
+    map.set('a', 'value');
+    map.set('b', 'value');
+    map.get('a');
+    // a would normally get deleted here, except that we called get()
+    map.set('c', 'value');
+    assert.isNotNull(map.get('a'));
+    // b got deleted instead of a
+    assert.isNull(map.get('b'));
+    assert.isNotNull(map.get('c'));
+  });
+
+  it('supports mutation', () => {
+    const map = new LRUMap(10);
+    map.set('keya', 'oldvalue');
+    map.set('keya', 'newvalue');
+    // mutation doesn't change the size
+    assert.strictEqual(map.size, 1);
+    assert.strictEqual(map.get('keya'), 'newvalue');
+  });
+});

--- a/src/renderer/atlas/LRUMap.ts
+++ b/src/renderer/atlas/LRUMap.ts
@@ -37,7 +37,11 @@ export default class LRUMap<T> {
   }
 
   private _appendNode(node: ILinkedListNode<T>): void {
-    node.prev = this._tail;
+    const tail = this._tail;
+    if (tail !== null) {
+      tail.next = node;
+    }
+    node.prev = tail;
     node.next = null;
     this._tail = node;
     if (this._head === null) {

--- a/src/renderer/atlas/LRUMap.ts
+++ b/src/renderer/atlas/LRUMap.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+interface ILinkedListNode<T> {
+  prev: ILinkedListNode<T>,
+  next: ILinkedListNode<T>,
+  key: string,
+  value: T,
+}
+
+export default class LRUMap<T> {
+  private _map = {};
+  private _head: ILinkedListNode<T> = null;
+  private _tail: ILinkedListNode<T> = null;
+  private _nodePool: ILinkedListNode<T>[] = [];
+  public size: number = 0;
+
+  constructor(public capacity: number) { }
+
+  private _unlinkNode(node: ILinkedListNode<T>): void {
+    const prev = node.prev;
+    const next = node.next;
+    if (node === this._head) {
+      this._head = next;
+    }
+    if (node === this._tail) {
+      this._tail = prev;
+    }
+    if (prev !== null) {
+      prev.next = next;
+    }
+    if (next !== null) {
+      next.prev = prev;
+    }
+  }
+
+  private _appendNode(node: ILinkedListNode<T>): void {
+    node.prev = this._tail;
+    node.next = null;
+    this._tail = node;
+    if (this._head === null) {
+      this._head = node;
+    }
+  }
+
+  /**
+   * Preallocate a bunch of linked-list nodes. Allocating these nodes ahead of time means that
+   * they're more likely to live next to each other in memory, which seems to improve performance.
+   *
+   * Each empty object only consumes about 60 bytes of memory, so this is pretty cheap, even for
+   * large maps.
+   */
+  public prealloc(count: number) {
+    const nodePool = this._nodePool;
+    for (let i = 0; i < count; i++) {
+      nodePool.push({
+        prev: null,
+        next: null,
+        key: null,
+        value: null,
+      });
+    }
+  }
+
+  public get(key: string): T | null {
+    // This is unsafe: We're assuming our keyspace doesn't overlap with Object.prototype. However,
+    // it's faster than calling hasOwnProperty, and in our case, it would never overlap.
+    const node = this._map[key];
+    if (node !== undefined) {
+      this._unlinkNode(node);
+      this._appendNode(node);
+      return node.value;
+    }
+    return null;
+  }
+
+  public peek(): T | null {
+    const head = this._head;
+    return head === null ? null : head.value;
+  }
+
+  public set(key: string, value: T): void {
+    // This is unsafe: See note above.
+    let node = this._map[key];
+    if (node !== undefined) {
+      // already exists, we just need to mutate it and move it to the end of the list
+      node = this._map[key];
+      this._unlinkNode(node);
+      node.value = value;
+    } else if (this.size >= this.capacity) {
+      // we're out of space: recycle the head node, move it to the tail
+      node = this._head;
+      this._unlinkNode(node);
+      delete this._map[node.key];
+      node.key = key;
+      node.value = value;
+      this._map[key] = node;
+    } else {
+      // make a new element
+      const nodePool = this._nodePool;
+      if (nodePool.length > 0) {
+        // use a preallocated node if we can
+        node = nodePool.pop();
+        node.key = key;
+        node.value = value;
+      } else {
+        node = {
+          prev: null,
+          next: null,
+          key,
+          value,
+        };
+      }
+      this._map[key] = node;
+      this.size++;
+    }
+    this._appendNode(node);
+  }
+}

--- a/src/renderer/atlas/NoneCharAtlas.ts
+++ b/src/renderer/atlas/NoneCharAtlas.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ *
+ * A dummy CharAtlas implementation that always fails to draw characters.
+ */
+
+import { IGlyphIdentifier } from './Types';
+import { ICharAtlasConfig } from '../../shared/atlas/Types';
+import BaseCharAtlas from './BaseCharAtlas';
+
+export default class NoneCharAtlas extends BaseCharAtlas {
+  constructor(document: Document, config: ICharAtlasConfig) {
+    super();
+  }
+
+  public draw(
+    ctx: CanvasRenderingContext2D,
+    glyph: IGlyphIdentifier,
+    x: number,
+    y: number
+  ): boolean {
+    return false;
+  }
+}

--- a/src/renderer/atlas/StaticCharAtlas.ts
+++ b/src/renderer/atlas/StaticCharAtlas.ts
@@ -6,7 +6,7 @@
 import { DIM_OPACITY, IGlyphIdentifier } from './Types';
 import { ICharAtlasConfig } from '../../shared/atlas/Types';
 import { CHAR_ATLAS_CELL_SPACING } from '../../shared/atlas/Types';
-import { generateCharAtlas } from '../../shared/atlas/CharAtlasGenerator';
+import { generateStaticCharAtlasTexture } from '../../shared/atlas/CharAtlasGenerator';
 import BaseCharAtlas from './BaseCharAtlas';
 
 export default class StaticCharAtlas extends BaseCharAtlas {
@@ -24,7 +24,7 @@ export default class StaticCharAtlas extends BaseCharAtlas {
   }
 
   public async _doWarmUp(): Promise<void> {
-    const result = generateCharAtlas(window, this._canvasFactory, this._config);
+    const result = generateStaticCharAtlasTexture(window, this._canvasFactory, this._config);
     if (result instanceof Promise) {
       this._texture = await result;
     } else {

--- a/src/renderer/atlas/StaticCharAtlas.ts
+++ b/src/renderer/atlas/StaticCharAtlas.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { DIM_OPACITY, IGlyphIdentifier } from './Types';
+import { ICharAtlasConfig } from '../../shared/atlas/Types';
+import { CHAR_ATLAS_CELL_SPACING } from '../../shared/atlas/Types';
+import { generateCharAtlas } from '../../shared/atlas/CharAtlasGenerator';
+import BaseCharAtlas from './BaseCharAtlas';
+
+export default class StaticCharAtlas extends BaseCharAtlas {
+  private _texture: HTMLCanvasElement | ImageBitmap;
+
+  constructor(private _document: Document, private _config: ICharAtlasConfig) {
+    super();
+  }
+
+  private _canvasFactory = (width: number, height: number) => {
+    const canvas = this._document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    return canvas;
+  }
+
+  public async _doWarmUp(): Promise<void> {
+    const result = generateCharAtlas(window, this._canvasFactory, this._config);
+    if (result instanceof Promise) {
+      this._texture = await result;
+    } else {
+      this._texture = result;
+    }
+  }
+
+  private _isCached(glyph: IGlyphIdentifier, colorIndex: number): boolean {
+    const isAscii = glyph.char.charCodeAt(0) < 256;
+    // A color is basic if it is one of the standard normal or bold weight
+    // colors of the characters held in the char atlas. Note that this excludes
+    // the normal weight _light_ color characters.
+    const isBasicColor = (colorIndex > 1 && glyph.fg < 16) && (glyph.fg < 8 || glyph.bold);
+    const isDefaultColor = glyph.fg >= 256;
+    const isDefaultBackground = glyph.bg >= 256;
+    return isAscii && (isBasicColor || isDefaultColor) && isDefaultBackground;
+  }
+
+  public draw(
+    ctx: CanvasRenderingContext2D,
+    glyph: IGlyphIdentifier,
+    x: number,
+    y: number,
+  ): boolean {
+    // we're not warmed up yet
+    if (this._texture == null) {
+      return false;
+    }
+
+    let colorIndex = 0;
+    if (glyph.fg < 256) {
+      colorIndex = glyph.fg + 2;
+    } else {
+      // If default color and bold
+      if (glyph.bold) {
+        colorIndex = 1;
+      }
+    }
+    if (!this._isCached(glyph, colorIndex)) {
+      return false;
+    }
+    // ImageBitmap's draw about twice as fast as from a canvas
+    const charAtlasCellWidth = this._config.scaledCharWidth + CHAR_ATLAS_CELL_SPACING;
+    const charAtlasCellHeight = this._config.scaledCharHeight + CHAR_ATLAS_CELL_SPACING;
+
+    // Apply alpha to dim the character
+    if (glyph.dim) {
+      ctx.globalAlpha = DIM_OPACITY;
+    }
+
+    // Draw the non-bold version of the same color if bold is not enabled
+    /*if (glyph.bold && !terminal.options.enableBold) {
+      // Ignore default color as it's not touched above
+      if (colorIndex > 1) {
+        colorIndex -= 8;
+      }
+    }*/
+
+    ctx.drawImage(
+      this._texture,
+      glyph.char.charCodeAt(0) * charAtlasCellWidth,
+      colorIndex * charAtlasCellHeight,
+      charAtlasCellWidth,
+      this._config.scaledCharHeight,
+      x,
+      y,
+      charAtlasCellWidth,
+      this._config.scaledCharHeight
+    );
+
+    return true;
+  }
+}

--- a/src/renderer/atlas/StaticCharAtlas.ts
+++ b/src/renderer/atlas/StaticCharAtlas.ts
@@ -4,8 +4,7 @@
  */
 
 import { DIM_OPACITY, IGlyphIdentifier } from './Types';
-import { ICharAtlasConfig } from '../../shared/atlas/Types';
-import { CHAR_ATLAS_CELL_SPACING } from '../../shared/atlas/Types';
+import { CHAR_ATLAS_CELL_SPACING, ICharAtlasConfig } from '../../shared/atlas/Types';
 import { generateStaticCharAtlasTexture } from '../../shared/atlas/CharAtlasGenerator';
 import BaseCharAtlas from './BaseCharAtlas';
 
@@ -23,12 +22,14 @@ export default class StaticCharAtlas extends BaseCharAtlas {
     return canvas;
   }
 
-  public async _doWarmUp(): Promise<void> {
+  public _doWarmUp() {
     const result = generateStaticCharAtlasTexture(window, this._canvasFactory, this._config);
-    if (result instanceof Promise) {
-      this._texture = await result;
-    } else {
+    if (result instanceof HTMLCanvasElement) {
       this._texture = result;
+    } else {
+      result.then(texture => {
+        this._texture = texture
+      });
     }
   }
 

--- a/src/renderer/atlas/StaticCharAtlas.ts
+++ b/src/renderer/atlas/StaticCharAtlas.ts
@@ -34,7 +34,7 @@ export default class StaticCharAtlas extends BaseCharAtlas {
   }
 
   private _isCached(glyph: IGlyphIdentifier, colorIndex: number): boolean {
-    const isAscii = glyph.char.charCodeAt(0) < 256;
+    const isAscii = glyph.code < 256;
     // A color is basic if it is one of the standard normal or bold weight
     // colors of the characters held in the char atlas. Note that this excludes
     // the normal weight _light_ color characters.
@@ -86,7 +86,7 @@ export default class StaticCharAtlas extends BaseCharAtlas {
 
     ctx.drawImage(
       this._texture,
-      glyph.char.charCodeAt(0) * charAtlasCellWidth,
+      glyph.code * charAtlasCellWidth,
       colorIndex * charAtlasCellHeight,
       charAtlasCellWidth,
       this._config.scaledCharHeight,

--- a/src/renderer/atlas/Types.ts
+++ b/src/renderer/atlas/Types.ts
@@ -5,3 +5,11 @@
 
 export const INVERTED_DEFAULT_COLOR = -1;
 export const DIM_OPACITY = 0.5;
+
+export interface IGlyphIdentifier {
+  char: string;
+  bg: number;
+  fg: number;
+  bold: boolean;
+  dim: boolean;
+}

--- a/src/renderer/atlas/Types.ts
+++ b/src/renderer/atlas/Types.ts
@@ -8,6 +8,7 @@ export const DIM_OPACITY = 0.5;
 
 export interface IGlyphIdentifier {
   char: string;
+  code: number;
   bg: number;
   fg: number;
   bold: boolean;

--- a/src/shared/atlas/CharAtlasGenerator.ts
+++ b/src/shared/atlas/CharAtlasGenerator.ts
@@ -5,6 +5,7 @@
 
 import { FontWeight } from 'xterm';
 import { CHAR_ATLAS_CELL_SPACING, ICharAtlasConfig } from './Types';
+import { IColor } from '../Types';
 import { isFirefox } from '../utils/Browser';
 
 declare const Promise: any;
@@ -20,9 +21,9 @@ export interface IOffscreenCanvas {
  * Generates a char atlas.
  * @param context The window or worker context.
  * @param canvasFactory A function to generate a canvas with a width or height.
- * @param request The config for the new char atlas.
+ * @param config The config for the new char atlas.
  */
-export function generateCharAtlas(context: Window, canvasFactory: (width: number, height: number) => HTMLCanvasElement | IOffscreenCanvas, config: ICharAtlasConfig): HTMLCanvasElement | Promise<ImageBitmap> {
+export function generateStaticCharAtlasTexture(context: Window, canvasFactory: (width: number, height: number) => HTMLCanvasElement | IOffscreenCanvas, config: ICharAtlasConfig): HTMLCanvasElement | Promise<ImageBitmap> {
   const cellWidth = config.scaledCharWidth + CHAR_ATLAS_CELL_SPACING;
   const cellHeight = config.scaledCharHeight + CHAR_ATLAS_CELL_SPACING;
   const canvas = canvasFactory(
@@ -100,10 +101,7 @@ export function generateCharAtlas(context: Window, canvasFactory: (width: number
   const charAtlasImageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
 
   // Remove the background color from the image so characters may overlap
-  const r = config.colors.background.rgba >>> 24;
-  const g = config.colors.background.rgba >>> 16 & 0xFF;
-  const b = config.colors.background.rgba >>> 8 & 0xFF;
-  clearColor(charAtlasImageData, r, g, b);
+  clearColor(charAtlasImageData, config.colors.background);
 
   return context.createImageBitmap(charAtlasImageData);
 }
@@ -111,7 +109,10 @@ export function generateCharAtlas(context: Window, canvasFactory: (width: number
 /**
  * Makes a partiicular rgb color in an ImageData completely transparent.
  */
-function clearColor(imageData: ImageData, r: number, g: number, b: number): void {
+export function clearColor(imageData: ImageData, color: IColor): void {
+  const r = color.rgba >>> 24;
+  const g = color.rgba >>> 16 & 0xFF;
+  const b = color.rgba >>> 8 & 0xFF;
   for (let offset = 0; offset < imageData.data.length; offset += 4) {
     if (imageData.data[offset] === r &&
         imageData.data[offset + 1] === g &&

--- a/src/shared/atlas/CharAtlasGenerator.ts
+++ b/src/shared/atlas/CharAtlasGenerator.ts
@@ -108,8 +108,10 @@ export function generateStaticCharAtlasTexture(context: Window, canvasFactory: (
 
 /**
  * Makes a partiicular rgb color in an ImageData completely transparent.
+ * @returns True if the result is "empty", meaning all pixels are fully transparent.
  */
-export function clearColor(imageData: ImageData, color: IColor): void {
+export function clearColor(imageData: ImageData, color: IColor): boolean {
+  let isEmpty = true;
   const r = color.rgba >>> 24;
   const g = color.rgba >>> 16 & 0xFF;
   const b = color.rgba >>> 8 & 0xFF;
@@ -118,8 +120,11 @@ export function clearColor(imageData: ImageData, color: IColor): void {
         imageData.data[offset + 1] === g &&
         imageData.data[offset + 2] === b) {
       imageData.data[offset + 3] = 0;
+    } else {
+      isEmpty = false;
     }
   }
+  return isEmpty;
 }
 
 function getFont(fontWeight: FontWeight, config: ICharAtlasConfig): string {

--- a/src/shared/atlas/Types.ts
+++ b/src/shared/atlas/Types.ts
@@ -9,6 +9,7 @@ import { IColorSet } from '../Types';
 export const CHAR_ATLAS_CELL_SPACING = 1;
 
 export interface ICharAtlasConfig {
+  type: 'none' | 'static';
   devicePixelRatio: number;
   fontSize: number;
   fontFamily: string;

--- a/src/shared/atlas/Types.ts
+++ b/src/shared/atlas/Types.ts
@@ -9,7 +9,7 @@ import { IColorSet } from '../Types';
 export const CHAR_ATLAS_CELL_SPACING = 1;
 
 export interface ICharAtlasConfig {
-  type: 'none' | 'static';
+  type: 'none' | 'static' | 'dynamic';
   devicePixelRatio: number;
   fontSize: number;
   fontFamily: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,7 @@
       "DOM",
       "ES5",
       "ScriptHost",
-      "ES2015.Promise",
-      "ES2015.Collection",
-      "ES2015.Iterable"
+      "ES2015.Promise"
     ],
     "rootDir": "src",
     "outDir": "lib",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
+    "lib": ["DOM", "ES5", "ScriptHost", "ES2015.Promise"],
     "rootDir": "src",
     "outDir": "lib",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,14 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": ["DOM", "ES5", "ScriptHost", "ES2015.Promise"],
+    "lib": [
+      "DOM",
+      "ES5",
+      "ScriptHost",
+      "ES2015.Promise",
+      "ES2015.Collection",
+      "ES2015.Iterable"
+    ],
     "rootDir": "src",
     "outDir": "lib",
     "sourceMap": true,

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -69,11 +69,15 @@ declare module 'xterm' {
      * - 'none': Don't use an atlas.
      * - 'static': Generate an atlas when the terminal starts or is reconfigured. This atlas will
      *   only contain ASCII characters in 16 colors.
+     * - 'dynamic': Generate an atlas using a LRU cache as characters are requested. Limited to
+     *   ASCII characters (for now), but supports 256 colors. For characters covered by the static
+     *   cache, it's slightly slower in comparison, since there's more overhead involved in
+     *   managing the cache.
      *
      * Currently defaults to 'static'. This option may be removed in the future. If it is, passed
      * parameters will be ignored.
      */
-    experimentalCharAtlas?: 'none' | 'static';
+    experimentalCharAtlas?: 'none' | 'static' | 'dynamic';
 
     /**
      * The font size used to render text.

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -62,6 +62,20 @@ declare module 'xterm' {
     enableBold?: boolean;
 
     /**
+     * What character atlas implementation to use. The character atlas caches drawn characters,
+     * speeding up rendering significantly. However, it can introduce some minor rendering
+     * artifacts.
+     *
+     * - 'none': Don't use an atlas.
+     * - 'static': Generate an atlas when the terminal starts or is reconfigured. This atlas will
+     *   only contain ASCII characters in 16 colors.
+     *
+     * Currently defaults to 'static'. This option may be removed in the future. If it is, passed
+     * parameters will be ignored.
+     */
+    experimentalCharAtlas?: 'none' | 'static';
+
+    /**
      * The font size used to render text.
      */
     fontSize?: number;


### PR DESCRIPTION
I've split this into a series of small commits, which should hopefully make reviewing this easier.

This introduces a character atlas API (defined by BaseCharAtlas), and three implementations of that API (static, dynamic, and none). The static character atlas is default for now, but you can switch between implementations using the `experimentalCharAtlas` configuration option, or with a dropdown in the demo webpage.

The new DynamicCharAtlas implementation uses a fixed-size texture and an ordered map to maintain an LRU cache of single-width characters in different colors and with different backgrounds. After using it for a while, you end up with an atlas that looks something like this:

![](https://user-images.githubusercontent.com/180404/37260732-df55f856-2553-11e8-8ffe-1bca4ca737c5.png)

When scrolling through vim with the dynamic character atlas, we can see that almost no time is spent calling `fillText`, and that most of the time is spent in calls to `drawImage` and `fillRect`:

![](https://user-images.githubusercontent.com/180404/37260867-efbd3758-2554-11e8-9f21-931e9c37bbea.png)

Whereas the opposite is generally true for the static char atlas:

![](https://user-images.githubusercontent.com/180404/37260899-40011a36-2555-11e8-9de0-3a0643393bbd.png)

There's more performance overhead involved in creating and managing the LRU cache, but in practice it should cover more glyphs, so performance will depend on what kind of text you're rendering.

I've got more optimizations I'm currently implementing and/or playing with that reduce the cost of drawing and the overhead of maintaining the cache, but I think the current implementation is usable and competitive with the static atlas for most use-cases.

This does add a dependency on `Map` (and an implementation of `Symbol.iterator` to traverse it), but that's only if you enable the dynamic atlas. If you don't enable the dynamic atlas, you shouldn't need `Map` (In theory; I haven't tested this claim).

I'm considering replacing `Map` with a custom ordered map implementation, since the act of deleting and setting entries on the Map with every cache read (to mark it as used and move it to the end of the Map) ends up being rather expensive, and appears to slow down over time (on V8 at least?). I think I can probably devise a data structure that works better for our access patterns.

Fixes #1294