### PR TITLE
Prototype of iTerm2 like image display

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -4,6 +4,7 @@ import * as fit from '../build/addons/fit/fit';
 import * as fullscreen from '../build/addons/fullscreen/fullscreen';
 import * as search from '../build/addons/search/search';
 import * as webLinks from '../build/addons/webLinks/webLinks';
+import * as imageLinks from '../build/addons/imageLinks/imageLinks';
 import * as winptyCompat from '../build/addons/winptyCompat/winptyCompat';
 
 
@@ -12,6 +13,7 @@ Terminal.applyAddon(fit);
 Terminal.applyAddon(fullscreen);
 Terminal.applyAddon(search);
 Terminal.applyAddon(webLinks);
+Terminal.applyAddon(imageLinks);
 Terminal.applyAddon(winptyCompat);
 
 
@@ -75,6 +77,7 @@ function createTerminal() {
   term.open(terminalContainer);
   term.winptyCompatInit();
   term.webLinksInit();
+  term.imageLinksInit();
   term.fit();
   term.focus();
 

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "mocha": "gulp test",
     "build:docs": "jsdoc -c jsdoc.json",
     "tsc": "tsc",
-    "prebuild": "concurrently --kill-others-on-fail --names \"lib,attach,fit,fullscreen,search,terminado,webLinks,winptyCompat,zmodem,css\" \"tsc\" \"tsc -p ./src/addons/attach\" \"tsc -p ./src/addons/fit\" \"tsc -p ./src/addons/fullscreen\" \"tsc -p ./src/addons/search\" \"tsc -p ./src/addons/terminado\" \"tsc -p ./src/addons/webLinks\" \"tsc -p ./src/addons/winptyCompat\" \"tsc -p ./src/addons/zmodem\" \"gulp css\"",
+    "prebuild": "concurrently --kill-others-on-fail --names \"lib,attach,fit,fullscreen,search,terminado,webLinks,imageLinks,winptyCompat,zmodem,css\" \"tsc\" \"tsc -p ./src/addons/attach\" \"tsc -p ./src/addons/fit\" \"tsc -p ./src/addons/fullscreen\" \"tsc -p ./src/addons/search\" \"tsc -p ./src/addons/terminado\" \"tsc -p ./src/addons/webLinks\" \"tsc -p ./src/addons/imageLinks\" \"tsc -p ./src/addons/winptyCompat\" \"tsc -p ./src/addons/zmodem\" \"gulp css\"",
     "build": "gulp build",
     "prepublish": "npm run build",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "webpack": "gulp webpack",
-    "watch": "concurrently --kill-others-on-fail --names \"lib,attach,fit,fullscreen,search,terminado,webLinks,winptyCompat,zmodem,css\" \"tsc -w\" \"tsc -w -p ./src/addons/attach\" \"tsc -w -p ./src/addons/fit\" \"tsc -w -p ./src/addons/fullscreen\" \"tsc -w -p ./src/addons/search\" \"tsc -w -p ./src/addons/terminado\" \"tsc -w -p ./src/addons/webLinks\" \"tsc -w -p ./src/addons/winptyCompat\" \"tsc -w -p ./src/addons/zmodem\" \"gulp watch-css\""
+    "watch": "concurrently --kill-others-on-fail --names \"lib,attach,fit,fullscreen,search,terminado,webLinks,imageLinks,winptyCompat,zmodem,css\" \"tsc -w\" \"tsc -w -p ./src/addons/attach\" \"tsc -w -p ./src/addons/fit\" \"tsc -w -p ./src/addons/fullscreen\" \"tsc -w -p ./src/addons/search\" \"tsc -w -p ./src/addons/terminado\" \"tsc -w -p ./src/addons/webLinks\" \"tsc -p ./src/addons/imageLinks\" \"tsc -w -p ./src/addons/winptyCompat\" \"tsc -w -p ./src/addons/zmodem\" \"gulp watch-css\""
   }
 }

--- a/src/Base64Image.ts
+++ b/src/Base64Image.ts
@@ -1,0 +1,223 @@
+import {IRenderDimensions} from './renderer/Types'
+import { IRenderable } from './Types';
+export interface StringMap { [s: string]: string; }
+
+export class Base64Image {
+  imageBase64: string
+  width: number
+  height: number
+  format: string
+  valid: boolean
+  attrs: StringMap
+
+  constructor(data:string) 
+  {
+    // replace all whitespace in data
+    let data_ = data.replace(/\s/g,'')
+    
+    // split into attributes/encodedImage
+    if (data_.indexOf(":") == -1) {
+      this.valid = false
+      return
+    }
+    let [attrStr, imageBase64] = data_.split(":", 2)
+    this.imageBase64 = imageBase64
+
+    // get the image format
+    this.format = this.imageFormat(this.imageBase64)
+    if (!this.format) {
+      this.valid = false
+      return
+    }
+
+    this.attrs = this.parseAttrs(attrStr)
+
+    // determine image size
+    let size = null;
+    if (this.format == "png") {
+      size = this.pngSize(atob(this.imageBase64))
+    } else if (this.format == "jpeg") {
+      size = this.jpegSize(atob(this.imageBase64))
+    }
+
+    if (!size) {
+      this.valid = false
+      return
+    }
+    this.width = size[0]
+    this.height = size[1]
+    this.valid = true
+  }
+
+  public dataUrl():string 
+  {
+    return "data:image/" + this.format + ";base64," + this.imageBase64
+  } 
+
+  public calculateDimensions(dimensions:IRenderDimensions): [number, number, number, number]
+  {
+    let width = this.getDimension(this.attrs['width'], 
+                        this.width,
+                        dimensions.scaledCellWidth, 
+                        dimensions.scaledCanvasWidth)
+    
+    let height = this.getDimension(this.attrs['height'], 
+                        this.height,
+                        dimensions.scaledCellHeight, 
+                        dimensions.scaledCanvasHeight - (dimensions.scaledCellHeight*2))
+
+    if (this.attrs['preserveAspectRatio'] !== "0") {
+      let scaleW = width/this.width
+      let scaleH = height/this.height
+
+      if (scaleW < scaleH) {
+        height = Math.ceil(this.height*scaleW)
+      } else {
+        width = Math.ceil(this.width*scaleH)
+      }
+    }
+
+    let nrows = Math.ceil(height/dimensions.scaledCellHeight)
+    let ncols = Math.ceil(width/dimensions.scaledCellWidth)
+
+    return [width, height, nrows, ncols]
+  }
+
+  public getImageData(img: HTMLImageElement, 
+                     width:number, 
+                     height:number, 
+                     nrows:number, 
+                     ncols:number, 
+                     dimensions:IRenderDimensions) : ImageData[][]
+  {
+    let cellWidth = dimensions.scaledCellWidth
+    let cellHeight = dimensions.scaledCellHeight
+
+    // create a canvas that fits the grid
+    let canvasWidth = ncols*cellWidth
+    let canvasHeight = nrows*cellHeight
+
+    let offscreenCanvas = document.createElement('canvas')
+    offscreenCanvas.width = canvasWidth
+    offscreenCanvas.height = canvasHeight
+
+    let context = offscreenCanvas.getContext('2d')
+    context.drawImage(img,0,0,width,height)
+
+    // slice the image in a grid of nrows * ncols
+    var res : ImageData[][] = []
+    for(var i=0; i < nrows; i++) {
+      res[i] = []
+      for(var j=0; j < ncols; j++) {
+        res[i][j] = context.getImageData(j*cellWidth, i*cellHeight, cellWidth, cellHeight)
+      }
+    }
+
+    return res
+  }
+
+  private getDimension(attr:string, imgDim:number, unit:number, total:number) : number
+  {
+    var res:number = NaN
+    if (attr.slice(-1) == '%') {
+      res = Math.floor((parseFloat(attr.slice(0, -1))/100) * total)
+    } else if (attr.slice(-2) == 'px') {
+      res = parseInt(attr.slice(0, -2))
+    } else if (attr != "auto") {
+      res = parseInt(attr) * unit
+    }
+    return !isNaN(res) ? res : Math.min(imgDim, total)
+  }
+
+  private imageFormat(base64Encoded:string) : string | null {
+    switch (base64Encoded.substr(0, 6)) {
+      case "/9j/4A": return "jpeg"
+      case "iVBORw": return "png"
+      default: return null
+    }
+  }
+
+  private parseAttrs(attrStr:string): StringMap {
+    if (attrStr.lastIndexOf("File=", 0) !== 0) return {}
+    attrStr = attrStr.substr("File=".length)
+    // parse key=value; pairs
+    var attrs : StringMap = {}
+    attrStr.split(";").forEach(el => {
+      if (el.lastIndexOf("=") !== -1) {
+        let [k,v] = el.split("=")
+        attrs[k] = v
+      }
+    });
+
+    attrs['name'] = attrs['name'] || 'Unnamed file'
+    attrs['width'] = attrs['width'] || 'auto'
+    attrs['height'] = attrs['height'] || 'auto'
+    attrs['preserveAspectRatio'] = attrs['preserveAspectRatio'] || '1'
+    attrs['inline'] = attrs['inline'] || '0'
+    
+    return attrs
+  }
+
+    // https://stackoverflow.com/a/1532798
+  private pngSize(data: string) : [number, number] {
+    return [toInt32(data.slice(16, 20)),
+            toInt32(data.slice(20, 24))]
+  }
+
+  private jpegSize(data:string) : [number, number] | null {
+    // https://stackoverflow.com/questions/2517854/getting-image-size-of-jpeg-from-its-binary/48488655#48488655
+    var off = 0;
+    
+    while(off<data.length) {
+      while(data.charCodeAt(off)==0xff) off++;
+      var mrkr = data.charCodeAt(off);  off++;
+  
+      if(mrkr==0xd8) continue;    // SOI
+      if(mrkr==0xd9) break;       // EOI
+      if(0xd0<=mrkr && mrkr<=0xd7) continue;
+      if(mrkr==0x01) continue;    // TEM
+  
+      var len = ((data.charCodeAt(off)<<8)|data.charCodeAt(off+1))-2;  off+=2;  
+  
+      if(mrkr==0xc0) {
+        let width = (data.charCodeAt(off+3)<<8)|data.charCodeAt(off+4)
+        let height = (data.charCodeAt(off+1)<<8)|data.charCodeAt(off+2)
+        return [width, height]
+      }
+      off+=len;
+    }
+    return null
+  }
+  
+}
+
+export class ImageCell implements IRenderable {
+  imageData: ImageData
+  _dataUrl: string
+
+  constructor(imageData: ImageData, dataUrl: string) {
+    this._dataUrl = dataUrl
+    this.imageData = imageData
+  }
+
+  public dataUrl() {
+    return this._dataUrl;
+  }
+
+  public drawBackground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void 
+  {
+    ctx.putImageData(this.imageData, x*scaledCellWidth, y*scaledCellHeight)
+  }
+
+  public drawForeground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void {}
+  
+}
+
+// https://stackoverflow.com/questions/47637340/base64-binary-decode-32-bit-array
+function toInt32(input: string) {
+  var view = new DataView(new ArrayBuffer(4))
+  for (var i = 0; i < 4; i++) {
+    view.setUint8(i, input.charCodeAt(i));
+  }
+  return view.getInt32(0);
+}

