### PR TITLE
Remove inner setTimeout(), prevents high CPU usage.

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1324,7 +1324,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     }
     if (this.writeBuffer.length > 0) {
       // Allow renderer to catch up before processing the next batch
-      setTimeout(() => this._innerWrite(), 0);
+      this._innerWrite();
     } else {
       this._writeInProgress = false;
     }

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1290,7 +1290,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
       // Kick off a write which will write all data in sequence recursively
       this._writeInProgress = true;
       // Kick off an async innerWrite so more writes can come in while processing data
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         this._innerWrite();
       });
     }


### PR DESCRIPTION
It appears that the recursive timeout was leaking memory and causing
high CPU usage. Prior to this change running top (via xterm) showed the
CPU usage for the WebKitProcess around 30-50%. Afterwards CPU usage is
between 5-20% and rendering is much faster visually which is
particularly useful for ncurses applications.

All tests continue to pass.