### PR TITLE
Fill lines inserted from scrolling with erase attributes

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1174,7 +1174,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
    * @param isWrapped Whether the new line is wrapped from the previous line.
    */
   public scroll(isWrapped?: boolean): void {
-    const newLine = this.buffer.getBlankLine(DEFAULT_ATTR, isWrapped);
+    const newLine = this.buffer.getBlankLine(this.eraseAttr(), isWrapped);
     const topRow = this.buffer.ybase + this.buffer.scrollTop;
     const bottomRow = this.buffer.ybase + this.buffer.scrollBottom;
 


### PR DESCRIPTION
When scrolling occurs due to a LF or scroll code, the new line should be
filled with the currently set background color.  As with VTE, fill with
the _default_ color if the new line was caused by line-wrap.