### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To start using xterm.js on your browser, add the `xterm.js` and `xterm.css` to t
       <script>
       	var term = new Terminal();
         term.open(document.getElementById('terminal'));
-        term.write('Hello from \033[1;3;31mxterm.js\033[0m $ ')
+        term.write('Hello from \u001B[1;3;31mxterm.js\u001B[0m $ ')
       </script>
     </body>
   </html>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To start using xterm.js on your browser, add the `xterm.js` and `xterm.css` to t
       <script>
       	var term = new Terminal();
         term.open(document.getElementById('terminal'));
-        term.write('Hello from \u001B[1;3;31mxterm.js\u001B[0m $ ')
+        term.write('Hello from \x1B[1;3;31mxterm.js\x1B[0m $ ')
       </script>
     </body>
   </html>


### PR DESCRIPTION
Closes #1419 

Replace the deprecated octal escapes with hex escapes.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal