### PR TITLE
Allow convertEol to be be modified with setOption

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -493,6 +493,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
         }
         break;
       case 'tabStopWidth': this.buffers.setupTabStops(); break;
+      case 'convertEol': this.convertEol = value; break;
     }
     // Inform renderer of changes
     if (this.renderer) {


### PR DESCRIPTION
The documentation says this should be set with `setOption`, but the code that checks this value checks `core.convertEol` not `core.options.convertEol` ... so calling `setOption` has no effect :/

For anyone else running into this issue, you can force the value to be set with:

```
xterm.setOption('convertEol', true);
xterm._core.convertEol = true; // workaround
```