### PR TITLE
refreshRowElements argument order was flipped

### DIFF
--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -52,7 +52,7 @@ export class DomRenderer extends EventEmitter implements IRenderer {
     this._rowContainer.classList.add(ROW_CONTAINER_CLASS);
     this._rowContainer.style.lineHeight = 'normal';
     this._rowContainer.setAttribute('aria-hidden', 'true');
-    this._refreshRowElements(this._terminal.rows, this._terminal.cols);
+    this._refreshRowElements(this._terminal.cols, this._terminal.rows);
     this._selectionContainer = document.createElement('div');
     this._selectionContainer.classList.add(SELECTION_CLASS);
     this._selectionContainer.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
This is potentially a fix for #1573 but I have not tested.