### PR TITLE
#1532: 'Reset to Initial State' (RIS) escape sequence no longer makes the cursor disappear

### DIFF
--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -125,6 +125,9 @@ describe('term.js addons', () => {
       term.cursorState = 1;
       term.reset();
       assert.equal(term.cursorState, 1);
+      term.cursorState = 0;
+      term.reset();
+      assert.equal(term.cursorState, 0);
     });
   });
 

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -120,6 +120,14 @@ describe('term.js addons', () => {
     });
   });
 
+  describe('reset', () => {
+    it('should not affect cursorState', () => {
+      term.cursorState = 1;
+      term.reset();
+      assert.equal(term.cursorState, 1);
+    });
+  });
+
   describe('clear', () => {
     it('should clear a buffer equal to rows', () => {
       const promptLine = term.buffer.lines.get(term.buffer.ybase + term.buffer.y);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1830,9 +1830,11 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     this.options.cols = this.cols;
     const customKeyEventHandler = this._customKeyEventHandler;
     const inputHandler = this._inputHandler;
+    const cursorState = this.cursorState;
     this._setup();
     this._customKeyEventHandler = customKeyEventHandler;
     this._inputHandler = inputHandler;
+    this.cursorState = cursorState;
     this.refresh(0, this.rows - 1);
     if (this.viewport) {
       this.viewport.syncScrollArea();


### PR DESCRIPTION
**Following issue [#1532](https://github.com/xtermjs/xterm.js/issues/1532)**

Here is the list of the modification I've made:
- saved cursorState attribute before the reset then restored it after
- added test case to ensure the value was not changed by the terminal reset