--- a/src/Base64Image.ts
+++ b/src/Base64Image.ts
@@ -1,222 +1,220 @@
-import {IRenderDimensions} from './renderer/Types'
+import { IRenderDimensions } from './renderer/Types';
 import { IRenderable } from './Types';
-export interface StringMap { [s: string]: string; }
 
 export class Base64Image {
-  imageBase64: string
-  width: number
-  height: number
-  format: string
-  valid: boolean
-  attrs: StringMap
+  imageBase64: string;
+  width: number;
+  height: number;
+  format: string;
+  valid: boolean;
+  attrs: { [s: string]: string; };
 
-  constructor(data:string) 
-  {
+  constructor(data: string) {
     // replace all whitespace in data
-    let data_ = data.replace(/\s/g,'')
-    
+    const data1 = data.replace(/\s/g, '');
+
     // split into attributes/encodedImage
-    if (data_.indexOf(":") == -1) {
-      this.valid = false
-      return
+    if (data1.indexOf(':') === -1) {
+      this.valid = false;
+      return;
     }
-    let [attrStr, imageBase64] = data_.split(":", 2)
-    this.imageBase64 = imageBase64
+    const [attrStr, imageBase64] = data1.split(':', 2);
+    this.imageBase64 = imageBase64;
 
     // get the image format
-    this.format = this.imageFormat(this.imageBase64)
+    this.format = this._imageFormat(this.imageBase64);
     if (!this.format) {
-      this.valid = false
-      return
+      this.valid = false;
+      return;
     }
 
-    this.attrs = this.parseAttrs(attrStr)
+    this.attrs = this._parseAttrs(attrStr);
 
     // determine image size
     let size = null;
-    if (this.format == "png") {
-      size = this.pngSize(atob(this.imageBase64))
-    } else if (this.format == "jpeg") {
-      size = this.jpegSize(atob(this.imageBase64))
+    if (this.format === 'png') {
+      size = this._pngSize(atob(this.imageBase64));
+    } else if (this.format === 'jpeg') {
+      size = this._jpegSize(atob(this.imageBase64));
     }
 
     if (!size) {
-      this.valid = false
-      return
+      this.valid = false;
+      return;
     }
-    this.width = size[0]
-    this.height = size[1]
-    this.valid = true
+    this.width = size[0];
+    this.height = size[1];
+    this.valid = true;
   }
 
-  public dataUrl():string 
+  public dataUrl(): string
   {
-    return "data:image/" + this.format + ";base64," + this.imageBase64
-  } 
+    return 'data:image/' + this.format + ';base64,' + this.imageBase64;
+  }
 
-  public calculateDimensions(dimensions:IRenderDimensions): [number, number, number, number]
+  public calculateDimensions(dimensions: IRenderDimensions): [number, number, number, number]
   {
-    let width = this.getDimension(this.attrs['width'], 
+    let width = this._getDimension(this.attrs['width'],
                         this.width,
-                        dimensions.scaledCellWidth, 
-                        dimensions.scaledCanvasWidth)
-    
-    let height = this.getDimension(this.attrs['height'], 
-                        this.height,
-                        dimensions.scaledCellHeight, 
-                        dimensions.scaledCanvasHeight - (dimensions.scaledCellHeight*2))
+                        dimensions.scaledCellWidth,
+                        dimensions.scaledCanvasWidth);
 
-    if (this.attrs['preserveAspectRatio'] !== "0") {
-      let scaleW = width/this.width
-      let scaleH = height/this.height
+    let height = this._getDimension(this.attrs['height'],
+                        this.height,
+                        dimensions.scaledCellHeight,
+                        dimensions.scaledCanvasHeight - (dimensions.scaledCellHeight * 2));
+
+    if (this.attrs['preserveAspectRatio'] !== '0') {
+      const scaleW = width / this.width;
+      const scaleH = height / this.height;
 
       if (scaleW < scaleH) {
-        height = Math.ceil(this.height*scaleW)
+        height = Math.ceil(this.height * scaleW);
       } else {
-        width = Math.ceil(this.width*scaleH)
+        width = Math.ceil(this.width * scaleH);
       }
     }
 
-    let nrows = Math.ceil(height/dimensions.scaledCellHeight)
-    let ncols = Math.ceil(width/dimensions.scaledCellWidth)
+    const nrows = Math.ceil(height / dimensions.scaledCellHeight);
+    const ncols = Math.ceil(width / dimensions.scaledCellWidth);
 
-    return [width, height, nrows, ncols]
+    return [width, height, nrows, ncols];
   }
 
-  public getImageData(img: HTMLImageElement, 
-                     width:number, 
-                     height:number, 
-                     nrows:number, 
-                     ncols:number, 
-                     dimensions:IRenderDimensions) : ImageData[][]
+  public getImageData(img: HTMLImageElement,
+                     width: number,
+                     height: number,
+                     nrows: number,
+                     ncols: number,
+                     dimensions: IRenderDimensions): ImageData[][]
   {
-    let cellWidth = dimensions.scaledCellWidth
-    let cellHeight = dimensions.scaledCellHeight
+    const cellWidth = dimensions.scaledCellWidth;
+    const cellHeight = dimensions.scaledCellHeight;
 
     // create a canvas that fits the grid
-    let canvasWidth = ncols*cellWidth
-    let canvasHeight = nrows*cellHeight
+    const canvasWidth = ncols * cellWidth;
+    const canvasHeight = nrows * cellHeight;
 
-    let offscreenCanvas = document.createElement('canvas')
-    offscreenCanvas.width = canvasWidth
-    offscreenCanvas.height = canvasHeight
+    const offscreenCanvas = document.createElement('canvas');
+    offscreenCanvas.width = canvasWidth;
+    offscreenCanvas.height = canvasHeight;
 
-    let context = offscreenCanvas.getContext('2d')
-    context.drawImage(img,0,0,width,height)
+    const context = offscreenCanvas.getContext('2d');
+    context.drawImage(img, 0, 0, width, height);
 
     // slice the image in a grid of nrows * ncols
-    var res : ImageData[][] = []
-    for(var i=0; i < nrows; i++) {
-      res[i] = []
-      for(var j=0; j < ncols; j++) {
-        res[i][j] = context.getImageData(j*cellWidth, i*cellHeight, cellWidth, cellHeight)
+    const res: ImageData[][] = [];
+    for (let i = 0; i < nrows; i++) {
+      res[i] = [];
+      for (let j = 0; j < ncols; j++) {
+        res[i][j] = context.getImageData(j * cellWidth, i * cellHeight, cellWidth, cellHeight);
       }
     }
 
-    return res
+    return res;
   }
 
-  private getDimension(attr:string, imgDim:number, unit:number, total:number) : number
+  private _getDimension(attr: string, imgDim: number, unit: number, total: number): number
   {
-    var res:number = NaN
-    if (attr.slice(-1) == '%') {
-      res = Math.floor((parseFloat(attr.slice(0, -1))/100) * total)
-    } else if (attr.slice(-2) == 'px') {
-      res = parseInt(attr.slice(0, -2))
-    } else if (attr != "auto") {
-      res = parseInt(attr) * unit
+    let res: number = NaN;
+    if (attr.slice(-1) === '%') {
+      res = Math.floor((parseFloat(attr.slice(0, -1)) / 100) * total);
+    } else if (attr.slice(-2) === 'px') {
+      res = parseInt(attr.slice(0, -2));
+    } else if (attr !== 'auto') {
+      res = parseInt(attr) * unit;
     }
-    return !isNaN(res) ? res : Math.min(imgDim, total)
+    return !isNaN(res) ? res : Math.min(imgDim, total);
   }
 
-  private imageFormat(base64Encoded:string) : string | null {
+  private _imageFormat(base64Encoded: string): string | null {
     switch (base64Encoded.substr(0, 6)) {
-      case "/9j/4A": return "jpeg"
-      case "iVBORw": return "png"
-      default: return null
+      case '/9j/4A': return 'jpeg';
+      case 'iVBORw': return 'png';
+      default: return null;
     }
   }
 
-  private parseAttrs(attrStr:string): StringMap {
-    if (attrStr.lastIndexOf("File=", 0) !== 0) return {}
-    attrStr = attrStr.substr("File=".length)
+  private _parseAttrs(attrStr: string): { [s: string]: string; } {
+    if (attrStr.lastIndexOf('File=', 0) !== 0) return {};
+    attrStr = attrStr.substr('File='.length);
     // parse key=value; pairs
-    var attrs : StringMap = {}
-    attrStr.split(";").forEach(el => {
-      if (el.lastIndexOf("=") !== -1) {
-        let [k,v] = el.split("=")
-        attrs[k] = v
+    const attrs: { [s: string]: string; } = {};
+    attrStr.split(';').forEach(el => {
+      if (el.lastIndexOf('=') !== -1) {
+        const [k, v] = el.split('=');
+        attrs[k] = v;
       }
     });
 
-    attrs['name'] = attrs['name'] || 'Unnamed file'
-    attrs['width'] = attrs['width'] || 'auto'
-    attrs['height'] = attrs['height'] || 'auto'
-    attrs['preserveAspectRatio'] = attrs['preserveAspectRatio'] || '1'
-    attrs['inline'] = attrs['inline'] || '0'
-    
-    return attrs
+    attrs['name'] = attrs['name'] || 'Unnamed file';
+    attrs['width'] = attrs['width'] || 'auto';
+    attrs['height'] = attrs['height'] || 'auto';
+    attrs['preserveAspectRatio'] = attrs['preserveAspectRatio'] || '1';
+    attrs['inline'] = attrs['inline'] || '0';
+
+    return attrs;
   }
 
     // https://stackoverflow.com/a/1532798
-  private pngSize(data: string) : [number, number] {
+  private _pngSize(data: string): [number, number] {
     return [toInt32(data.slice(16, 20)),
-            toInt32(data.slice(20, 24))]
+            toInt32(data.slice(20, 24))];
   }
 
-  private jpegSize(data:string) : [number, number] | null {
+  private _jpegSize(data: string): [number, number] | null {
     // https://stackoverflow.com/questions/2517854/getting-image-size-of-jpeg-from-its-binary/48488655#48488655
-    var off = 0;
-    
-    while(off<data.length) {
-      while(data.charCodeAt(off)==0xff) off++;
-      var mrkr = data.charCodeAt(off);  off++;
-  
-      if(mrkr==0xd8) continue;    // SOI
-      if(mrkr==0xd9) break;       // EOI
-      if(0xd0<=mrkr && mrkr<=0xd7) continue;
-      if(mrkr==0x01) continue;    // TEM
-  
-      var len = ((data.charCodeAt(off)<<8)|data.charCodeAt(off+1))-2;  off+=2;  
-  
-      if(mrkr==0xc0) {
-        let width = (data.charCodeAt(off+3)<<8)|data.charCodeAt(off+4)
-        let height = (data.charCodeAt(off+1)<<8)|data.charCodeAt(off+2)
-        return [width, height]
+    let off = 0;
+
+    while (off < data.length) {
+      while (data.charCodeAt(off) === 0xff) off++;
+      const mrkr = data.charCodeAt(off);  off++;
+
+      if (mrkr === 0xd8) continue;    // SOI
+      if (mrkr === 0xd9) break;       // EOI
+      if (0xd0 <= mrkr && mrkr <= 0xd7) continue;
+      if (mrkr === 0x01) continue;    // TEM
+
+      const len = ((data.charCodeAt(off) << 8) | data.charCodeAt(off + 1)) - 2;  off += 2;
+
+      if (mrkr === 0xc0) {
+        const width = (data.charCodeAt(off + 3) << 8) | data.charCodeAt(off + 4);
+        const height = (data.charCodeAt(off + 1) << 8) | data.charCodeAt(off + 2);
+        return [width, height];
       }
-      off+=len;
+      off += len;
     }
-    return null
+    return null;
   }
-  
+
 }
 
 export class ImageCell implements IRenderable {
-  imageData: ImageData
-  _dataUrl: string
+  imageData: ImageData;
+  url: string;
 
   constructor(imageData: ImageData, dataUrl: string) {
-    this._dataUrl = dataUrl
-    this.imageData = imageData
+    this.url = dataUrl;
+    this.imageData = imageData;
   }
 
-  public dataUrl() {
-    return this._dataUrl;
+  public dataUrl(): string {
+    return this.url;
   }
 
-  public drawBackground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void 
+  public drawBackground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void
   {
-    ctx.putImageData(this.imageData, x*scaledCellWidth, y*scaledCellHeight)
+    ctx.putImageData(this.imageData, x * scaledCellWidth, y * scaledCellHeight);
   }
 
   public drawForeground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void {}
-  
+
 }
 
 // https://stackoverflow.com/questions/47637340/base64-binary-decode-32-bit-array
-function toInt32(input: string) {
-  var view = new DataView(new ArrayBuffer(4))
-  for (var i = 0; i < 4; i++) {
+function toInt32(input: string): number {
+  const view = new DataView(new ArrayBuffer(4));
+  for (let i = 0; i < 4; i++) {
     view.setUint8(i, input.charCodeAt(i));
   }
   return view.getInt32(0);

--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -273,10 +273,10 @@ describe('Buffer', () => {
   describe ('translateBufferLineToString', () => {
     it('should handle selecting a section of ascii text', () => {
       buffer.lines.set(0, [
-        [ null, 'a', 1, 'a'.charCodeAt(0)],
-        [ null, 'b', 1, 'b'.charCodeAt(0)],
-        [ null, 'c', 1, 'c'.charCodeAt(0)],
-        [ null, 'd', 1, 'd'.charCodeAt(0)]
+        [ null, 'a', 1, 'a'.charCodeAt(0), undefined],
+        [ null, 'b', 1, 'b'.charCodeAt(0), undefined],
+        [ null, 'c', 1, 'c'.charCodeAt(0), undefined],
+        [ null, 'd', 1, 'd'.charCodeAt(0), undefined]
       ]);
 
       const str = buffer.translateBufferLineToString(0, true, 0, 2);
@@ -285,9 +285,9 @@ describe('Buffer', () => {
 
     it('should handle a cut-off double width character by including it', () => {
       buffer.lines.set(0, [
-        [ null, '語', 2, 35486 ],
-        [ null, '', 0, null],
-        [ null, 'a', 1, 'a'.charCodeAt(0)]
+        [ null, '語', 2, 35486, undefined],
+        [ null, '', 0, null, undefined],
+        [ null, 'a', 1, 'a'.charCodeAt(0), undefined]
       ]);
 
       const str1 = buffer.translateBufferLineToString(0, true, 0, 1);
@@ -296,9 +296,9 @@ describe('Buffer', () => {
 
     it('should handle a zero width character in the middle of the string by not including it', () => {
       buffer.lines.set(0, [
-        [ null, '語', 2, '語'.charCodeAt(0) ],
-        [ null, '', 0, null],
-        [ null, 'a', 1, 'a'.charCodeAt(0)]
+        [ null, '語', 2, '語'.charCodeAt(0), undefined ],
+        [ null, '', 0, null, undefined],
+        [ null, 'a', 1, 'a'.charCodeAt(0), undefined]
       ]);
 
       const str0 = buffer.translateBufferLineToString(0, true, 0, 1);
@@ -313,8 +313,8 @@ describe('Buffer', () => {
 
     it('should handle single width emojis', () => {
       buffer.lines.set(0, [
-        [ null, '😁', 1, '😁'.charCodeAt(0) ],
-        [ null, 'a', 1, 'a'.charCodeAt(0)]
+        [ null, '😁', 1, '😁'.charCodeAt(0), undefined],
+        [ null, 'a', 1, 'a'.charCodeAt(0), undefined]
       ]);
 
       const str1 = buffer.translateBufferLineToString(0, true, 0, 1);
@@ -326,8 +326,8 @@ describe('Buffer', () => {
 
     it('should handle double width emojis', () => {
       buffer.lines.set(0, [
-        [ null, '😁', 2, '😁'.charCodeAt(0) ],
-        [ null, '', 0, null]
+        [ null, '😁', 2, '😁'.charCodeAt(0), undefined],
+        [ null, '', 0, null, undefined]
       ]);
 
       const str1 = buffer.translateBufferLineToString(0, true, 0, 1);
@@ -337,9 +337,9 @@ describe('Buffer', () => {
       assert.equal(str2, '😁');
 
       buffer.lines.set(0, [
-        [ null, '😁', 2, '😁'.charCodeAt(0) ],
-        [ null, '', 0, null],
-        [ null, 'a', 1, 'a'.charCodeAt(0)]
+        [ null, '😁', 2, '😁'.charCodeAt(0), undefined],
+        [ null, '', 0, null, undefined],
+        [ null, 'a', 1, 'a'.charCodeAt(0), undefined]
       ]);
 
       const str3 = buffer.translateBufferLineToString(0, true, 0, 3);

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -13,6 +13,8 @@ export const CHAR_DATA_ATTR_INDEX = 0;
 export const CHAR_DATA_CHAR_INDEX = 1;
 export const CHAR_DATA_WIDTH_INDEX = 2;
 export const CHAR_DATA_CODE_INDEX = 3;
+export const CHAR_DATA_RENDERABLE_INDEX = 4;
+
 export const MAX_BUFFER_SIZE = 4294967295; // 2^32 - 1
 
 /**
@@ -117,7 +119,7 @@ export class Buffer implements IBuffer {
     if (this.lines.length > 0) {
       // Deal with columns increasing (we don't do anything when columns reduce)
       if (this._terminal.cols < newCols) {
-        const ch: CharData = [DEFAULT_ATTR, ' ', 1, 32]; // does xterm use the default attr?
+        const ch: CharData = [DEFAULT_ATTR, ' ', 1, 32, undefined]; // does xterm use the default attr?
         for (let i = 0; i < this.lines.length; i++) {
           while (this.lines.get(i).length < newCols) {
             this.lines.get(i).push(ch);

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -13,7 +13,7 @@ import { wcwidth } from './CharWidth';
 import { EscapeSequenceParser } from './EscapeSequenceParser';
 import { ICharset } from './core/Types';
 import { Disposable } from './common/Lifecycle';
-import { Base64Image, ImageCell } from './Base64Image' 
+import { Base64Image, ImageCell } from './Base64Image';
 /**
  * Map collect to glevel. Used in `selectCharset`.
  */
@@ -1872,9 +1872,9 @@ export class InputHandler extends Disposable implements IInputHandler {
    * height	  	              Height to render. See notes below.
    * preserveAspectRatio	  	If set to 0, then the image's inherent aspect ratio will not be respected; otherwise,
    *                          it will fill the specified width and height as much as possible without stretching. Defaults to 1.
-   * inline	  	              If set to 1, the file will be displayed inline. Otherwise, it will be downloaded with no visual representation 
+   * inline	  	              If set to 1, the file will be displayed inline. Otherwise, it will be downloaded with no visual representation
    *                          in the terminal session. Defaults to 0.
-   * 
+   *
    * The width and height are given as a number followed by a unit, or the word "auto".
    *
    * N: N character cells.
@@ -1884,58 +1884,58 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
 
   public displayImage(data: string): void {
-    let b64img = new Base64Image(data)
+    const b64img = new Base64Image(data);
     if (!b64img.valid) {
-      return
+      return;
     }
 
-    let [width, height, nrows, ncols]  = b64img.calculateDimensions(this._terminal.renderer.dimensions)
+    const [width, height, nrows, ncols]  = b64img.calculateDimensions(this._terminal.renderer.dimensions);
 
-    let termX = this._terminal.buffer.x
-    let termY = this._terminal.buffer.y + this._terminal.buffer.ybase
-   
-    for (var i = 0; i < (nrows-1); i++) {
-      this.index() // TODO does this overwrite everything?
+    const termX = this._terminal.buffer.x;
+    const termY = this._terminal.buffer.y + this._terminal.buffer.ybase;
+
+    for (let i = 0; i < (nrows - 1); i++) {
+      this.index(); // TODO does this overwrite everything?
     }
-    this._terminal.buffer.x = termX + ncols
+    this._terminal.buffer.x = termX + ncols;
 
-    let img = new Image()
-    let dataUrl = b64img.dataUrl()
-    img.src = dataUrl
+    const img = new Image();
+    const dataUrl = b64img.dataUrl();
+    img.src = dataUrl;
 
-    let emptyImage = new ImageData(this._terminal.renderer.dimensions.scaledCellWidth,
-                                   this._terminal.renderer.dimensions.scaledCellHeight)
+    const emptyImage = new ImageData(this._terminal.renderer.dimensions.scaledCellWidth,
+                                     this._terminal.renderer.dimensions.scaledCellHeight);
 
-    for (var y = termY; y < termY+nrows; y++) {
+    for (let y = termY; y < termY + nrows; y++) {
 
       const line = this._terminal.buffer.lines.get(y);
 
-      for (var x=termX; x < Math.min(this._terminal.cols, termX+ncols); x++) {
-        let cell = new ImageCell(emptyImage, dataUrl)
+      for (let x = termX; x < Math.min(this._terminal.cols, termX + ncols); x++) {
+        const cell = new ImageCell(emptyImage, dataUrl);
         line[x] = [this._terminal.eraseAttr(), ' ', 1, 32, cell];
       }
     }
-    
-    img.onload = () => {
-      let imageData = b64img.getImageData(img, width, height, nrows, ncols, this._terminal.renderer.dimensions)
 
-      for (var y = termY; y < termY+nrows; y++) {
+    img.onload = () => {
+      const imageData = b64img.getImageData(img, width, height, nrows, ncols, this._terminal.renderer.dimensions);
+
+      for (let y = termY; y < termY + nrows; y++) {
 
         const line = this._terminal.buffer.lines.get(y);
-        let imgs = imageData[y-termY]
+        const imgs = imageData[y - termY];
 
-        for (var x=termX; x < Math.min(this._terminal.cols, termX+ncols); x++) {
-          let renderable = line[x][CHAR_DATA_RENDERABLE_INDEX]
-          if (renderable && renderable.dataUrl() == dataUrl) {
-            let imgdata = imgs[x-termX]
-            let cell = new ImageCell(imgdata, dataUrl)
+        for (let x = termX; x < Math.min(this._terminal.cols, termX + ncols); x++) {
+          const renderable = line[x][CHAR_DATA_RENDERABLE_INDEX];
+          if (renderable && renderable.dataUrl() === dataUrl) {
+            const imgdata = imgs[x - termX];
+            const cell = new ImageCell(imgdata, dataUrl);
             line[x] = [this._terminal.eraseAttr(), ' ', 1, 32, cell];
           }
         }
 
       }
-      this._terminal.refresh(termY, termY+nrows);
-    }
+      this._terminal.refresh(termY, termY + nrows);
+    };
 
   }
 

--- a/src/Linkifier.test.ts
+++ b/src/Linkifier.test.ts
@@ -51,7 +51,7 @@ describe('Linkifier', () => {
   function stringToRow(text: string): LineData {
     const result: LineData = [];
     for (let i = 0; i < text.length; i++) {
-      result.push([0, text.charAt(i), 1, text.charCodeAt(i)]);
+      result.push([0, text.charAt(i), 1, text.charCodeAt(i), undefined]);
     }
     return result;
   }

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -4,10 +4,9 @@
  */
 
 import { IMouseZoneManager } from './ui/Types';
-import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes, ILinkMatcherOptions, ILinkifier, ITerminal, LineData } from './Types';
+import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes, ILinkMatcherOptions, ILinkifier, ITerminal, LineData, IRenderable } from './Types';
 import { MouseZone } from './ui/MouseZoneManager';
 import { EventEmitter } from './EventEmitter';
-import {IRenderable} from './Types'
 import { CHAR_DATA_RENDERABLE_INDEX } from './Buffer';
 
 /**
@@ -195,11 +194,11 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     }
 
     for (let i = 0; i < this._linkMatchers.length; i++) {
-      let linkMatcher = this._linkMatchers[i]
+      const linkMatcher = this._linkMatchers[i];
       if (linkMatcher.matchDataUrls) {
-        let line = this._terminal.buffer.lines.get(rowIndex);
-        for (var ix = 0; ix < line.length; ix++) {
-          let cell = line[ix]
+        const line = this._terminal.buffer.lines.get(rowIndex);
+        for (let ix = 0; ix < line.length; ix++) {
+          const cell = line[ix];
           this._doLinkifyCell(rowIndex, ix, cell, linkMatcher);
         }
       } else {
@@ -251,24 +250,24 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     }
   }
 
-  
+
   /**
    * Linkifies a cell given a specific handler.
    * @param rowIndex The row index to linkify.
    * @param colIndex The col index to linkify.
-   * @param cell The cell of the row 
+   * @param cell The cell of the row
    * @param matcher The link matcher for this line.
    * @param offset The how much of the row has already been linkified.
    */
-  private _doLinkifyCell(rowIndex: number, colIndex:number, cell: [number, string, number, number, IRenderable], matcher: ILinkMatcher): void {
+  private _doLinkifyCell(rowIndex: number, colIndex: number, cell: [number, string, number, number, IRenderable], matcher: ILinkMatcher): void {
     if (!cell[CHAR_DATA_RENDERABLE_INDEX]) {
-      return
+      return;
     }
-    let dataUrl = cell[CHAR_DATA_RENDERABLE_INDEX].dataUrl()
+    const dataUrl = cell[CHAR_DATA_RENDERABLE_INDEX].dataUrl();
     if (!dataUrl.match(matcher.regex)) {
-      return
+      return;
     }
-    
+
     // Ensure the link is valid before registering
     if (matcher.validationCallback) {
       matcher.validationCallback(dataUrl, isValid => {

--- a/src/SelectionManager.test.ts
+++ b/src/SelectionManager.test.ts
@@ -55,13 +55,13 @@ describe('SelectionManager', () => {
   function stringToRow(text: string): LineData {
     const result: LineData = [];
     for (let i = 0; i < text.length; i++) {
-      result.push([0, text.charAt(i), 1, text.charCodeAt(i)]);
+      result.push([0, text.charAt(i), 1, text.charCodeAt(i), undefined]);
     }
     return result;
   }
 
   function stringArrayToRow(chars: string[]): LineData {
-    return chars.map(c => <CharData>[0, c, 1, c.charCodeAt(0)]);
+    return chars.map(c => <CharData>[0, c, 1, c.charCodeAt(0), undefined]);
   }
 
   describe('_selectWordAt', () => {
@@ -98,21 +98,21 @@ describe('SelectionManager', () => {
     it('should expand selection for wide characters', () => {
       // Wide characters use a special format
       buffer.lines.set(0, [
-        [null, '中', 2, '中'.charCodeAt(0)],
-        [null, '', 0, null],
-        [null, '文', 2, '文'.charCodeAt(0)],
-        [null, '', 0, null],
-        [null, ' ', 1, ' '.charCodeAt(0)],
-        [null, 'a', 1, 'a'.charCodeAt(0)],
-        [null, '中', 2, '中'.charCodeAt(0)],
-        [null, '', 0, null],
-        [null, '文', 2, '文'.charCodeAt(0)],
-        [null, '', 0, ''.charCodeAt(0)],
-        [null, 'b', 1, 'b'.charCodeAt(0)],
-        [null, ' ', 1, ' '.charCodeAt(0)],
-        [null, 'f', 1, 'f'.charCodeAt(0)],
-        [null, 'o', 1, 'o'.charCodeAt(0)],
-        [null, 'o', 1, 'o'.charCodeAt(0)]
+        [null, '中', 2, '中'.charCodeAt(0), undefined],
+        [null, '', 0, null, undefined],
+        [null, '文', 2, '文'.charCodeAt(0), undefined],
+        [null, '', 0, null, undefined],
+        [null, ' ', 1, ' '.charCodeAt(0), undefined],
+        [null, 'a', 1, 'a'.charCodeAt(0), undefined],
+        [null, '中', 2, '中'.charCodeAt(0), undefined],
+        [null, '', 0, null, undefined],
+        [null, '文', 2, '文'.charCodeAt(0), undefined],
+        [null, '', 0, ''.charCodeAt(0), undefined],
+        [null, 'b', 1, 'b'.charCodeAt(0), undefined],
+        [null, ' ', 1, ' '.charCodeAt(0), undefined],
+        [null, 'f', 1, 'f'.charCodeAt(0), undefined],
+        [null, 'o', 1, 'o'.charCodeAt(0), undefined],
+        [null, 'o', 1, 'o'.charCodeAt(0), undefined]
       ]);
       // Ensure wide characters take up 2 columns
       selectionManager.selectWordAt([0, 0]);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1697,7 +1697,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     if (!line) {
       return;
     }
-    const ch: CharData = [this.eraseAttr(), ' ', 1, 32 /* ' '.charCodeAt(0) */]; // xterm
+    const ch: CharData = [this.eraseAttr(), ' ', 1, 32 /* ' '.charCodeAt(0) */, undefined]; // xterm
     for (; x < this.cols; x++) {
       line[x] = ch;
     }
@@ -1714,7 +1714,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     if (!line) {
       return;
     }
-    const ch: CharData = [this.eraseAttr(), ' ', 1, 32 /* ' '.charCodeAt(0) */]; // xterm
+    const ch: CharData = [this.eraseAttr(), ' ', 1, 32 /* ' '.charCodeAt(0) */, undefined]; // xterm
     x++;
     while (x--) {
       line[x] = ch;
@@ -1760,7 +1760,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   public blankLine(cur?: boolean, isWrapped?: boolean, cols?: number): LineData {
     const attr = cur ? this.eraseAttr() : DEFAULT_ATTR;
 
-    const ch: CharData = [attr, ' ', 1, 32 /* ' '.charCodeAt(0) */]; // width defaults to 1 halfwidth character
+    const ch: CharData = [attr, ' ', 1, 32 /* ' '.charCodeAt(0) */, undefined]; // width defaults to 1 halfwidth character
     const line: LineData = [];
 
     // TODO: It is not ideal that this is a property on an array, a buffer line
@@ -1783,9 +1783,9 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
    */
   public ch(cur?: boolean): CharData {
     if (cur) {
-      return [this.eraseAttr(), ' ', 1, 32 /* ' '.charCodeAt(0) */];
+      return [this.eraseAttr(), ' ', 1, 32 /* ' '.charCodeAt(0) */, undefined];
     }
-    return [DEFAULT_ATTR, ' ', 1, 32 /* ' '.charCodeAt(0) */];
+    return [DEFAULT_ATTR, ' ', 1, 32 /* ' '.charCodeAt(0) */, undefined];
   }
 
   /**

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -12,7 +12,13 @@ export type CustomKeyEventHandler = (event: KeyboardEvent) => boolean;
 
 export type XtermListener = (...args: any[]) => void;
 
-export type CharData = [number, string, number, number];
+export interface IRenderable {
+  dataUrl(): string|undefined;
+  drawBackground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void;
+  drawForeground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void;
+}
+
+export type CharData = [number, string, number, number, IRenderable|undefined];
 export type LineData = CharData[];
 
 export type LinkMatcherHandler = (event: MouseEvent, uri: string) => void;
@@ -192,6 +198,7 @@ export interface ILinkMatcher {
   validationCallback?: LinkMatcherValidationCallback;
   priority?: number;
   willLinkActivate?: (event: MouseEvent, uri: string) => boolean;
+  matchDataUrls?: boolean
 }
 
 export interface ILinkHoverEvent {
@@ -200,6 +207,7 @@ export interface ILinkHoverEvent {
   x2: number;
   y2: number;
   cols: number;
+  isText: boolean;
 }
 
 export interface ITerminal extends PublicTerminal, IElementAccessor, IBufferAccessor, ILinkifierAccessor {
@@ -360,6 +368,11 @@ export interface ILinkMatcherOptions {
    * mouse event will continue propagation (eg. double click to select word).
    */
   willLinkActivate?: (event: MouseEvent, uri: string) => boolean;
+  /** 
+   * A flag that causes the Linkifier to match data URLs instead of text in the
+   * terminal.
+   */
+  matchDataUrls?: boolean
 }
 
 export interface IBrowser {
@@ -508,3 +521,4 @@ export interface IEscapeSequenceParser extends IDisposable {
   setErrorHandler(callback: (state: IParsingState) => IParsingState): void;
   clearErrorHandler(): void;
 }
+

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -13,12 +13,12 @@ export type CustomKeyEventHandler = (event: KeyboardEvent) => boolean;
 export type XtermListener = (...args: any[]) => void;
 
 export interface IRenderable {
-  dataUrl(): string|undefined;
+  dataUrl(): string | undefined;
   drawBackground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void;
   drawForeground(ctx: CanvasRenderingContext2D, x: number, y: number, scaledCellWidth: number, scaledCellHeight: number): void;
 }
 
-export type CharData = [number, string, number, number, IRenderable|undefined];
+export type CharData = [number, string, number, number, IRenderable | undefined];
 export type LineData = CharData[];
 
 export type LinkMatcherHandler = (event: MouseEvent, uri: string) => void;
@@ -198,7 +198,7 @@ export interface ILinkMatcher {
   validationCallback?: LinkMatcherValidationCallback;
   priority?: number;
   willLinkActivate?: (event: MouseEvent, uri: string) => boolean;
-  matchDataUrls?: boolean
+  matchDataUrls?: boolean;
 }
 
 export interface ILinkHoverEvent {
@@ -368,11 +368,11 @@ export interface ILinkMatcherOptions {
    * mouse event will continue propagation (eg. double click to select word).
    */
   willLinkActivate?: (event: MouseEvent, uri: string) => boolean;
-  /** 
+  /**
    * A flag that causes the Linkifier to match data URLs instead of text in the
    * terminal.
    */
-  matchDataUrls?: boolean
+  matchDataUrls?: boolean;
 }
 
 export interface IBrowser {

--- a/src/addons/imageLinks/imageLinks.ts
+++ b/src/addons/imageLinks/imageLinks.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { Terminal, ILinkMatcherOptions } from 'xterm';
+
+function handleLink(event: MouseEvent, uri: string): void {
+  var userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.indexOf(' electron/') > -1) {
+    window.open(uri, '_blank');
+  } else {
+    var win = window.open()
+    win.document.body.innerHTML = "<img src='" + uri + "'>"
+  }
+}
+
+/**
+ * Initialize the image links addon, registering the link matcher.
+ * @param term The terminal to use image links within.
+ * @param handler A custom handler to use.
+ * @param options Custom options to use, matchIndex will always be ignored.
+ */
+export function imageLinksInit(term: Terminal, handler: (event: MouseEvent, uri: string) => void = handleLink, options: ILinkMatcherOptions = {}): void {
+  options.matchIndex = 1;
+  options.matchDataUrls = true;
+  term.registerLinkMatcher(new RegExp("^data:image\\/(png|jpeg);"), handler, options);
+}
+
+export function apply(terminalConstructor: typeof Terminal): void {
+  (<any>terminalConstructor.prototype).imageLinksInit = function (handler?: (event: MouseEvent, uri: string) => void, options?: ILinkMatcherOptions): void {
+    imageLinksInit(this, handler, options);
+  };
+}

--- a/src/addons/imageLinks/imageLinks.ts
+++ b/src/addons/imageLinks/imageLinks.ts
@@ -6,12 +6,12 @@
 import { Terminal, ILinkMatcherOptions } from 'xterm';
 
 function handleLink(event: MouseEvent, uri: string): void {
-  var userAgent = navigator.userAgent.toLowerCase();
+  const userAgent = navigator.userAgent.toLowerCase();
   if (userAgent.indexOf(' electron/') > -1) {
     window.open(uri, '_blank');
   } else {
-    var win = window.open()
-    win.document.body.innerHTML = "<img src='" + uri + "'>"
+    const win = window.open();
+    win.document.body.innerHTML = '<img src=\'' + uri + '\'>';
   }
 }
 
@@ -24,7 +24,7 @@ function handleLink(event: MouseEvent, uri: string): void {
 export function imageLinksInit(term: Terminal, handler: (event: MouseEvent, uri: string) => void = handleLink, options: ILinkMatcherOptions = {}): void {
   options.matchIndex = 1;
   options.matchDataUrls = true;
-  term.registerLinkMatcher(new RegExp("^data:image\\/(png|jpeg);"), handler, options);
+  term.registerLinkMatcher(new RegExp('^data:image\\/(png|jpeg);'), handler, options);
 }
 
 export function apply(terminalConstructor: typeof Terminal): void {

--- a/src/addons/imageLinks/package.json
+++ b/src/addons/imageLinks/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "xterm.imagelinks",
+  "main": "imageLinks.js",
+  "private": true
+}

--- a/src/addons/imageLinks/tsconfig.json
+++ b/src/addons/imageLinks/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "target": "es5",
+      "rootDir": ".",
+      "outDir": "../../../lib/addons/imageLinks/",
+      "sourceMap": true,
+      "removeComments": true,
+      "declaration": true,
+      "preserveWatchOutput": true
+    },
+    "include": [
+      "**/*.ts",
+      "../../../typings/xterm.d.ts"
+    ]
+  }
+  

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -4,7 +4,7 @@
  */
 
 import { IRenderLayer, IColorSet, IRenderDimensions } from './Types';
-import { CharData, ITerminal } from '../Types';
+import { CharData, ITerminal, IRenderable } from '../Types';
 import { DIM_OPACITY, INVERTED_DEFAULT_COLOR } from './atlas/Types';
 import BaseCharAtlas from './atlas/BaseCharAtlas';
 import { acquireCharAtlas } from './atlas/CharAtlasCache';
@@ -122,6 +122,17 @@ export abstract class BaseRenderLayer implements IRenderLayer {
         y * this._scaledCellHeight,
         width * this._scaledCellWidth,
         height * this._scaledCellHeight);
+  }
+
+  /**
+   * TODO doc
+   */
+  protected drawRenderableBackground(renderable: IRenderable, x: number, y: number): void {
+    renderable.drawBackground(this._ctx, x, y, this._scaledCellWidth, this._scaledCellHeight)
+  }
+
+  protected drawRenderableForeground(renderable: IRenderable, x: number, y: number): void {
+    renderable.drawBackground(this._ctx, x, y, this._scaledCellWidth, this._scaledCellHeight)
   }
 
   /**

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -128,11 +128,11 @@ export abstract class BaseRenderLayer implements IRenderLayer {
    * TODO doc
    */
   protected drawRenderableBackground(renderable: IRenderable, x: number, y: number): void {
-    renderable.drawBackground(this._ctx, x, y, this._scaledCellWidth, this._scaledCellHeight)
+    renderable.drawBackground(this._ctx, x, y, this._scaledCellWidth, this._scaledCellHeight);
   }
 
   protected drawRenderableForeground(renderable: IRenderable, x: number, y: number): void {
-    renderable.drawBackground(this._ctx, x, y, this._scaledCellWidth, this._scaledCellHeight)
+    renderable.drawBackground(this._ctx, x, y, this._scaledCellWidth, this._scaledCellHeight);
   }
 
   /**

--- a/src/renderer/CharacterJoinerRegistry.test.ts
+++ b/src/renderer/CharacterJoinerRegistry.test.ts
@@ -23,11 +23,11 @@ describe('CharacterJoinerRegistry', () => {
     lines.set(5, [...lineData('a', 0x11111111), ...lineData(' -> b -> c -> '), ...lineData('d', 0x22222222)]);
     lines.set(6, [
       ...lineData('wi'),
-      [0, '￥', 2, '￥'.charCodeAt(0)],
-      [0, '', 0, null],
+      [0, '￥', 2, '￥'.charCodeAt(0), undefined],
+      [0, '', 0, null, undefined],
       ...lineData('deemo'),
-      [0, '\xf0\x9f\x98\x81', 1, 128513],
-      [0, ' ', 1, ' '.charCodeAt(0)],
+      [0, '\xf0\x9f\x98\x81', 1, 128513, undefined],
+      [0, ' ', 1, ' '.charCodeAt(0), undefined],
       ...lineData('jiabc')
     ]);
     (<MockBuffer>terminal.buffer).setLines(lines);
@@ -258,7 +258,7 @@ describe('CharacterJoinerRegistry', () => {
 });
 
 function lineData(line: string, attr: number = 0): LineData {
-  return line.split('').map<CharData>(char => [attr, char, 1, char.charCodeAt(0)]);
+  return line.split('').map<CharData>(char => [attr, char, 1, char.charCodeAt(0), undefined]);
 }
 
 function substringJoiner(substring: string): (sequence: string) => [number, number][] {

--- a/src/renderer/LinkRenderLayer.ts
+++ b/src/renderer/LinkRenderLayer.ts
@@ -40,16 +40,18 @@ export class LinkRenderLayer extends BaseRenderLayer {
 
   private _onLinkHover(e: ILinkHoverEvent): void {
     this._ctx.fillStyle = this._colors.foreground.css;
-    if (e.y1 === e.y2) {
-      // Single line link
-      this.fillBottomLineAtCells(e.x1, e.y1, e.x2 - e.x1);
-    } else {
-      // Multi-line link
-      this.fillBottomLineAtCells(e.x1, e.y1, e.cols - e.x1);
-      for (let y = e.y1 + 1; y < e.y2; y++) {
-        this.fillBottomLineAtCells(0, y, e.cols);
+    if (e.isText) {
+      if (e.y1 === e.y2) {
+        // Single line link
+        this.fillBottomLineAtCells(e.x1, e.y1, e.x2 - e.x1);
+      } else {
+        // Multi-line link
+        this.fillBottomLineAtCells(e.x1, e.y1, e.cols - e.x1);
+        for (let y = e.y1 + 1; y < e.y2; y++) {
+          this.fillBottomLineAtCells(0, y, e.cols);
+        }
+        this.fillBottomLineAtCells(0, e.y2, e.x2);
       }
-      this.fillBottomLineAtCells(0, e.y2, e.x2);
     }
     this._state = e;
   }

--- a/src/renderer/TextRenderLayer.ts
+++ b/src/renderer/TextRenderLayer.ts
@@ -59,7 +59,7 @@ export class TextRenderLayer extends BaseRenderLayer {
       code: number,
       chars: string,
       width: number,
-      renderable: IRenderable|undefined,
+      renderable: IRenderable | undefined,
       x: number,
       y: number,
       fg: number,
@@ -80,7 +80,7 @@ export class TextRenderLayer extends BaseRenderLayer {
         let chars: string = charData[CHAR_DATA_CHAR_INDEX];
         const attr: number = charData[CHAR_DATA_ATTR_INDEX];
         let width: number = charData[CHAR_DATA_WIDTH_INDEX];
-        let renderable: IRenderable = charData[CHAR_DATA_RENDERABLE_INDEX];
+        const renderable: IRenderable = charData[CHAR_DATA_RENDERABLE_INDEX];
 
         // If true, indicates that the current character(s) to draw were joined.
         let isJoined = false;
@@ -189,9 +189,9 @@ export class TextRenderLayer extends BaseRenderLayer {
       let nextFillStyle = null; // null represents default background color
 
       if (renderable != null) {
-        prevFillStyle = null
+        prevFillStyle = null;
         this.drawRenderableBackground(renderable, x, y);
-        return
+        return;
       }
 
       if (bg === INVERTED_DEFAULT_COLOR) {
@@ -199,7 +199,7 @@ export class TextRenderLayer extends BaseRenderLayer {
       } else if (bg < 256) {
         nextFillStyle = this._colors.ansi[bg].css;
       }
-      
+
       if (prevFillStyle === null) {
         // This is either the first iteration, or the default background was set. Either way, we
         // don't need to draw anything.
@@ -236,10 +236,10 @@ export class TextRenderLayer extends BaseRenderLayer {
       if (flags & FLAGS.INVISIBLE) {
         return;
       }
-      
+
       if (renderable != null) {
         this.drawRenderableForeground(renderable, x, y);
-        return
+        return;
       }
 
       if (flags & FLAGS.UNDERLINE) {

--- a/src/renderer/dom/DomRendererRowFactory.test.ts
+++ b/src/renderer/dom/DomRendererRowFactory.test.ts
@@ -31,9 +31,9 @@ describe('DomRendererRowFactory', () => {
     });
 
     it('should set correct attributes for double width characters', () => {
-      lineData[0] = [DEFAULT_ATTR, '語', 2, '語'.charCodeAt(0)];
+      lineData[0] = [DEFAULT_ATTR, '語', 2, '語'.charCodeAt(0), undefined];
       // There should be no element for the following "empty" cell
-      lineData[1] = [DEFAULT_ATTR, '', 0, undefined];
+      lineData[1] = [DEFAULT_ATTR, '', 0, undefined, undefined];
       const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
       assert.equal(getFragmentHtml(fragment),
         '<span style="width: 10px;">語</span>'
@@ -49,8 +49,8 @@ describe('DomRendererRowFactory', () => {
     });
 
     it('should not render cells that go beyond the terminal\'s columns', () => {
-      lineData[0] = [DEFAULT_ATTR, 'a', 1, 'a'.charCodeAt(0)];
-      lineData[1] = [DEFAULT_ATTR, 'b', 1, 'b'.charCodeAt(0)];
+      lineData[0] = [DEFAULT_ATTR, 'a', 1, 'a'.charCodeAt(0), undefined];
+      lineData[1] = [DEFAULT_ATTR, 'b', 1, 'b'.charCodeAt(0), undefined];
       const fragment = rowFactory.createRow(lineData, false, 0, 5, 1);
       assert.equal(getFragmentHtml(fragment),
         '<span>a</span>'
@@ -59,7 +59,7 @@ describe('DomRendererRowFactory', () => {
 
     describe('attributes', () => {
       it('should add class for bold', () => {
-        lineData[0] = [DEFAULT_ATTR | (FLAGS.BOLD << 18), 'a', 1, 'a'.charCodeAt(0)];
+        lineData[0] = [DEFAULT_ATTR | (FLAGS.BOLD << 18), 'a', 1, 'a'.charCodeAt(0), undefined];
         const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span class="xterm-bold">a</span>' +
@@ -68,7 +68,7 @@ describe('DomRendererRowFactory', () => {
       });
 
       it('should add class for italic', () => {
-        lineData[0] = [DEFAULT_ATTR | (FLAGS.ITALIC << 18), 'a', 1, 'a'.charCodeAt(0)];
+        lineData[0] = [DEFAULT_ATTR | (FLAGS.ITALIC << 18), 'a', 1, 'a'.charCodeAt(0), undefined];
         const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span class="xterm-italic">a</span>' +
@@ -79,7 +79,7 @@ describe('DomRendererRowFactory', () => {
       it('should add classes for 256 foreground colors', () => {
         const defaultAttrNoFgColor = (0 << 9) | (256 << 0);
         for (let i = 0; i < 256; i++) {
-          lineData[0] = [defaultAttrNoFgColor | (i << 9), 'a', 1, 'a'.charCodeAt(0)];
+          lineData[0] = [defaultAttrNoFgColor | (i << 9), 'a', 1, 'a'.charCodeAt(0), undefined];
           const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
           assert.equal(getFragmentHtml(fragment),
             `<span class="xterm-fg-${i}">a</span>` +
@@ -91,7 +91,7 @@ describe('DomRendererRowFactory', () => {
       it('should add classes for 256 background colors', () => {
         const defaultAttrNoBgColor = (257 << 9) | (0 << 0);
         for (let i = 0; i < 256; i++) {
-          lineData[0] = [defaultAttrNoBgColor | (i << 0), 'a', 1, 'a'.charCodeAt(0)];
+          lineData[0] = [defaultAttrNoBgColor | (i << 0), 'a', 1, 'a'.charCodeAt(0), undefined];
           const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
           assert.equal(getFragmentHtml(fragment),
             `<span class="xterm-bg-${i}">a</span>` +
@@ -101,7 +101,7 @@ describe('DomRendererRowFactory', () => {
       });
 
       it('should correctly invert colors', () => {
-        lineData[0] = [(FLAGS.INVERSE << 18) | (2 << 9) | (1 << 0), 'a', 1, 'a'.charCodeAt(0)];
+        lineData[0] = [(FLAGS.INVERSE << 18) | (2 << 9) | (1 << 0), 'a', 1, 'a'.charCodeAt(0), undefined];
         const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span class="xterm-fg-1 xterm-bg-2">a</span>' +
@@ -110,7 +110,7 @@ describe('DomRendererRowFactory', () => {
       });
 
       it('should correctly invert default fg color', () => {
-        lineData[0] = [(FLAGS.INVERSE << 18) | (257 << 9) | (1 << 0), 'a', 1, 'a'.charCodeAt(0)];
+        lineData[0] = [(FLAGS.INVERSE << 18) | (257 << 9) | (1 << 0), 'a', 1, 'a'.charCodeAt(0), undefined];
         const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span class="xterm-fg-1 xterm-bg-15">a</span>' +
@@ -119,7 +119,7 @@ describe('DomRendererRowFactory', () => {
       });
 
       it('should correctly invert default bg color', () => {
-        lineData[0] = [(FLAGS.INVERSE << 18) | (1 << 9) | (256 << 0), 'a', 1, 'a'.charCodeAt(0)];
+        lineData[0] = [(FLAGS.INVERSE << 18) | (1 << 9) | (256 << 0), 'a', 1, 'a'.charCodeAt(0), undefined];
         const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span class="xterm-fg-0 xterm-bg-1">a</span>' +
@@ -129,7 +129,7 @@ describe('DomRendererRowFactory', () => {
 
       it('should turn bold fg text bright', () => {
         for (let i = 0; i < 8; i++) {
-          lineData[0] = [(FLAGS.BOLD << 18) | (i << 9) | (256 << 0), 'a', 1, 'a'.charCodeAt(0)];
+          lineData[0] = [(FLAGS.BOLD << 18) | (i << 9) | (256 << 0), 'a', 1, 'a'.charCodeAt(0), undefined];
           const fragment = rowFactory.createRow(lineData, false, 0, 5, 20);
           assert.equal(getFragmentHtml(fragment),
             `<span class="xterm-bold xterm-fg-${i + 8}">a</span>` +
@@ -149,7 +149,7 @@ describe('DomRendererRowFactory', () => {
   function createEmptyLineData(cols: number): LineData {
     const lineData: LineData = [];
     for (let i = 0; i < cols; i++) {
-      lineData.push([DEFAULT_ATTR, ' ', 1, 32 /* ' '.charCodeAt(0) */]);
+      lineData.push([DEFAULT_ATTR, ' ', 1, 32 /* ' '.charCodeAt(0) */, undefined]);
     }
     return lineData;
   }

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -231,7 +231,7 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   eraseLeft(x: number, y: number): void {
     throw new Error('Method not implemented.');
   }
-  blankLine(cur?: boolean, isWrapped?: boolean): [number, string, number, number, IRenderable|undefined][] {
+  blankLine(cur?: boolean, isWrapped?: boolean): [number, string, number, number, IRenderable | undefined][] {
     throw new Error('Method not implemented.');
   }
   prevStop(x?: number): number {
@@ -312,7 +312,7 @@ export class MockBuffer implements IBuffer {
   prevStop(x?: number): number {
     throw new Error('Method not implemented.');
   }
-  setLines(lines: ICircularList<[number, string, number, number, IRenderable|undefined][]>): void {
+  setLines(lines: ICircularList<[number, string, number, number, IRenderable | undefined][]>): void {
     this.lines = lines;
   }
 }

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { IColorSet, IRenderer, IRenderDimensions, IColorManager } from '../renderer/Types';
-import { LineData, IInputHandlingTerminal, IViewport, ICompositionHelper, ITerminal, IBuffer, IBufferSet, IBrowser, ICharMeasure, ISelectionManager, ITerminalOptions, ICircularList, ILinkifier, IMouseHelper, ILinkMatcherOptions, XtermListener, CharacterJoinerHandler } from '../Types';
+import { LineData, IInputHandlingTerminal, IViewport, ICompositionHelper, ITerminal, IBuffer, IBufferSet, IBrowser, ICharMeasure, ISelectionManager, ITerminalOptions, ICircularList, ILinkifier, IMouseHelper, ILinkMatcherOptions, XtermListener, CharacterJoinerHandler, IRenderable } from '../Types';
 import { Buffer } from '../Buffer';
 import * as Browser from '../shared/utils/Browser';
 import { ITheme, IDisposable, IMarker } from 'xterm';
@@ -152,7 +152,7 @@ export class MockTerminal implements ITerminal {
     const line: LineData = [];
     cols = cols || this.cols;
     for (let i = 0; i < cols; i++) {
-      line.push([0, ' ', 1, 32]);
+      line.push([0, ' ', 1, 32, undefined]);
     }
     return line;
   }
@@ -231,7 +231,7 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   eraseLeft(x: number, y: number): void {
     throw new Error('Method not implemented.');
   }
-  blankLine(cur?: boolean, isWrapped?: boolean): [number, string, number, number][] {
+  blankLine(cur?: boolean, isWrapped?: boolean): [number, string, number, number, IRenderable|undefined][] {
     throw new Error('Method not implemented.');
   }
   prevStop(x?: number): number {
@@ -289,7 +289,7 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
 
 export class MockBuffer implements IBuffer {
   isCursorInViewport: boolean;
-  lines: ICircularList<[number, string, number, number][]>;
+  lines: ICircularList<[number, string, number, number, IRenderable | undefined][]>;
   ydisp: number;
   ybase: number;
   hasScrollback: boolean;
@@ -312,7 +312,7 @@ export class MockBuffer implements IBuffer {
   prevStop(x?: number): number {
     throw new Error('Method not implemented.');
   }
-  setLines(lines: ICircularList<[number, string, number, number][]>): void {
+  setLines(lines: ICircularList<[number, string, number, number, IRenderable|undefined][]>): void {
     this.lines = lines;
   }
 }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -274,6 +274,11 @@ declare module 'xterm' {
      * mouse event will continue propagation (eg. double click to select word).
      */
     willLinkActivate?: (event: MouseEvent, uri: string) => boolean;
+    /** 
+     * A flag that causes the Linkifier to match data URLs instead of text in the
+     * terminal.
+     */
+    matchDataUrls?: boolean
   }
 
   export interface IEventEmitter {


### PR DESCRIPTION
This is a prototype of adding iTerm2 like image display capabilities to xterm.js, as requested in several tickets:

https://github.com/xtermjs/xterm.js/issues/614
https://github.com/zeit/hyper/issues/101
https://github.com/Microsoft/vscode/issues/44436

Images can also be clicked to be opened in full size in a new window.

![xterm-screenshot](https://user-images.githubusercontent.com/247775/43088834-7742fc96-8ea3-11e8-9998-6e6acef1ff29.png)

It works by slicing the image into patches of ```scaledCellWidth```/```scaledCellHeight``` size and adding the resulting ```ImageData``` object directly to the ```Buffer``` object. When a cell in the buffer is overwritten, the previous ```ImageData``` is thrown away and the memory is freed - e.g. this is useful when showing animated charts by overwriting the previous image.

We are developing an app that would greatly benefit from a cross platform terminal with image display, so I would be quite happy if this feature could make it to xterm.js in one way or another.

Please let me know if I can be of further help to have this feature land in xterm.js!