### PR TITLE
Fix search addon

### DIFF
--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -117,7 +117,7 @@ export class SearchHelper implements ISearchHelper {
     if (searchIndex >= 0) {
       const line = this._terminal._core.buffer.lines.get(y);
       for (let i = 0; i < searchIndex; i++) {
-        const charData = line[i];
+        const charData = line.get(i);
         // Adjust the searchIndex to normalize emoji into single chars
         const char = charData[1/*CHAR_DATA_CHAR_INDEX*/];
         if (char.length > 1) {

--- a/src/addons/search/search.test.ts
+++ b/src/addons/search/search.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert, expect } from 'chai';
+import * as search from './search';
+import { SearchHelper } from './SearchHelper';
+import { ISearchHelper } from './Interfaces';
+
+
+class MockTerminalPlain {}
+
+class MockTerminal {
+  private _core: any;
+  public searchHelper: ISearchHelper;
+  constructor(options: any) {
+    this._core = new (require('../../../lib/Terminal').Terminal)(options);
+    this.searchHelper = new SearchHelper(this as any);
+  }
+  get core(): any {
+    return this._core;
+  }
+}
+
+describe('search addon', function(): void {
+  describe('apply', () => {
+    it('should register findNext and findPrevious', () => {
+      search.apply(<any>MockTerminalPlain);
+      assert.equal(typeof (<any>MockTerminalPlain).prototype.findNext, 'function');
+      assert.equal(typeof (<any>MockTerminalPlain).prototype.findPrevious, 'function');
+    });
+    });
+  it('Searchhelper - should find correct position', function(done: () => void): void {
+    search.apply(<any>MockTerminal);
+    const term = new MockTerminal({cols: 20, rows: 3});
+    term.core.write('Hello World\r\ntest\n123....hello');
+    setTimeout(() => {
+      const hello0 = (term.searchHelper as any)._findInLine('Hello', 0);
+      const hello1 = (term.searchHelper as any)._findInLine('Hello', 1);
+      const hello2 = (term.searchHelper as any)._findInLine('Hello', 2);
+      expect(hello0).eql({col: 0, row: 0, term: 'Hello'});
+      expect(hello1).eql(undefined);
+      expect(hello2).eql({col: 11, row: 2, term: 'Hello'});
+      done();
+    }, 100);
+  });
+  // selection stuff not testable - depends on window
+  // the plugin is imho to high level and does more than searching
+  // maybe separate into:
+  //    - a search addon  - get positions for a term
+  //    - a mark addon    - highlight positions in output
+});

--- a/src/addons/search/search.test.ts
+++ b/src/addons/search/search.test.ts
@@ -21,6 +21,9 @@ class MockTerminal {
   get core(): any {
     return this._core;
   }
+  pushWriteData(): void {
+    this._core._innerWrite();
+  }
 }
 
 describe('search addon', function(): void {
@@ -30,24 +33,17 @@ describe('search addon', function(): void {
       assert.equal(typeof (<any>MockTerminalPlain).prototype.findNext, 'function');
       assert.equal(typeof (<any>MockTerminalPlain).prototype.findPrevious, 'function');
     });
-    });
-  it('Searchhelper - should find correct position', function(done: () => void): void {
+  });
+  it('Searchhelper - should find correct position', function(): void {
     search.apply(<any>MockTerminal);
     const term = new MockTerminal({cols: 20, rows: 3});
     term.core.write('Hello World\r\ntest\n123....hello');
-    setTimeout(() => {
-      const hello0 = (term.searchHelper as any)._findInLine('Hello', 0);
-      const hello1 = (term.searchHelper as any)._findInLine('Hello', 1);
-      const hello2 = (term.searchHelper as any)._findInLine('Hello', 2);
-      expect(hello0).eql({col: 0, row: 0, term: 'Hello'});
-      expect(hello1).eql(undefined);
-      expect(hello2).eql({col: 11, row: 2, term: 'Hello'});
-      done();
-    }, 100);
+    term.pushWriteData();
+    const hello0 = (term.searchHelper as any)._findInLine('Hello', 0);
+    const hello1 = (term.searchHelper as any)._findInLine('Hello', 1);
+    const hello2 = (term.searchHelper as any)._findInLine('Hello', 2);
+    expect(hello0).eql({col: 0, row: 0, term: 'Hello'});
+    expect(hello1).eql(undefined);
+    expect(hello2).eql({col: 11, row: 2, term: 'Hello'});
   });
-  // selection stuff not testable - depends on window
-  // the plugin is imho to high level and does more than searching
-  // maybe separate into:
-  //    - a search addon  - get positions for a term
-  //    - a mark addon    - highlight positions in output
 });


### PR DESCRIPTION
Fixes #1647.

A small test for `SearchHelper` is included, was not able to do this more generally since the addon relies on the selection manager with `window` defined. I suggest to split this addon into a search and a mark addon.