### PR TITLE
#1629: Mouse cursor style is refreshed after focusing on terminal

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1146,8 +1146,8 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   /**
    * Change the cursor style for different selection modes
    */
-  public updateCursorStyle(ev: KeyboardEvent): void {
-    if (this.selectionManager && this.selectionManager.shouldColumnSelect(ev)) {
+  public updateCursorStyle(ev?: KeyboardEvent): void {
+    if (ev && this.selectionManager && this.selectionManager.shouldColumnSelect(ev)) {
       this.element.classList.add('xterm-cursor-crosshair');
     } else {
       this.element.classList.remove('xterm-cursor-crosshair');

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -235,6 +235,7 @@ export interface ITerminal extends PublicTerminal, IElementAccessor, IBufferAcce
   log(text: string): void;
   showCursor(): void;
   blankLine(cur?: boolean, isWrapped?: boolean, cols?: number): LineData;
+  updateCursorStyle(ev?: KeyboardEvent): void;
 }
 
 export interface IBufferAccessor {

--- a/src/renderer/CursorRenderLayer.ts
+++ b/src/renderer/CursorRenderLayer.ts
@@ -75,6 +75,7 @@ export class CursorRenderLayer extends BaseRenderLayer {
     if (this._cursorBlinkStateManager) {
       this._cursorBlinkStateManager.resume(terminal);
     } else {
+      terminal.updateCursorStyle();
       terminal.refresh(terminal.buffer.y, terminal.buffer.y);
     }
   }

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -155,6 +155,7 @@ export class MockTerminal implements ITerminal {
   }
   registerCharacterJoiner(handler: CharacterJoinerHandler): number { return 0; }
   deregisterCharacterJoiner(joinerId: number): void { }
+  updateCursorStyle(ev?: KeyboardEvent): void { }
 }
 
 export class MockCharMeasure implements ICharMeasure {


### PR DESCRIPTION
Fixes remaining crosshair cursor after alt-tabbing out of terminal