### PR TITLE
Fixed translateBufferLineToStringWithWrap to correctly not remove spaces in the middle of a multiline wrapped string

### DIFF
--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -170,10 +170,10 @@ export class SearchHelper implements ISearchHelper {
     let lineWrapsToNext: boolean;
 
     do {
-      lineString += this._terminal._core.buffer.translateBufferLineToString(lineIndex, true);
-      lineIndex++;
       const nextLine = this._terminal._core.buffer.lines.get(lineIndex);
-      lineWrapsToNext = nextLine ? this._terminal._core.buffer.lines.get(lineIndex).isWrapped : false;
+      lineWrapsToNext = nextLine ? nextLine.isWrapped : false;
+      lineString += this._terminal._core.buffer.translateBufferLineToString(lineIndex, !lineWrapsToNext && trimRight);
+      lineIndex++;
     } while (lineWrapsToNext);
 
     return lineString;

--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -170,7 +170,7 @@ export class SearchHelper implements ISearchHelper {
     let lineWrapsToNext: boolean;
 
     do {
-      const nextLine = this._terminal._core.buffer.lines.get(lineIndex);
+      const nextLine = this._terminal._core.buffer.lines.get(lineIndex + 1);
       lineWrapsToNext = nextLine ? nextLine.isWrapped : false;
       lineString += this._terminal._core.buffer.translateBufferLineToString(lineIndex, !lineWrapsToNext && trimRight);
       lineIndex++;

--- a/src/addons/search/search.test.ts
+++ b/src/addons/search/search.test.ts
@@ -59,14 +59,15 @@ describe('search addon', () => {
       search.apply(<any>MockTerminal);
       const term = new MockTerminal({cols: 10, rows: 5});
       term.core.write('texttextHellotext\r\n');
-      term.core.write('texttexttextHellotext');
+      term.core.write('texttexttextHellotext         goodbye');
       term.pushWriteData();
       /*
         texttextHe
         llotext
         texttextte
         xtHellotex
-        t
+        t         (these spaces included intentionally)
+        goodbye
       */
 
       const hello0 = (term.searchHelper as any)._findInLine('Hello', 0);
@@ -74,11 +75,13 @@ describe('search addon', () => {
       const hello2 = (term.searchHelper as any)._findInLine('Hello', 2);
       const hello3 = (term.searchHelper as any)._findInLine('Hello', 3);
       const llo = (term.searchHelper as any)._findInLine('llo', 1);
+      const goodbye = (term.searchHelper as any)._findInLine('goodbye', 2);
       expect(hello0).eql({col: 8, row: 0, term: 'Hello'});
       expect(hello1).eql(undefined);
       expect(hello2).eql({col: 2, row: 3, term: 'Hello'});
       expect(hello3).eql(undefined);
       expect(llo).eql(undefined);
+      expect(goodbye).eql({col: 0, row: 5, term: 'goodbye'});
     });
     it('should respect search regex', () => {
       search.apply(<any>MockTerminal);


### PR DESCRIPTION
Fixes #1680 
