### PR TITLE
Save and restore the ctx for cached characters

### DIFF
--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -250,6 +250,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     const isDefaultBackground = bg >= 256;
     const drawInBrightColor = (terminal.options.drawBoldTextInBrightColors && bold && fg < 8);
     if (this._charAtlas && isAscii && (isBasicColor || isDefaultColor) && isDefaultBackground && !italic) {
+      this._ctx.save(); // we may set globalAlpha, so we need to be able to restore
       let colorIndex: number;
       if (isDefaultColor) {
         colorIndex = (bold && terminal.options.enableBold ? 1 : 0);
@@ -275,6 +276,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
           y * this._scaledCellHeight + this._scaledCharTop,
           charAtlasCellWidth,
           this._scaledCharHeight);
+      this._ctx.restore();
     } else {
       this._drawUncachedChar(terminal, char, width, fg + (drawInBrightColor ? 8 : 0), x, y, bold && terminal.options.enableBold, dim, italic);
     }


### PR DESCRIPTION
Drawing dim colors sets the globalAlpha to 0.5, so we need to
save/restore the ctx state. Otherwise, every time we draw some dim
content, our display will get progressively dimmer.

I tested this by running `echo '\u001b[2mfoo'` a few times in zsh.

Fixes #1424