### PR TITLE
Fix copyright line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,6 @@ To contribute either code, documentation or issues to xterm.js please read the [
 
 If you contribute code to this project, you are implicitly allowing your code to be distributed under the MIT license. You are also implicitly verifying that all code is your original work.
 
-Copyright (c) 2017-2018, [The xterm.js authors](https://github.com/xtermjs/xterm.js/graphs/contributors) (MIT License)
-Copyright (c) 2014-2017, SourceLair, Private Company ([www.sourcelair.com](https://www.sourcelair.com/home)) (MIT License)
+Copyright (c) 2017-2018, [The xterm.js authors](https://github.com/xtermjs/xterm.js/graphs/contributors) (MIT License)<br>
+Copyright (c) 2014-2017, SourceLair, Private Company ([www.sourcelair.com](https://www.sourcelair.com/home)) (MIT License)<br>
 Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)


### PR DESCRIPTION
Before when viewed on github.com:

<img width="1052" alt="screen shot 2018-06-07 at 9 22 30 am" src="https://user-images.githubusercontent.com/2193314/41084390-54bcf458-6a34-11e8-9dc5-bb6b95b2e664.png">
