### PR TITLE
Batch background draws together to reduce draws

### DIFF
--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -26,7 +26,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     private _container: HTMLElement,
     id: string,
     zIndex: number,
-    private _alpha: boolean,
+    protected _alpha: boolean,
     protected _colors: IColorSet
   ) {
     this._canvas = document.createElement('canvas');

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -26,7 +26,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     private _container: HTMLElement,
     id: string,
     zIndex: number,
-    protected _alpha: boolean,
+    private _alpha: boolean,
     protected _colors: IColorSet
   ) {
     this._canvas = document.createElement('canvas');


### PR DESCRIPTION
Adjacent cells on the same row sharing the same background color will be drawn using the same `fillCells` call. This should make drawing an application with a solid or mostly solid background color (e.g. vim) faster.

I set vim to draw the background color for a file, and started scrolling through it. Before, `_drawBackground` was taking around 6ms per frame. After this commit, it was taking around 0.5ms per frame.

Based on prior experience, I'd expect these results to be more drastic for larger terminal windows. The demo's window is pretty small.