### PR TITLE
Fix tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/chai": "^3.4.34",
     "@types/jsdom": "^11.0.1",
     "@types/mocha": "^2.2.33",
-    "@types/node": "^6.0.41",
+    "@types/node": "6.0.108",
     "@types/text-encoding": "0.0.32",
     "browserify": "^13.3.0",
     "chai": "3.5.0",


### PR DESCRIPTION
The recent build failures are due to [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/3667b0f7e9808bdf274285ed6c7f7b332080a4b4/types/node/v6) being updated to v6.0.109 and is allowed by the semantic versioning in `package.json`.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25407 introduced the breaking change:

* Type [`Iterable`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3667b0f7e9808bdf274285ed6c7f7b332080a4b4/types/node/v6/index.d.ts#L1974) was introduced
* Type [`Iterator`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3667b0f7e9808bdf274285ed6c7f7b332080a4b4/types/node/v6/index.d.ts#L1978) was introduced
* The well-known [`Symbol.iterator`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Iteration_protocols) was used for the first time

It's unclear to me whether this is a bug because, according to docs when targeting es5 and using es6 builtins, tsc should have been throwing errors. Although the es6 features that are being used worked fine with `@types/node` v6.0.108 and backward to the minimum version in xterm.js/package.json.

The author of the aforementioned PR is asked about type `Iterator` in a review and it's explained that the type was copied from `@types/node` v7. The PR was merged but perhaps they should've used type `IterableIterator`???

Anyways, maybe somebody with more TS knowledge will get some useful pointers from this PR.