### PR TITLE
Move tslint prefer-const with the other core rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -39,6 +39,7 @@
     "one-variable-per-declaration": true,
     "no-unsafe-finally": true,
     "no-var-keyword": true,
+    "prefer-const": true,
     "quotemark": [
       true,
       "single"
@@ -107,7 +108,6 @@
     },
     "prefer-const-enum": [
       true
-    ],
-    "prefer-const": true
+    ]
   }
 }


### PR DESCRIPTION
The ones at the bottom are separated as they're part of tslint-consistent-codestyle