### PR TITLE
Fix link cursor CSS

### DIFF
--- a/src/xterm.css
+++ b/src/xterm.css
@@ -135,6 +135,10 @@
     cursor: text;
 }
 
+.xterm.xterm-cursor-pointer {
+    cursor: pointer !important;
+}
+
 .xterm .xterm-accessibility,
 .xterm .xterm-message {
     position: absolute;
@@ -152,8 +156,4 @@
     width: 1px;
     height: 1px;
     overflow: hidden;
-}
-
-.xterm-cursor-pointer {
-    cursor: pointer;
 }

--- a/src/xterm.css
+++ b/src/xterm.css
@@ -126,17 +126,17 @@
     line-height: normal;
 }
 
+.xterm {
+    cursor: text;
+}
+
 .xterm.enable-mouse-events {
     /* When mouse events are enabled (eg. tmux), revert to the standard pointer cursor */
     cursor: default;
 }
 
-.xterm:not(.enable-mouse-events) {
-    cursor: text;
-}
-
 .xterm.xterm-cursor-pointer {
-    cursor: pointer !important;
+    cursor: pointer;
 }
 
 .xterm .xterm-accessibility,


### PR DESCRIPTION
Ensure pointer overrides the default mouse events mode cursor.

Fixes #1437