### PR TITLE
Improve unicode string handling in linkifier

### DIFF
--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -357,7 +357,7 @@ describe('Buffer', () => {
     it('multiline ascii', () => {
       const input = 'This is ASCII text spanning multiple lines.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -368,7 +368,7 @@ describe('Buffer', () => {
     it('combining e\u0301 in a sentence', () => {
       const input = 'Sitting in the cafe\u0301 drinking coffee.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 19; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -388,7 +388,7 @@ describe('Buffer', () => {
     it('multiline combining e\u0301', () => {
       const input = 'e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 2 string indices
       for (let i = 0; i < input.length; ++i) {
@@ -400,7 +400,7 @@ describe('Buffer', () => {
     it('surrogate char in a sentence', () => {
       const input = 'The 𝄞 is a clef widely used in modern notation.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 5; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -420,7 +420,7 @@ describe('Buffer', () => {
     it('multiline surrogate char', () => {
       const input = '𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 2 string indices
       for (let i = 0; i < input.length; ++i) {
@@ -433,7 +433,7 @@ describe('Buffer', () => {
       // eye of Ra with acute accent - string length of 3
       const input = '𓂀\u0301 - the eye hiroglyph with an acute accent.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       // index 0..2 should map to 0
       assert.deepEqual([0, 0], terminal.buffer.stringIndexToBufferIndex(0, 1));
@@ -447,7 +447,7 @@ describe('Buffer', () => {
     it('multiline surrogate with combining', () => {
       const input = '𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 3 string indices
       for (let i = 0; i < input.length; ++i) {
@@ -459,7 +459,7 @@ describe('Buffer', () => {
     it('fullwidth chars', () => {
       const input = 'These １２３ are some fat numbers.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 6; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -478,7 +478,7 @@ describe('Buffer', () => {
     it('multiline fullwidth chars', () => {
       const input = '１２３４５６７８９０１２３４５６７８９０';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       for (let i = 9; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -489,7 +489,7 @@ describe('Buffer', () => {
     it('fullwidth combining with emoji - match emoji cell', () => {
       const input = 'Lots of ￥\u0301 make me 😃.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).toArray()[0];
+      const s = terminal.buffer.contents(true).next().content;
       assert.equal(input, s);
       const stringIndex = s.match(/😃/).index;
       const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, stringIndex);

--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -357,7 +357,7 @@ describe('Buffer', () => {
     it('multiline ascii', () => {
       const input = 'This is ASCII text spanning multiple lines.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -368,7 +368,7 @@ describe('Buffer', () => {
     it('combining e\u0301 in a sentence', () => {
       const input = 'Sitting in the cafe\u0301 drinking coffee.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 19; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -388,7 +388,7 @@ describe('Buffer', () => {
     it('multiline combining e\u0301', () => {
       const input = 'e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 2 string indices
       for (let i = 0; i < input.length; ++i) {
@@ -400,7 +400,7 @@ describe('Buffer', () => {
     it('surrogate char in a sentence', () => {
       const input = 'The 𝄞 is a clef widely used in modern notation.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 5; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -420,7 +420,7 @@ describe('Buffer', () => {
     it('multiline surrogate char', () => {
       const input = '𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 2 string indices
       for (let i = 0; i < input.length; ++i) {
@@ -433,7 +433,7 @@ describe('Buffer', () => {
       // eye of Ra with acute accent - string length of 3
       const input = '𓂀\u0301 - the eye hiroglyph with an acute accent.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // index 0..2 should map to 0
       assert.deepEqual([0, 0], terminal.buffer.stringIndexToBufferIndex(0, 1));
@@ -447,7 +447,7 @@ describe('Buffer', () => {
     it('multiline surrogate with combining', () => {
       const input = '𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 3 string indices
       for (let i = 0; i < input.length; ++i) {
@@ -459,7 +459,7 @@ describe('Buffer', () => {
     it('fullwidth chars', () => {
       const input = 'These １２３ are some fat numbers.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 6; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -478,7 +478,7 @@ describe('Buffer', () => {
     it('multiline fullwidth chars', () => {
       const input = '１２３４５６７８９０１２３４５６７８９０';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 9; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
@@ -489,7 +489,7 @@ describe('Buffer', () => {
     it('fullwidth combining with emoji - match emoji cell', () => {
       const input = 'Lots of ￥\u0301 make me 😃.';
       terminal.writeSync(input);
-      const s = terminal.buffer.contents(true).next().content;
+      const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       const stringIndex = s.match(/😃/).index;
       const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, stringIndex);

--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -7,19 +7,11 @@ import { assert } from 'chai';
 import { ITerminal } from './Types';
 import { Buffer, DEFAULT_ATTR, CHAR_DATA_CHAR_INDEX } from './Buffer';
 import { CircularList } from './common/CircularList';
-import { MockTerminal } from './utils/TestUtils.test';
+import { MockTerminal, TestTerminal } from './utils/TestUtils.test';
 import { BufferLine } from './BufferLine';
-import { Terminal } from './Terminal';
 
 const INIT_COLS = 80;
 const INIT_ROWS = 24;
-
-class TestTerminal extends Terminal {
-  writeSync(data: string): void {
-    this.writeBuffer.push(data);
-    this._innerWrite();
-  }
-}
 
 describe('Buffer', () => {
   let terminal: ITerminal;
@@ -355,12 +347,14 @@ describe('Buffer', () => {
       assert.equal(str3, '😁a');
     });
   });
-  describe('stringIndexToBufferIndex', function(): void {
+  describe('stringIndexToBufferIndex', () => {
     let terminal: TestTerminal;
-    beforeEach(function(): void {
+
+    beforeEach(() => {
       terminal = new TestTerminal({rows: 5, cols: 10});
     });
-    it('multiline ascii', function(): void {
+
+    it('multiline ascii', () => {
       const input = 'This is ASCII text spanning multiple lines.';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -370,7 +364,8 @@ describe('Buffer', () => {
         assert.deepEqual([(i / terminal.cols) | 0, i % terminal.cols], bufferIndex);
       }
     });
-    it('combining e\u0301 in a sentence', function(): void {
+
+    it('combining e\u0301 in a sentence', () => {
       const input = 'Sitting in the cafe\u0301 drinking coffee.';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -389,7 +384,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i - 1) / terminal.cols) | 0, (i - 1) % terminal.cols], bufferIndex);
       }
     });
-    it('multiline combining e\u0301', function(): void {
+
+    it('multiline combining e\u0301', () => {
       const input = 'e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -400,7 +396,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i >> 1) / terminal.cols) | 0, (i >> 1) % terminal.cols], bufferIndex);
       }
     });
-    it('surrogate char in a sentence', function(): void {
+
+    it('surrogate char in a sentence', () => {
       const input = 'The 𝄞 is a clef widely used in modern notation.';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -419,7 +416,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i - 1) / terminal.cols) | 0, (i - 1) % terminal.cols], bufferIndex);
       }
     });
-    it('multiline surrogate char', function(): void {
+
+    it('multiline surrogate char', () => {
       const input = '𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -430,7 +428,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i >> 1) / terminal.cols) | 0, (i >> 1) % terminal.cols], bufferIndex);
       }
     });
-    it('surrogate char with combining', function(): void {
+
+    it('surrogate char with combining', () => {
       // eye of Ra with acute accent - string length of 3
       const input = '𓂀\u0301 - the eye hiroglyph with an acute accent.';
       terminal.writeSync(input);
@@ -444,7 +443,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i - 2) / terminal.cols) | 0, (i - 2) % terminal.cols], bufferIndex);
       }
     });
-    it('multiline surrogate with combining', function(): void {
+
+    it('multiline surrogate with combining', () => {
       const input = '𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -455,7 +455,8 @@ describe('Buffer', () => {
         assert.deepEqual([(((i / 3) | 0) / terminal.cols) | 0, ((i / 3) | 0) % terminal.cols], bufferIndex);
       }
     });
-    it('fullwidth chars', function(): void {
+
+    it('fullwidth chars', () => {
       const input = 'These １２３ are some fat numbers.';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -473,7 +474,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i + 3) / terminal.cols) | 0, (i + 3) % terminal.cols], bufferIndex);
       }
     });
-    it('multiline fullwidth chars', function(): void {
+
+    it('multiline fullwidth chars', () => {
       const input = '１２３４５６７８９０１２３４５６７８９０';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -483,7 +485,8 @@ describe('Buffer', () => {
         assert.deepEqual([((i << 1) / terminal.cols) | 0, (i << 1) % terminal.cols], bufferIndex);
       }
     });
-    it('fullwidth combining with emoji - match emoji cell', function(): void {
+
+    it('fullwidth combining with emoji - match emoji cell', () => {
       const input = 'Lots of ￥\u0301 make me 😃.';
       terminal.writeSync(input);
       const s = terminal.buffer.contents(true).toArray()[0];
@@ -492,7 +495,8 @@ describe('Buffer', () => {
       const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, stringIndex);
       assert(terminal.buffer.lines.get(bufferIndex[0]).get(bufferIndex[1])[CHAR_DATA_CHAR_INDEX], '😃');
     });
-    it('multiline fullwidth chars with offset 1 (currently tests for broken behavior)', function(): void {
+
+    it('multiline fullwidth chars with offset 1 (currently tests for broken behavior)', () => {
       const input = 'a１２３４５６７８９０１２３４５６７８９０';
       // the 'a' at the beginning moves all fullwidth chars one to the right
       // now the end of the line contains a dangling empty cell since

--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -355,33 +355,26 @@ describe('Buffer', () => {
       terminal.write = (s: string): void => {
         oldWrite(s);
         (terminal as any)._innerWrite();
-      }
+      };
     });
-    function wholeString(terminal: ITerminal, range : {first: number, last: number}): string {
-      let result = '';
-      for (let i = range.first; i <= range.last; ++i) {
-        result += terminal.buffer.translateBufferLineToString(i, i == range.last);
-      }
-      return result;
-    }
     it('multiline ascii', function(): void {
       const input = 'This is ASCII text spanning multiple lines.';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       for (let i = 0; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([(i/terminal.cols) | 0, i % terminal.cols], bufferIndex);
+        assert.deepEqual([(i / terminal.cols) | 0, i % terminal.cols], bufferIndex);
       }
     });
     it('combining e\u0301 in a sentence', function(): void {
       const input = 'Sitting in the cafe\u0301 drinking coffee.';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       for (let i = 0; i < 19; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([(i/terminal.cols) | 0, i % terminal.cols], bufferIndex);
+        assert.deepEqual([(i / terminal.cols) | 0, i % terminal.cols], bufferIndex);
       }
       // string index 18 & 19 point to combining char e\u0301 ---> same buffer Index
       assert.deepEqual(
@@ -390,28 +383,28 @@ describe('Buffer', () => {
       // after the combining char every string index has an offset of -1
       for (let i = 19; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i - 1)/terminal.cols) | 0, (i - 1) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i - 1) / terminal.cols) | 0, (i - 1) % terminal.cols], bufferIndex);
       }
     });
     it('multiline combining e\u0301', function(): void {
       const input = 'e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
-      // every buffer cell index contains 2 string indices 
+      // every buffer cell index contains 2 string indices
       for (let i = 0; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i >> 1)/terminal.cols) | 0, (i >> 1) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i >> 1) / terminal.cols) | 0, (i >> 1) % terminal.cols], bufferIndex);
       }
     });
     it('surrogate char in a sentence', function(): void {
       const input = 'The 𝄞 is a clef widely used in modern notation.';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       for (let i = 0; i < 5; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([(i/terminal.cols) | 0, i % terminal.cols], bufferIndex);
+        assert.deepEqual([(i / terminal.cols) | 0, i % terminal.cols], bufferIndex);
       }
       // string index 4 & 5 point to surrogate char 𝄞 ---> same buffer Index
       assert.deepEqual(
@@ -420,53 +413,53 @@ describe('Buffer', () => {
       // after the combining char every string index has an offset of -1
       for (let i = 5; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i - 1)/terminal.cols) | 0, (i - 1) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i - 1) / terminal.cols) | 0, (i - 1) % terminal.cols], bufferIndex);
       }
     });
     it('multiline surrogate char', function(): void {
       const input = '𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
-      // every buffer cell index contains 2 string indices 
+      // every buffer cell index contains 2 string indices
       for (let i = 0; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i >> 1)/terminal.cols) | 0, (i >> 1) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i >> 1) / terminal.cols) | 0, (i >> 1) % terminal.cols], bufferIndex);
       }
     });
     it('surrogate char with combining', function(): void {
       // eye of Ra with acute accent - string length of 3
       const input = '𓂀\u0301 - the eye hiroglyph with an acute accent.';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       // index 0..2 should map to 0
       assert.deepEqual([0, 0], terminal.buffer.stringIndexToBufferIndex(0, 1));
       assert.deepEqual([0, 0], terminal.buffer.stringIndexToBufferIndex(0, 2));
       for (let i = 2; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i - 2)/terminal.cols) | 0, (i - 2) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i - 2) / terminal.cols) | 0, (i - 2) % terminal.cols], bufferIndex);
       }
     });
     it('multiline surrogate with combining', function(): void {
       const input = '𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
-      // every buffer cell index contains 3 string indices 
+      // every buffer cell index contains 3 string indices
       for (let i = 0; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([(((i / 3) | 0) /terminal.cols) | 0, ((i / 3) | 0) % terminal.cols], bufferIndex);
+        assert.deepEqual([(((i / 3) | 0) / terminal.cols) | 0, ((i / 3) | 0) % terminal.cols], bufferIndex);
       }
     });
     it('fullwidth chars', function(): void {
       const input = 'These １２３ are some fat numbers.';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       for (let i = 0; i < 6; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([(i/terminal.cols) | 0, i % terminal.cols], bufferIndex);
+        assert.deepEqual([(i / terminal.cols) | 0, i % terminal.cols], bufferIndex);
       }
       // string index 6, 7, 8 take 2 cells
       assert.deepEqual([0, 8], terminal.buffer.stringIndexToBufferIndex(0, 7));
@@ -474,23 +467,23 @@ describe('Buffer', () => {
       // rest of the string has offset of +3
       for (let i = 9; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i + 3)/terminal.cols) | 0, (i + 3) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i + 3) / terminal.cols) | 0, (i + 3) % terminal.cols], bufferIndex);
       }
     });
     it('multiline fullwidth chars', function(): void {
       const input = '１２３４５６７８９０１２３４５６７８９０';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       for (let i = 9; i < input.length; ++i) {
         const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i);
-        assert.deepEqual([((i << 1)/terminal.cols) | 0, (i << 1) % terminal.cols], bufferIndex);
+        assert.deepEqual([((i << 1) / terminal.cols) | 0, (i << 1) % terminal.cols], bufferIndex);
       }
     });
     it('fullwidth combining with emoji - match emoji cell', function(): void {
       const input = 'Lots of ￥\u0301 make me 😃.';
       terminal.write(input);
-      const s = wholeString(terminal, terminal.buffer.getWrappedRangeForLine(0));
+      const s = terminal.buffer.contents(true).toArray()[0];
       assert.equal(input, s);
       const stringIndex = s.match(/😃/).index;
       const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, stringIndex);

--- a/src/Buffer.test.ts
+++ b/src/Buffer.test.ts
@@ -489,5 +489,22 @@ describe('Buffer', () => {
       const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, stringIndex);
       assert(terminal.buffer.lines.get(bufferIndex[0]).get(bufferIndex[1])[CHAR_DATA_CHAR_INDEX], '😃');
     });
+    it('multiline fullwidth chars with offset 1 (currently tests for broken behavior)', function(): void {
+      const input = 'a１２３４５６７８９０１２３４５６７８９０';
+      // the 'a' at the beginning moves all fullwidth chars one to the right
+      // now the end of the line contains a dangling empty cell since
+      // the next fullwidth char has to wrap early
+      // the dangling last cell is wrongly added in the string
+      // --> fixable after resolving #1685
+      terminal.write(input);
+      // TODO: reenable after fix
+      // const s = terminal.buffer.contents(true).toArray()[0];
+      // assert.equal(input, s);
+      for (let i = 10; i < input.length; ++i) {
+        const bufferIndex = terminal.buffer.stringIndexToBufferIndex(0, i + 1); // TODO: remove +1 after fix
+        const j = (i - 0) << 1;
+        assert.deepEqual([(j / terminal.cols) | 0, j % terminal.cols], bufferIndex);
+      }
+    });
   });
 });

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -374,7 +374,7 @@ export class Buffer implements IBuffer {
     this.markers.splice(this.markers.indexOf(marker), 1);
   }
 
-  public contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
+  public iterator(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
     return new BufferStringIterator(this, trimRight, startIndex, endIndex);
   }
 }

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -420,7 +420,7 @@ export class BufferStringIterator implements IBufferStringIterator {
     const range = this._buffer.getWrappedRangeForLine(this._current);
     let result = '';
     for (let i = range.first; i <= range.last; ++i) {
-      // TODO: always apply trimRight after fixing #1685 
+      // TODO: always apply trimRight after fixing #1685
       result += this._buffer.translateBufferLineToString(i, (this._trimRight) ? i === range.last : false);
     }
     this._current = range.last;

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -194,6 +194,26 @@ export class Buffer implements IBuffer {
     this.scrollBottom = newRows - 1;
   }
 
+  public stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[] {
+    if (!stringIndex) {
+      return [lineIndex, 0];
+    }
+    while (stringIndex) {
+      let line = this.lines.get(lineIndex);
+      if (!line) {
+        [-1, -1];
+      }
+      for (let i = 0; i < line.length; ++i) {
+        stringIndex -= line.get(i)[CHAR_DATA_CHAR_INDEX].length;
+        if (stringIndex < 0) {
+          return [lineIndex, i];
+        }
+      }
+      lineIndex++;
+    }
+    return [lineIndex, 0];
+  }
+
   /**
    * Translates a buffer line to a string, with optional start and end columns.
    * Wide characters will count as two columns in the resulting string. This

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -408,8 +408,8 @@ export class BufferStringIterator implements IBufferStringIterator {
     private _buffer: IBuffer,
     private _trimRight: boolean,
     private _startIndex: number = 0,
-    private _endIndex: number = _buffer.lines.length)
-  {
+    private _endIndex: number = _buffer.lines.length
+  ) {
     this._current = this._startIndex;
   }
 

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -199,7 +199,7 @@ export class Buffer implements IBuffer {
    * To get the correct buffer position the string must start at `startCol` 0
    * (default in translateBufferLineToString).
    * The method also works on wrapped line strings given rows were not trimmed.
-   * The method operates on the CharData width attribute, there are no
+   * The method operates on the CharData string length, there are no
    * additional content or boundary checks. Therefore the string and the buffer
    * should not be altered in between.
    * TODO: respect trim flag after fixing #1685
@@ -208,9 +208,6 @@ export class Buffer implements IBuffer {
    * @param startCol column offset the string was retrieved from
    */
   public stringIndexToBufferIndex(lineIndex: number, stringIndex: number): BufferIndex {
-    if (!stringIndex) {
-      return [lineIndex, 0];
-    }
     while (stringIndex) {
       const line = this.lines.get(lineIndex);
       if (!line) {

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -408,14 +408,17 @@ export class BufferStringIterator implements IBufferStringIterator {
   private _start: number;
   private _end: number;
   private _current: number;
+
   constructor (private _buffer: IBuffer, private _trimRight: boolean, startIndex?: number, endIndex?: number) {
     this._start = startIndex || 0;
     this._end = endIndex || this._buffer.lines.length;
     this._current = this._start;
   }
+
   public hasNext(): boolean {
     return this._current < this._end;
   }
+
   public next(withRanges: boolean = false): string | [{first: number, last: number}, string] {
     const range = this._buffer.getWrappedRangeForLine(this._current);
     let result = '';
@@ -423,12 +426,12 @@ export class BufferStringIterator implements IBufferStringIterator {
       // TODO: always apply trimRight after fixing #1685
       result += this._buffer.translateBufferLineToString(i, (this._trimRight) ? i === range.last : false);
     }
-    this._current = range.last;
-    this._current++;
+    this._current = range.last + 1;
     return (withRanges) ? [range, result] : result;
   }
-  toArray(): string[] {
-    const result: string[] = [];
+
+  public toArray(): string[] {
+    const result = [];
     while (this.hasNext()) {
       result.push(this.next() as string);
     }

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -405,18 +405,19 @@ export class Marker extends EventEmitter implements IMarker {
 }
 
 export class BufferStringIterator implements IBufferStringIterator {
-  private _start: number;
-  private _end: number;
   private _current: number;
 
-  constructor (private _buffer: IBuffer, private _trimRight: boolean, startIndex?: number, endIndex?: number) {
-    this._start = startIndex || 0;
-    this._end = endIndex || this._buffer.lines.length;
-    this._current = this._start;
+  constructor (
+    private _buffer: IBuffer,
+    private _trimRight: boolean,
+    private _startIndex: number = 0,
+    private _endIndex: number = _buffer.lines.length)
+  {
+    this._current = this._startIndex;
   }
 
   public hasNext(): boolean {
-    return this._current < this._end;
+    return this._current < this._endIndex;
   }
 
   public next(): IBufferStringIteratorResult {

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -4,7 +4,7 @@
  */
 
 import { CircularList } from './common/CircularList';
-import { CharData, ITerminal, IBuffer, IBufferLine, BufferIndex, IBufferStringIterator } from './Types';
+import { CharData, ITerminal, IBuffer, IBufferLine, BufferIndex, IBufferStringIterator, IBufferStringIteratorResult } from './Types';
 import { EventEmitter } from './common/EventEmitter';
 import { IMarker } from 'xterm';
 import { BufferLine } from './BufferLine';
@@ -419,7 +419,7 @@ export class BufferStringIterator implements IBufferStringIterator {
     return this._current < this._end;
   }
 
-  public next(withRanges: boolean = false): string | [{first: number, last: number}, string] {
+  public next(): IBufferStringIteratorResult {
     const range = this._buffer.getWrappedRangeForLine(this._current);
     let result = '';
     for (let i = range.first; i <= range.last; ++i) {
@@ -427,14 +427,6 @@ export class BufferStringIterator implements IBufferStringIterator {
       result += this._buffer.translateBufferLineToString(i, (this._trimRight) ? i === range.last : false);
     }
     this._current = range.last + 1;
-    return (withRanges) ? [range, result] : result;
-  }
-
-  public toArray(): string[] {
-    const result = [];
-    while (this.hasNext()) {
-      result.push(this.next() as string);
-    }
-    return result;
+    return {range: range, content: result};
   }
 }

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -202,6 +202,7 @@ export class Buffer implements IBuffer {
    * The method operates on the CharData width attribute, there are no
    * additional content or boundary checks. Therefore the string and the buffer
    * should not be altered in between.
+   * TODO: respect trim flag after fixing #1685
    * @param lineIndex line index the string was retrieved from
    * @param stringIndex index within the string
    * @param startCol column offset the string was retrieved from
@@ -419,6 +420,7 @@ export class BufferStringIterator implements IBufferStringIterator {
     const range = this._buffer.getWrappedRangeForLine(this._current);
     let result = '';
     for (let i = range.first; i <= range.last; ++i) {
+      // TODO: always apply trimRight after fixing #1685 
       result += this._buffer.translateBufferLineToString(i, (this._trimRight) ? i === range.last : false);
     }
     this._current = range.last;

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -194,6 +194,18 @@ export class Buffer implements IBuffer {
     this.scrollBottom = newRows - 1;
   }
 
+  /**
+   * Translates a string index back to a BufferIndex.
+   * To get the correct buffer position the string must start at `startCol` 0
+   * (default in translateBufferLineToString).
+   * The method also works on wrapped line strings given rows were not trimmed.
+   * The method operates on the CharData width attribute, there are no
+   * additional content or boundary checks. Therefore the string and the buffer
+   * should not be altered in between.
+   * @param lineIndex line index the string was retrieved from
+   * @param stringIndex index within the string
+   * @param startCol column offset the string was retrieved from
+   */
   public stringIndexToBufferIndex(lineIndex: number, stringIndex: number): BufferIndex {
     if (!stringIndex) {
       return [lineIndex, 0];

--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -4,7 +4,7 @@
  */
 
 import { CircularList } from './common/CircularList';
-import { CharData, ITerminal, IBuffer, IBufferLine } from './Types';
+import { CharData, ITerminal, IBuffer, IBufferLine, BufferIndex, IBufferStringIterator } from './Types';
 import { EventEmitter } from './common/EventEmitter';
 import { IMarker } from 'xterm';
 import { BufferLine } from './BufferLine';
@@ -194,12 +194,12 @@ export class Buffer implements IBuffer {
     this.scrollBottom = newRows - 1;
   }
 
-  public stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[] {
+  public stringIndexToBufferIndex(lineIndex: number, stringIndex: number): BufferIndex {
     if (!stringIndex) {
       return [lineIndex, 0];
     }
     while (stringIndex) {
-      let line = this.lines.get(lineIndex);
+      const line = this.lines.get(lineIndex);
       if (!line) {
         [-1, -1];
       }
@@ -360,6 +360,10 @@ export class Buffer implements IBuffer {
     // TODO: This could probably be optimized by relying on sort order and trimming the array using .length
     this.markers.splice(this.markers.indexOf(marker), 1);
   }
+
+  public contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
+    return new BufferStringIterator(this, trimRight, startIndex, endIndex);
+  }
 }
 
 export class Marker extends EventEmitter implements IMarker {
@@ -384,5 +388,36 @@ export class Marker extends EventEmitter implements IMarker {
     // Emit before super.dispose such that dispose listeners get a change to react
     this.emit('dispose');
     super.dispose();
+  }
+}
+
+export class BufferStringIterator implements IBufferStringIterator {
+  private _start: number;
+  private _end: number;
+  private _current: number;
+  constructor (private _buffer: IBuffer, private _trimRight: boolean, startIndex?: number, endIndex?: number) {
+    this._start = startIndex || 0;
+    this._end = endIndex || this._buffer.lines.length;
+    this._current = this._start;
+  }
+  public hasNext(): boolean {
+    return this._current < this._end;
+  }
+  public next(withRanges: boolean = false): string | [{first: number, last: number}, string] {
+    const range = this._buffer.getWrappedRangeForLine(this._current);
+    let result = '';
+    for (let i = range.first; i <= range.last; ++i) {
+      result += this._buffer.translateBufferLineToString(i, (this._trimRight) ? i === range.last : false);
+    }
+    this._current = range.last;
+    this._current++;
+    return (withRanges) ? [range, result] : result;
+  }
+  toArray(): string[] {
+    const result: string[] = [];
+    while (this.hasNext()) {
+      result.push(this.next() as string);
+    }
+    return result;
   }
 }

--- a/src/CharWidth.test.ts
+++ b/src/CharWidth.test.ts
@@ -21,8 +21,8 @@ describe('getStringCellWidth', function(): void {
     let result = 0;
     for (let i = start; i < end; ++i) {
       const line = buffer.lines.get(i);
-      for (let j = 0; j < line.length; ++i) { // TODO: change to trimBorder with multiline
-        const ch = line.get(i);
+      for (let j = 0; j < line.length; ++j) { // TODO: change to trimBorder with multiline
+        const ch = line.get(j);
         result += ch[CHAR_DATA_WIDTH_INDEX];
         // return on sentinel
         if (ch[CHAR_DATA_CHAR_INDEX] === sentinel) {

--- a/src/CharWidth.test.ts
+++ b/src/CharWidth.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { TestTerminal } from './utils/TestUtils.test';
+import { assert } from 'chai';
+import { getStringCellWidth } from './CharWidth';
+import { IBuffer } from './Types';
+import { CHAR_DATA_WIDTH_INDEX, CHAR_DATA_CHAR_INDEX } from './Buffer';
+
+
+describe('getStringCellWidth', function(): void {
+  let terminal: TestTerminal;
+
+  beforeEach(() => {
+    terminal = new TestTerminal({rows: 5, cols: 30});
+  });
+
+  function sumWidths(buffer: IBuffer, start: number, end: number, sentinel: string): number {
+    let result = 0;
+    for (let i = start; i < end; ++i) {
+      const line = buffer.lines.get(i);
+      for (let j = 0; j < line.length; ++i) { // TODO: change to trimBorder with multiline
+        const ch = line.get(i);
+        result += ch[CHAR_DATA_WIDTH_INDEX];
+        // return on sentinel
+        if (ch[CHAR_DATA_CHAR_INDEX] === sentinel) {
+          return result;
+        }
+      }
+    }
+    return result;
+  }
+
+  it('ASCII chars', function(): void {
+    const input = 'This is just ASCII text.#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  it('combining chars', function(): void {
+    const input = 'e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  it('surrogate chars', function(): void {
+    const input = '𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  it('surrogate combining chars', function(): void {
+    const input = '𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  it('fullwidth chars', function(): void {
+    const input = '１２３４５６７８９０#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  it('fullwidth chars offset 1', function(): void {
+    const input = 'a１２３４５６７８９０#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  // TODO: multiline tests once #1685 is resolved
+});

--- a/src/CharWidth.ts
+++ b/src/CharWidth.ts
@@ -169,3 +169,26 @@ export const wcwidth = (function(opts: {nul: number, control: number}): (ucs: nu
       return wcwidthHigh(num);
     };
 })({nul: 0, control: 0});  // configurable options
+
+/**
+ * Get the terminal cell width for a string.
+ * @param s
+ */
+export function stringWidth(s: string): number {
+  let result = 0;
+  for (let i = 0; i < s.length; ++i) {
+    let code = s.charCodeAt(i);
+    if (0xD800 <= code && code <= 0xDBFF) {
+      const low = s.charCodeAt(i + 1);
+      if (isNaN(low)) {
+        return result;
+      }
+      code = ((code - 0xD800) * 0x400) + (low - 0xDC00) + 0x10000;
+    }
+    if (0xDC00 <= code && code <= 0xDFFF) {
+      continue;
+    }
+    result += wcwidth(code);
+  }
+  return result;
+}

--- a/src/CharWidth.ts
+++ b/src/CharWidth.ts
@@ -172,9 +172,8 @@ export const wcwidth = (function(opts: {nul: number, control: number}): (ucs: nu
 
 /**
  * Get the terminal cell width for a string.
- * @param s
  */
-export function stringWidth(s: string): number {
+export function getStringCellWidth(s: string): number {
   let result = 0;
   for (let i = 0; i < s.length; ++i) {
     let code = s.charCodeAt(i);

--- a/src/Linkifier.test.ts
+++ b/src/Linkifier.test.ts
@@ -271,35 +271,69 @@ describe('Linkifier', () => {
       }, 0);
     }
 
-    it('combining before - match within one line', function(done: () => void): void {
-      assertLinkifiesInTerminal('e\u0301e\u0301e\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+    describe('unicode before the match', function(): void {
+      it('combining - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('e\u0301e\u0301e\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+      });
+      it('combining - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('e\u0301e\u0301e\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      });
+      it('surrogate - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('𝄞𝄞𝄞 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+      });
+      it('surrogate - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('𝄞𝄞𝄞     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      });
+      it('combining surrogate - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+      });
+      it('combining surrogate - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      });
+      it('fullwidth - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('１２ foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      });
+      it('fullwidth - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('１２    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      });
+      it('combining fullwidth - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('￥\u0301￥\u0301 foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      });
+      it('combining fullwidth - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('￥\u0301￥\u0301    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      });
     });
-    it('combining before - match over two lines', function(done: () => void): void {
-      assertLinkifiesInTerminal('e\u0301e\u0301e\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
-    });
-    it('surrogate before - match within one line', function(done: () => void): void {
-      assertLinkifiesInTerminal('𝄞𝄞𝄞 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
-    });
-    it('surrogate before - match over two lines', function(done: () => void): void {
-      assertLinkifiesInTerminal('𝄞𝄞𝄞     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
-    });
-    it('combining surrogate before - match within one line', function(done: () => void): void {
-      assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
-    });
-    it('combining surrogate before - match over two lines', function(done: () => void): void {
-      assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
-    });
-    it('fullwidth before - match within one line', function(done: () => void): void {
-      assertLinkifiesInTerminal('１２ foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
-    });
-    it('fullwidth before - match over two lines', function(done: () => void): void {
-      assertLinkifiesInTerminal('１２    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
-    });
-    it('combining fullwidth before - match within one line', function(done: () => void): void {
-      assertLinkifiesInTerminal('￥\u0301￥\u0301 foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
-    });
-    it('combining fullwidth before - match over two lines', function(done: () => void): void {
-      assertLinkifiesInTerminal('￥\u0301￥\u0301    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+    describe('unicode within the match', function(): void {
+      it('combining - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('test cafe\u0301', /cafe\u0301/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
+      });
+      it('combining - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('testtest cafe\u0301', /cafe\u0301/, [{x1: 9, x2: 3, y1: 0, y2: 1}], done);
+      });
+      it('surrogate - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('test a𝄞b', /a𝄞b/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      });
+      it('surrogate - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('testtest a𝄞b', /a𝄞b/, [{x1: 9, x2: 2, y1: 0, y2: 1}], done);
+      });
+      it('combining surrogate - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('test a𓂀\u0301b', /a𓂀\u0301b/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      });
+      it('combining surrogate - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('testtest a𓂀\u0301b', /a𓂀\u0301b/, [{x1: 9, x2: 2, y1: 0, y2: 1}], done);
+      });
+      it('fullwidth - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('test a１b', /a１b/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
+      });
+      it('fullwidth - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('testtest a１b', /a１b/, [{x1: 9, x2: 3, y1: 0, y2: 1}], done);
+      });
+      it('combining fullwidth - match within one line', function(done: () => void): void {
+        assertLinkifiesInTerminal('test a￥\u0301b', /a￥\u0301b/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
+      });
+      it('combining fullwidth - match over two lines', function(done: () => void): void {
+        assertLinkifiesInTerminal('testtest a￥\u0301b', /a￥\u0301b/, [{x1: 9, x2: 3, y1: 0, y2: 1}], done);
+      });
     });
   });
 });

--- a/src/Linkifier.test.ts
+++ b/src/Linkifier.test.ts
@@ -7,10 +7,9 @@ import { assert } from 'chai';
 import { IMouseZoneManager, IMouseZone } from './ui/Types';
 import { ILinkMatcher, ITerminal, IBufferLine } from './Types';
 import { Linkifier } from './Linkifier';
-import { MockBuffer, MockTerminal } from './utils/TestUtils.test';
+import { MockBuffer, MockTerminal, TestTerminal } from './utils/TestUtils.test';
 import { CircularList } from './common/CircularList';
 import { BufferLine } from './BufferLine';
-import { Terminal } from './Terminal';
 
 class TestLinkifier extends Linkifier {
   constructor(terminal: ITerminal) {
@@ -239,23 +238,20 @@ describe('Linkifier', () => {
       });
     });
   });
-  describe('unicode handling', function(): void {
+  describe('unicode handling', () => {
+    let terminal: TestTerminal;
+
     // other than the tests above unicode testing needs the full terminal instance
     // to get the special handling of fullwidth, surrogate and combining chars in the input handler
-    beforeEach(function(): void {
-      terminal = new Terminal({cols: 10, rows: 5});
-      const oldWrite: any = terminal.write.bind(terminal);
-      terminal.write = (s: string): void => {
-        oldWrite(s);
-        (terminal as any)._innerWrite();
-      };
+    beforeEach(() => {
+      terminal = new TestTerminal({cols: 10, rows: 5});
       linkifier = new TestLinkifier(terminal);
       mouseZoneManager = new TestMouseZoneManager();
       linkifier.attachToDom(mouseZoneManager);
     });
 
     function assertLinkifiesInTerminal(rowText: string, linkMatcherRegex: RegExp, links: {x1: number, y1: number, x2: number, y2: number}[], done: MochaDone): void {
-      terminal.write(rowText);
+      terminal.writeSync(rowText);
       linkifier.registerLinkMatcher(linkMatcherRegex, () => {});
       linkifier.linkifyRows();
       // Allow linkify to happen
@@ -271,7 +267,7 @@ describe('Linkifier', () => {
       }, 0);
     }
 
-    describe('unicode before the match', function(): void {
+    describe('unicode before the match', () => {
       it('combining - match within one line', function(done: () => void): void {
         assertLinkifiesInTerminal('e\u0301e\u0301e\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
       });
@@ -303,7 +299,7 @@ describe('Linkifier', () => {
         assertLinkifiesInTerminal('￥\u0301￥\u0301    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
       });
     });
-    describe('unicode within the match', function(): void {
+    describe('unicode within the match', () => {
       it('combining - match within one line', function(done: () => void): void {
         assertLinkifiesInTerminal('test cafe\u0301', /cafe\u0301/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
       });

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -255,7 +255,6 @@ export class Linkifier extends EventEmitter implements ILinkifier {
       y2--;
     }
 
-
     this._mouseZoneManager.add(new MouseZone(
       x1 + 1,
       y1 + 1,

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -4,7 +4,7 @@
  */
 
 import { IMouseZoneManager } from './ui/Types';
-import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes, ILinkMatcherOptions, ILinkifier, ITerminal, IBufferLine } from './Types';
+import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes, ILinkMatcherOptions, ILinkifier, ITerminal } from './Types';
 import { MouseZone } from './ui/MouseZoneManager';
 import { EventEmitter } from './common/EventEmitter';
 import { CHAR_DATA_ATTR_INDEX } from './Buffer';
@@ -159,11 +159,10 @@ export class Linkifier extends EventEmitter implements ILinkifier {
    */
   private _linkifyRow(rowIndex: number): void {
     // Ensure the row exists
-    let absoluteRowIndex = this._terminal.buffer.ydisp + rowIndex;
+    const absoluteRowIndex = this._terminal.buffer.ydisp + rowIndex;
     if (absoluteRowIndex >= this._terminal.buffer.lines.length) {
       return;
     }
-    
     const unwrappedLinesIterator = this._terminal.buffer.contents(false, absoluteRowIndex, absoluteRowIndex + 1);
     while (unwrappedLinesIterator.hasNext()) {
       for (let i = 0; i < this._linkMatchers.length; i++) {

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -93,8 +93,8 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     // we skip those later in _doLinkifyRow
     const linesIterator = this._terminal.buffer.contents(false, absoluteRowIndexStart, this._terminal.buffer.ydisp + this._rowsToLinkify.end + 1);
     while (linesIterator.hasNext()) {
+      const lineData: any = linesIterator.next(true);
       for (let i = 0; i < this._linkMatchers.length; i++) {
-        const lineData: any = linesIterator.next(true);
         this._doLinkifyRow(lineData[0].first, lineData[1], this._linkMatchers[i]);
       }
     }
@@ -182,6 +182,12 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     let stringIndex = -1;
     while ((match = rex.exec(text)) !== null) {
       const uri = match[typeof matcher.matchIndex !== 'number' ? 0 : matcher.matchIndex];
+      if (!uri) {
+        // something matched but does not comply with the given matchIndex
+        // since this is most likely a bug the regex itself we simply do nothing here
+        // TODO: should this be logged for debugging?
+        break;
+      }
 
       // due to complex regexes we cannot use match.index directly
       // instead we search the position of the match group in text again TODO: Can this be avoided?

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -186,7 +186,11 @@ export class Linkifier extends EventEmitter implements ILinkifier {
       if (!uri) {
         // something matched but does not comply with the given matchIndex
         // since this is most likely a bug the regex itself we simply do nothing here
-        // TODO: should this be logged for debugging?
+        // DEBUG: print match and throw
+        if ((<any>this._terminal).debug) {
+          console.log({match, matcher});
+          throw new Error('match found without corresponding matchIndex');
+        }
         break;
       }
 

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -91,9 +91,9 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     // _doLinkifyRow gets full unwrapped lines with the start row as buffer offset for every matcher
     // for wrapped content over several rows the iterator might return rows outside the viewport
     // we skip those later in _doLinkifyRow
-    const linesIterator = this._terminal.buffer.contents(false, absoluteRowIndexStart, this._terminal.buffer.ydisp + this._rowsToLinkify.end + 1);
-    while (linesIterator.hasNext()) {
-      const lineData: IBufferStringIteratorResult = linesIterator.next();
+    const iterator = this._terminal.buffer.iterator(false, absoluteRowIndexStart, this._terminal.buffer.ydisp + this._rowsToLinkify.end + 1);
+    while (iterator.hasNext()) {
+      const lineData: IBufferStringIteratorResult = iterator.next();
       for (let i = 0; i < this._linkMatchers.length; i++) {
         this._doLinkifyRow(lineData.range.first, lineData.content, this._linkMatchers[i]);
       }

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -4,7 +4,7 @@
  */
 
 import { IMouseZoneManager } from './ui/Types';
-import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes, ILinkMatcherOptions, ILinkifier, ITerminal } from './Types';
+import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes, ILinkMatcherOptions, ILinkifier, ITerminal, IBufferStringIteratorResult } from './Types';
 import { MouseZone } from './ui/MouseZoneManager';
 import { EventEmitter } from './common/EventEmitter';
 import { CHAR_DATA_ATTR_INDEX } from './Buffer';
@@ -93,9 +93,9 @@ export class Linkifier extends EventEmitter implements ILinkifier {
     // we skip those later in _doLinkifyRow
     const linesIterator = this._terminal.buffer.contents(false, absoluteRowIndexStart, this._terminal.buffer.ydisp + this._rowsToLinkify.end + 1);
     while (linesIterator.hasNext()) {
-      const lineData: any = linesIterator.next(true);
+      const lineData: IBufferStringIteratorResult = linesIterator.next();
       for (let i = 0; i < this._linkMatchers.length; i++) {
-        this._doLinkifyRow(lineData[0].first, lineData[1], this._linkMatchers[i]);
+        this._doLinkifyRow(lineData.range.first, lineData.content, this._linkMatchers[i]);
       }
     }
 

--- a/src/Linkifier.ts
+++ b/src/Linkifier.ts
@@ -8,6 +8,7 @@ import { ILinkHoverEvent, ILinkMatcher, LinkMatcherHandler, LinkHoverEventTypes,
 import { MouseZone } from './ui/MouseZoneManager';
 import { EventEmitter } from './common/EventEmitter';
 import { CHAR_DATA_ATTR_INDEX } from './Buffer';
+import { stringWidth } from './CharWidth';
 
 /**
  * The Linkifier applies links to rows shortly after they have been refreshed.
@@ -222,14 +223,16 @@ export class Linkifier extends EventEmitter implements ILinkifier {
    * @param fg The link color for hover event.
    */
   private _addLink(x: number, y: number, uri: string, matcher: ILinkMatcher, fg: number): void {
+    const length = stringWidth(uri);
     const x1 = x % this._terminal.cols;
     const y1 = y + Math.floor(x / this._terminal.cols);
-    let x2 = (x1 + uri.length) % this._terminal.cols;
-    let y2 = y1 + Math.floor((x1 + uri.length) / this._terminal.cols);
+    let x2 = (x1 + length) % this._terminal.cols;
+    let y2 = y1 + Math.floor((x1 + length) / this._terminal.cols);
     if (x2 === 0) {
       x2 = this._terminal.cols;
       y2--;
     }
+
 
     this._mouseZoneManager.add(new MouseZone(
       x1 + 1,

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -19,6 +19,9 @@ export type LinkMatcherValidationCallback = (uri: string, callback: (isValid: bo
 
 export type CharacterJoinerHandler = (text: string) => [number, number][];
 
+// BufferIndex denotes a position in the buffer: [rowIndex, colIndex]
+export type BufferIndex = [number, number];
+
 export const enum LinkHoverEventTypes {
   HOVER = 'linkhover',
   TOOLTIP = 'linktooltip',
@@ -265,6 +268,12 @@ export interface ITerminalOptions extends IPublicTerminalOptions {
   useFlowControl?: boolean;
 }
 
+export interface IBufferStringIterator {
+  hasNext(): boolean;
+  next(withRanges: boolean): string | [{first: number, last: number}, string];
+  toArray(): string[];
+}
+
 export interface IBuffer {
   readonly lines: ICircularList<IBufferLine>;
   ydisp: number;
@@ -283,6 +292,7 @@ export interface IBuffer {
   nextStop(x?: number): number;
   prevStop(x?: number): number;
   stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[];
+  contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator;
 }
 
 export interface IBufferSet extends IEventEmitter {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -271,7 +271,6 @@ export interface ITerminalOptions extends IPublicTerminalOptions {
 export interface IBufferStringIterator {
   hasNext(): boolean;
   next(withRanges: boolean): string | [{first: number, last: number}, string];
-  toArray(): string[];
 }
 
 export interface IBuffer {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -282,6 +282,7 @@ export interface IBuffer {
   getWrappedRangeForLine(y: number): { first: number, last: number };
   nextStop(x?: number): number;
   prevStop(x?: number): number;
+  stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[];
 }
 
 export interface IBufferSet extends IEventEmitter {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -268,10 +268,14 @@ export interface ITerminalOptions extends IPublicTerminalOptions {
   useFlowControl?: boolean;
 }
 
+export interface IBufferStringIteratorResult {
+  range: {first: number, last: number};
+  content: string;
+}
+
 export interface IBufferStringIterator {
   hasNext(): boolean;
-  next(withRanges: boolean): string | [{first: number, last: number}, string];
-  toArray(): string[];
+  next(): IBufferStringIteratorResult;
 }
 
 export interface IBuffer {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -271,6 +271,7 @@ export interface ITerminalOptions extends IPublicTerminalOptions {
 export interface IBufferStringIterator {
   hasNext(): boolean;
   next(withRanges: boolean): string | [{first: number, last: number}, string];
+  toArray(): string[];
 }
 
 export interface IBuffer {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -296,7 +296,7 @@ export interface IBuffer {
   nextStop(x?: number): number;
   prevStop(x?: number): number;
   stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[];
-  contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator;
+  iterator(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator;
 }
 
 export interface IBufferSet extends IEventEmitter {

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -322,8 +322,8 @@ export class MockBuffer implements IBuffer {
   stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[] {
     return Buffer.prototype.stringIndexToBufferIndex.apply(this, arguments);
   }
-  contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
-    return Buffer.prototype.contents.apply(this, arguments);
+  iterator(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
+    return Buffer.prototype.iterator.apply(this, arguments);
   }
 }
 

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -6,7 +6,7 @@
 import { IColorSet, IRenderer, IRenderDimensions, IColorManager } from '../renderer/Types';
 import { IInputHandlingTerminal, IViewport, ICompositionHelper, ITerminal, IBuffer, IBufferSet, IBrowser, ICharMeasure, ISelectionManager, ITerminalOptions, ILinkifier, IMouseHelper, ILinkMatcherOptions, CharacterJoinerHandler, IBufferLine, IBufferStringIterator } from '../Types';
 import { ICircularList, XtermListener } from '../common/Types';
-import { Buffer } from '../Buffer';
+import { Buffer, BufferStringIterator } from '../Buffer';
 import * as Browser from '../shared/utils/Browser';
 import { ITheme, IDisposable, IMarker } from 'xterm';
 
@@ -300,7 +300,7 @@ export class MockBuffer implements IBuffer {
     return Buffer.prototype.translateBufferLineToString.apply(this, arguments);
   }
   getWrappedRangeForLine(y: number): { first: number; last: number; } {
-    throw new Error('Method not implemented.');
+    return Buffer.prototype.getWrappedRangeForLine.apply(this, arguments);
   }
   nextStop(x?: number): number {
     throw new Error('Method not implemented.');
@@ -312,10 +312,10 @@ export class MockBuffer implements IBuffer {
     this.lines = lines;
   }
   stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[] {
-    throw new Error('Method not implemented.');
+    return Buffer.prototype.stringIndexToBufferIndex.apply(this, arguments);
   }
   contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
-    throw new Error('Method not implemented.');
+    return Buffer.prototype.contents.apply(this, arguments);
   }
 }
 

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -6,7 +6,7 @@
 import { IColorSet, IRenderer, IRenderDimensions, IColorManager } from '../renderer/Types';
 import { IInputHandlingTerminal, IViewport, ICompositionHelper, ITerminal, IBuffer, IBufferSet, IBrowser, ICharMeasure, ISelectionManager, ITerminalOptions, ILinkifier, IMouseHelper, ILinkMatcherOptions, CharacterJoinerHandler, IBufferLine, IBufferStringIterator } from '../Types';
 import { ICircularList, XtermListener } from '../common/Types';
-import { Buffer, BufferStringIterator } from '../Buffer';
+import { Buffer } from '../Buffer';
 import * as Browser from '../shared/utils/Browser';
 import { ITheme, IDisposable, IMarker } from 'xterm';
 

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -9,6 +9,14 @@ import { ICircularList, XtermListener } from '../common/Types';
 import { Buffer } from '../Buffer';
 import * as Browser from '../shared/utils/Browser';
 import { ITheme, IDisposable, IMarker } from 'xterm';
+import { Terminal } from '../Terminal';
+
+export class TestTerminal extends Terminal {
+  writeSync(data: string): void {
+    this.writeBuffer.push(data);
+    this._innerWrite();
+  }
+}
 
 export class MockTerminal implements ITerminal {
   markers: IMarker[];

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { IColorSet, IRenderer, IRenderDimensions, IColorManager } from '../renderer/Types';
-import { IInputHandlingTerminal, IViewport, ICompositionHelper, ITerminal, IBuffer, IBufferSet, IBrowser, ICharMeasure, ISelectionManager, ITerminalOptions, ILinkifier, IMouseHelper, ILinkMatcherOptions, CharacterJoinerHandler, IBufferLine } from '../Types';
+import { IInputHandlingTerminal, IViewport, ICompositionHelper, ITerminal, IBuffer, IBufferSet, IBrowser, ICharMeasure, ISelectionManager, ITerminalOptions, ILinkifier, IMouseHelper, ILinkMatcherOptions, CharacterJoinerHandler, IBufferLine, IBufferStringIterator } from '../Types';
 import { ICircularList, XtermListener } from '../common/Types';
 import { Buffer } from '../Buffer';
 import * as Browser from '../shared/utils/Browser';
@@ -310,6 +310,12 @@ export class MockBuffer implements IBuffer {
   }
   setLines(lines: ICircularList<IBufferLine>): void {
     this.lines = lines;
+  }
+  stringIndexToBufferIndex(lineIndex: number, stringIndex: number): number[] {
+    throw new Error('Method not implemented.');
+  }
+  contents(trimRight: boolean, startIndex?: number, endIndex?: number): IBufferStringIterator {
+    throw new Error('Method not implemented.');
   }
 }
 


### PR DESCRIPTION
Had to do several changes to get the cell/length offset mess working. This PR shall fix #1669.

**Changes in `Buffer.ts`:**
- `BufferStringIterator`: class to get a hold of the buffer string content in a convenient way
- `Buffer.stringIndexToBufferIndex`: method to translate a string index from a string retrieved by `Buffer.translateBufferLineToString` to get the row and cols indices in the buffer. Atm this method assumes that the string started at col 0. ~(Can be changed easily to respect `startCol` as well.)~
- `Buffer.contents`: return a `BufferStringIterator`

**Changes in `Linkifier.ts`:**
- reimplemented `_linkifyRow` and `_doLinkifyRow`

**TODO:**

- [x] reimplement `Linkifier._addLink` to support unicode char offsets within a match (currently only pre/post match offsets are respected)
- [x] tests for unicode chars in linkifier

~@alexr00 The new methods in `Buffer` can also fix the highlight offset problems of the selection manager. Might be worth a look once this PR can land.~ ~_Seems to work now._~ issue created #1680 + #1686 