### PR TITLE
Add support for the "Not italic" escape code

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1631,6 +1631,9 @@ export class InputHandler extends Disposable implements IInputHandler {
         // not bold nor faint
         flags &= ~FLAGS.BOLD;
         flags &= ~FLAGS.DIM;
+      } else if (p === 23) {
+        // not italic
+        flags &= ~FLAGS.ITALIC;
       } else if (p === 24) {
         // not underlined
         flags &= ~FLAGS.UNDERLINE;


### PR DESCRIPTION
This PR adds support for the `\x1B[23m` "Not italic" escape code which is supported by most terminal emulators (that also support "Italic" itself) and [used by the popular `chalk` package](https://github.com/chalk/ansi-styles/blob/master/index.js#L27).

I wasn't sure whether and where I should add tests for this.