### PR TITLE
Expose Viewport syncScrollArea() to Terminal and include force param

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1287,6 +1287,10 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     }
   }
 
+  public syncScrollArea(force?: boolean): void {
+    this.viewport.syncScrollArea(force);
+  }
+
   /**
    * Writes text to the terminal.
    * @param data The text to write to the terminal.

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -91,7 +91,7 @@ export interface IInputHandlingTerminal extends IEventEmitter {
 
 export interface IViewport extends IDisposable {
   scrollBarWidth: number;
-  syncScrollArea(): void;
+  syncScrollArea(force?: boolean): void;
   getLinesScrolled(ev: WheelEvent): number;
   onWheel(ev: WheelEvent): void;
   onTouchStart(ev: TouchEvent): void;

--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -96,7 +96,7 @@ export class Viewport extends Disposable implements IViewport {
   /**
    * Updates dimensions and synchronizes the scroll area if necessary.
    */
-  public syncScrollArea(): void {
+  public syncScrollArea(force?: boolean): void {
     if (this._lastRecordedBufferLength !== this._terminal.buffer.lines.length) {
       // If buffer height changed
       this._lastRecordedBufferLength = this._terminal.buffer.lines.length;
@@ -104,11 +104,11 @@ export class Viewport extends Disposable implements IViewport {
     } else if (this._lastRecordedViewportHeight !== (<any>this._terminal).renderer.dimensions.canvasHeight) {
       // If viewport height changed
       this._refresh();
-    } else {
+    } else if (this._terminal.renderer.dimensions.scaledCellHeight / window.devicePixelRatio !== this._currentRowHeight) {
       // If size has changed, refresh viewport
-      if (this._terminal.renderer.dimensions.scaledCellHeight / window.devicePixelRatio !== this._currentRowHeight) {
-        this._refresh();
-      }
+      this._refresh();
+    } else if (force) {
+      this._refresh();
     }
   }
 

--- a/src/public/Terminal.ts
+++ b/src/public/Terminal.ts
@@ -110,6 +110,9 @@ export class Terminal implements ITerminalApi {
   public scrollToLine(line: number): void {
     this._core.scrollToLine(line);
   }
+  public syncScrollArea(force?: boolean): void {
+    this._core.syncScrollArea(force);
+  }
   public clear(): void {
     this._core.clear();
   }

--- a/src/utils/TestUtils.test.ts
+++ b/src/utils/TestUtils.test.ts
@@ -87,6 +87,9 @@ export class MockTerminal implements ITerminal {
   scrollToBottom(): void {
     throw new Error('Method not implemented.');
   }
+  syncScrollArea(force?: boolean): void {
+    throw new Error('Method not implemented.');
+  }
   clear(): void {
     throw new Error('Method not implemented.');
   }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -603,6 +603,12 @@ declare module 'xterm' {
     scrollToLine(line: number): void;
 
     /**
+     * Syncs the scroll area of the underlying viewport
+     * @param line force a refresh.
+     */
+    syncScrollArea(force?: boolean): void;
+
+    /**
      * Clear the entire buffer, making the prompt line the new first line.
      */
     clear(): void;


### PR DESCRIPTION
To allow explicit invocation of scroll sync.

See: https://github.com/Microsoft/vscode/issues/58532