### PR TITLE
Suppress Safari promise rejections.

### DIFF
--- a/src/shared/atlas/CharAtlasGenerator.ts
+++ b/src/shared/atlas/CharAtlasGenerator.ts
@@ -6,7 +6,7 @@
 import { FontWeight } from 'xterm';
 import { CHAR_ATLAS_CELL_SPACING, ICharAtlasConfig } from './Types';
 import { IColor } from '../Types';
-import { isFirefox } from '../utils/Browser';
+import { isFirefox, isSafari } from '../utils/Browser';
 
 declare const Promise: any;
 
@@ -99,7 +99,7 @@ export function generateStaticCharAtlasTexture(context: Window, canvasFactory: (
   // if support is lacking as drawImage works there too. Firefox is also
   // included here as ImageBitmap appears both buggy and has horrible
   // performance (tested on v55).
-  if (!('createImageBitmap' in context) || isFirefox) {
+  if (!('createImageBitmap' in context) || isFirefox || isSafari) {
     // Don't attempt to clear background colors if createImageBitmap is not supported
     if (canvas instanceof HTMLCanvasElement) {
       // Just return the HTMLCanvas if it's a HTMLCanvasElement

--- a/src/shared/utils/Browser.ts
+++ b/src/shared/utils/Browser.ts
@@ -8,6 +8,7 @@ const userAgent = (isNode) ? 'node' : navigator.userAgent;
 const platform = (isNode) ? 'node' : navigator.platform;
 
 export const isFirefox = !!~userAgent.indexOf('Firefox');
+export const isSafari = !!~userAgent.indexOf('Safari');
 export const isMSIE = !!~userAgent.indexOf('MSIE') || !!~userAgent.indexOf('Trident');
 
 // Find the users platform. We use this to interpret the meta key

--- a/src/shared/utils/Browser.ts
+++ b/src/shared/utils/Browser.ts
@@ -8,7 +8,7 @@ const userAgent = (isNode) ? 'node' : navigator.userAgent;
 const platform = (isNode) ? 'node' : navigator.platform;
 
 export const isFirefox = !!~userAgent.indexOf('Firefox');
-export const isSafari = !!~userAgent.indexOf('Safari');
+export const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent);
 export const isMSIE = !!~userAgent.indexOf('MSIE') || !!~userAgent.indexOf('Trident');
 
 // Find the users platform. We use this to interpret the meta key


### PR DESCRIPTION
Currently Webkit implements createImageBitmap() but returns a promise
rejection.

Note that once Webkit implements createImageBitmap() correctly these
changes should be removed.