### PR TITLE
Enforce strict equality through tslint

### DIFF
--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -283,7 +283,7 @@ export class Buffer implements IBuffer {
    * @param i The index to start setting up tab stops from.
    */
   public setupTabStops(i?: number): void {
-    if (i != null) {
+    if (i !== null && i !== undefined) {
       if (!this.tabs[i]) {
         i = this.prevStop(i);
       }
@@ -302,7 +302,7 @@ export class Buffer implements IBuffer {
    * @param x The position to move the cursor to the previous tab stop.
    */
   public prevStop(x?: number): number {
-    if (x == null) {
+    if (x === null || x === undefined) {
       x = this.x;
     }
     while (!this.tabs[--x] && x > 0);
@@ -314,7 +314,7 @@ export class Buffer implements IBuffer {
    * @param x The position to move the cursor one tab stop forward.
    */
   public nextStop(x?: number): number {
-    if (x == null) {
+    if (x === null || x === undefined) {
       x = this.x;
     }
     while (!this.tabs[++x] && x < this._terminal.cols);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -251,7 +251,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
 
   private _setup(): void {
     Object.keys(DEFAULT_OPTIONS).forEach((key) => {
-      if (this.options[key] == null) {
+      if (this.options[key] === null || this.options[key] === undefined) {
         this.options[key] = DEFAULT_OPTIONS[key];
       }
     });
@@ -960,9 +960,9 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
       // 1, and 2 - with 64 added
       switch ((<any>ev).overrideType || ev.type) {
         case 'mousedown':
-          button = ev.button != null
+          button = ev.button !== null && ev.button !== undefined
             ? +ev.button
-          : ev.which != null
+          : ev.which !== null && ev.which !== undefined
             ? ev.which - 1
           : null;
 
@@ -1587,7 +1587,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
 
     if (ev.charCode) {
       key = ev.charCode;
-    } else if (ev.which == null) {
+    } else if (ev.which === null || ev.which === undefined) {
       key = ev.keyCode;
     } else if (ev.which !== 0 && ev.charCode !== 0) {
       key = ev.which;
@@ -1932,7 +1932,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   public matchColor(r1: number, g1: number, b1: number): number {
     const hash = (r1 << 16) | (g1 << 8) | b1;
 
-    if (matchColorCache[hash] != null) {
+    if (matchColorCache[hash] !== null && matchColorCache[hash] !== undefined) {
       return matchColorCache[hash];
     }
 

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -94,7 +94,7 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
   ): boolean {
     const glyphKey = getGlyphCacheKey(glyph);
     const cacheValue = this._cacheMap.get(glyphKey);
-    if (cacheValue != null) {
+    if (cacheValue !== null && cacheValue !== undefined) {
       this._drawFromCache(ctx, cacheValue, x, y);
       return true;
     } else if (this._canCache(glyph) && this._drawToCacheCount < FRAME_CACHE_DRAW_LIMIT) {

--- a/src/renderer/atlas/StaticCharAtlas.ts
+++ b/src/renderer/atlas/StaticCharAtlas.ts
@@ -53,7 +53,7 @@ export default class StaticCharAtlas extends BaseCharAtlas {
     y: number
   ): boolean {
     // we're not warmed up yet
-    if (this._texture == null) {
+    if (this._texture === null || this._texture === undefined) {
       return false;
     }
 

--- a/src/utils/MouseHelper.ts
+++ b/src/utils/MouseHelper.ts
@@ -11,7 +11,7 @@ export class MouseHelper {
 
   public static getCoordsRelativeToElement(event: {pageX: number, pageY: number}, element: HTMLElement): [number, number] {
     // Ignore browsers that don't support MouseEvent.pageX
-    if (event.pageX == null) {
+    if (event.pageX === null || event.pageX === undefined) {
       return null;
     }
 

--- a/tslint.json
+++ b/tslint.json
@@ -111,6 +111,7 @@
     "prefer-const-enum": [
       true
     ],
-    "prefer-const": true
+    "prefer-const": true,
+    "triple-equals": true
   }
 }


### PR DESCRIPTION
Mandates use of `===` and `!==`. Ref: https://github.com/xtermjs/xterm.js/pull/1624#issuecomment-415262946