### PR TITLE
Stop typescript from emitting output files in typings test

### DIFF
--- a/fixtures/typings-test/tsconfig.json
+++ b/fixtures/typings-test/tsconfig.json
@@ -4,6 +4,7 @@
   ],
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5"
+    "target": "es5",
+    "noEmit": true
   }
 }

--- a/src/Terminal.integration.ts
+++ b/src/Terminal.integration.ts
@@ -163,7 +163,5 @@ describe('typings', () => {
     const fixtureDir = path.join(__dirname, '..', 'fixtures', 'typings-test');
     const result = cp.spawnSync(tsc, { cwd: fixtureDir });
     assert.equal(result.status, 0, `build did not succeed:\nstdout: ${result.stdout.toString()}\nstderr: ${result.stderr.toString()}\n`);
-    // Clean up
-    fs.unlinkSync(path.join(fixtureDir, 'typings-test.js'));
   });
 });


### PR DESCRIPTION
From https://github.com/xtermjs/xterm-addon-ligatures/pull/4#discussion_r209108648, prevents tsc from outputting any files so they no longer need to be cleaned up.