### PR TITLE
Fix Demo String Options

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -218,7 +218,7 @@ function initOptions(term) {
       term.setOption(o, input.checked);
     });
   });
-  numberOptions.concat(Object.keys(stringOptions)).forEach(o => {
+  numberOptions.forEach(o => {
     var input = document.getElementById(`opt-${o}`);
     input.addEventListener('change', () => {
       console.log('change', o, input.value);
@@ -227,6 +227,13 @@ function initOptions(term) {
       } else {
         term.setOption(o, parseInt(input.value, 10));
       }
+    });
+  });
+  Object.keys(stringOptions).forEach(o => {
+    var input = document.getElementById(`opt-${o}`);
+    input.addEventListener('change', () => {
+      console.log('change', o, input.value);
+      term.setOption(o, input.value);
     });
   });
 }


### PR DESCRIPTION
Fix Demo String Options

Because the number options were bundled with the string options, this was happening 

![image](https://user-images.githubusercontent.com/16099035/40890068-25c3d3f2-6768-11e8-97d4-de48aa63ba17.png)
