### PR TITLE
Testbed: text attribute atlas & buffer redesign thoughts

### DIFF
--- a/src/AttributeAtlas.ts
+++ b/src/AttributeAtlas.ts
@@ -1,0 +1,92 @@
+interface ITextAttributes {
+  flags: number;
+  foreground: number;
+  background: number;
+}
+
+export const enum AtlasEntry {
+  FLAGS = 1,
+  FOREGROUND = 2,
+  BACKGROUND = 3
+}
+
+export class TextAttributeAtlas {
+  /** data storage */
+  public data: Uint32Array;
+  constructor(size: number) {
+    this.data = new Uint32Array(size * 4);
+  }
+  private _setData(idx: number, attributes: ITextAttributes): void {
+    this.data[idx] = 0;
+    this.data[idx + AtlasEntry.FLAGS] = attributes.flags;
+    this.data[idx + AtlasEntry.FOREGROUND] = attributes.foreground;
+    this.data[idx + AtlasEntry.BACKGROUND] = attributes.background;
+  }
+
+  /**
+   * convenient method to inspect attributes at slot `idx`.
+   * For better performance atlas idx and AtlasEntry
+   * should be used directly to avoid number conversions.
+   * @param {number} idx
+   * @return {ITextAttributes}
+   */
+  getAttributes(idx: number): ITextAttributes {
+    return {
+      flags: this.data[idx + AtlasEntry.FLAGS],
+      foreground: this.data[idx + AtlasEntry.FOREGROUND],
+      background: this.data[idx + AtlasEntry.BACKGROUND]
+    };
+  }
+
+  /**
+   * Returns a slot index in the atlas for the given text attributes.
+   * To be called upon attributes changes, e.g. by SGR.
+   * NOTE: The ref counter is set to 0 for a new slot index, thus
+   * values will get overwritten if not referenced in between.
+   * @param {ITextAttributes} attributes
+   * @return {number}
+   */
+  getSlot(attributes: ITextAttributes): number {
+    // find equal slot or free
+    for (let i = 0; i < this.data.length; i += 4) {
+      if (!this.data[i]) {
+        this._setData(i, attributes);
+        return i;
+      }
+      if (
+          this.data[i + AtlasEntry.FLAGS] === attributes.flags
+          && this.data[i + AtlasEntry.FOREGROUND] === attributes.foreground
+          && this.data[i + AtlasEntry.BACKGROUND] === attributes.background
+      ) {
+          return i;
+      }
+    }
+    // could not find a valid slot --> resize storage
+    const data = new Uint32Array(this.data.length * 2);
+    for (let i = 0; i < this.data.length; ++i) data[i] = this.data[i];
+    const idx = this.data.length;
+    this.data = data;
+    this._setData(idx, attributes);
+    return idx;
+  }
+
+  /**
+   * Increment ref counter.
+   * To be called for every terminal cell, that holds `idx` as text attributes.
+   * @param {number} idx
+   */
+  ref(idx: number): void {
+    this.data[idx]++;
+  }
+
+  /**
+   * Decrement ref counter. Once dropped to 0 the slot will be reused.
+   * To be called for every cell that gets removed or reused with another value.
+   * @param {number} idx
+   */
+  unref(idx: number): void {
+    this.data[idx]--;
+    if (this.data[idx] < 0)
+    this.data[idx] = 0;
+  }
+}

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -117,10 +117,11 @@ export class Buffer implements IBuffer {
     if (this.lines.length > 0) {
       // Deal with columns increasing (we don't do anything when columns reduce)
       if (this._terminal.cols < newCols) {
-        const ch: CharData = [DEFAULT_ATTR, ' ', 1, 32]; // does xterm use the default attr?
+        const ch: CharData = [this._terminal.attributeAtlas.getSlot({flags: DEFAULT_ATTR, foreground: 0, background: 0}), ' ', 1, 32]; // does xterm use the default attr?
         for (let i = 0; i < this.lines.length; i++) {
           while (this.lines.get(i).length < newCols) {
             this.lines.get(i).push(ch);
+            this._terminal.attributeAtlas.ref(ch[0]);
           }
         }
       }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -7,6 +7,7 @@ import { Terminal as PublicTerminal, ITerminalOptions as IPublicTerminalOptions,
 import { IColorSet, IRenderer } from './renderer/Types';
 import { IMouseZoneManager } from './input/Types';
 import { ICharset } from './core/Types';
+import { TextAttributeAtlas } from './AttributeAtlas';
 
 export type CustomKeyEventHandler = (event: KeyboardEvent) => boolean;
 
@@ -229,6 +230,7 @@ export interface ITerminal extends PublicTerminal, IElementAccessor, IBufferAcce
   log(text: string): void;
   showCursor(): void;
   blankLine(cur?: boolean, isWrapped?: boolean, cols?: number): LineData;
+  attributeAtlas: TextAttributeAtlas;
 }
 
 export interface IBufferAccessor {

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -9,6 +9,7 @@ import { CharData, ITerminal } from '../Types';
 import { INVERTED_DEFAULT_COLOR } from './atlas/Types';
 import { GridCache } from './GridCache';
 import { BaseRenderLayer } from './BaseRenderLayer';
+import { AtlasEntry } from '../AttributeAtlas';
 
 /**
  * This CharData looks like a null character, which will forc a clear and render
@@ -70,7 +71,8 @@ export class TextRenderLayer extends BaseRenderLayer {
         const charData = line[x];
         const code: number = <number>charData[CHAR_DATA_CODE_INDEX];
         const char: string = charData[CHAR_DATA_CHAR_INDEX];
-        const attr: number = charData[CHAR_DATA_ATTR_INDEX];
+        let attr: number = charData[CHAR_DATA_ATTR_INDEX];
+        attr = terminal.attributeAtlas.data[attr + AtlasEntry.FLAGS];
         let width: number = charData[CHAR_DATA_WIDTH_INDEX];
 
         // The character to the left is a wide character, drawing is owned by


### PR DESCRIPTION
This is just a testbed, do not merge. It adds some thoughts and implementation ideas to the discussion from this issue #791.

The PR illustrates the usage of a ref counting text attribute atlas. The code works, but is not well integrated in the codebase, I simply extended the obvious code parts with the needed ref handling and slot indirection. Also not all refs are released atm, this would need a tight integration with `Buffer` and `CircularList` to catch all derefs. And the atlas will need some index lookup magic to avoid searching in O(n) through existing slot entries (though not an issue in the tests, taken slots were always < 64).

So what is this good for? It shows a way to save memory by using indexed SGR attributes instead of holding them at every single cell, which will come handy once we support true color. It might also be a small step into a new buffer layout. Real memory usage is a tough topic with JS due to the dynamic way the engines act, I try a rough estimation:

- memory usage with current buffer layout with true color per cell
  ```
  CharData = [
    number (attr),
    string (content),
    number (wcwidth),
    number (charCode),
    number (foreground),  // needed for true color
    number (background)   // needed for true color
  ];
  ```
  this is roughly: 4 + 8 + 4 + 4 + 4 + 4 = 28 bytes, for 10000 lines à 100 cells it is ~28 MB of data, real usage is much bigger due to the JS objects and the way the engine decides how to store the primitives in the JS array (can be pointered, which will add 8 bytes per data point --> ~76 MB).
- with text attribute atlas per cell
  ```
  CharData = [
    number (index to attr slot),
    string (content),
    number (wcwidth),
    number (charCode)
  ];
  AtlasSlot = [
    uint32 (ref counter),
    uint32 (attr),
    uint32 (foreground),
    uint32 (background)
  ];
  ```
  which is 4 + 8 + 4 + 4 = 20 bytes per cell + the atlas size, for 10000 lines à 100 cells it is ~20 MB of data (or ~52 MB pointered) plus the atlas size. Atlas size is hard to determine, for my benchmark with `ls -lR /usr/lib` it was only ~800 bytes, worst case is 10000 * 100 * 4 * 4 = 16 MB, which is slightly worse than the direct approach (expected since an atlas cant play its advantages if all cells differ). Runtime is not much affected, the atlas indirections, lookups and management takes less than 0.1% runtime.

What do the calculations/tests show?
- we have no control/clue about the real mem usage due to the dynamics of JS objects
- adding data entries to the cell buffer directly is a bad idea, it adds much more than the actual data size, total mem consumption grows linearly on a bigger scale
- an attribute atlas can help to keep this low by reusing them
- almost no runtime penalty for the indirections

Imho the points have implications on a possible buffer redesign. The buffer contains two orthogonal data parts atm, that are changed independently:
- content related: the actual string, wcwidth and the charCode for the renderer atlas, set in `InputHandler.print`
- SGR attributes: only the flags number atm (to be extended with true color foreground and background), changed in `InputHandler.charAttributes` terminal wide and applied to a cell at different occations (most in `InputHandler.print` as well)

To really save memory at this point I would propose a step by step redesign of the cell buffer:
1. build a separate ref counting cell content storage to hold string data, wcwidth and charCode, maybe TypedArray based to avoid JS objects overhead
2. refine the attribute atlas with better integration
3. change `CharData` to `[number (attr pointer), number (content pointer)]`
4. change `CircularList` and `Buffer` to operate on a preallocated TypedArray

Also the steps 1. and 4. are likely to give a better runtime performance by avoiding unnecessary object creations and GC runs (GC is at 20% runtime atm).