### PR TITLE
Get correct col/row coords from mouse event

### DIFF
--- a/src/utils/MouseHelper.test.ts
+++ b/src/utils/MouseHelper.test.ts
@@ -49,13 +49,14 @@ describe('MouseHelper.getCoords', () => {
 
   it('should return the cell that was clicked', () => {
     let coords: [number, number];
-    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH / 2, pageY: CHAR_HEIGHT / 2 }, document.createElement('div'), charMeasure, 1, 10, 10);
+    const element = document.createElement('div');
+    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH / 2, pageY: CHAR_HEIGHT / 2 }, element, charMeasure, 1, 10, 10);
     assert.deepEqual(coords, [1, 1]);
-    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH, pageY: CHAR_HEIGHT }, document.createElement('div'), charMeasure, 1, 10, 10);
+    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH - 1, pageY: CHAR_HEIGHT - 1 }, element, charMeasure, 1, 10, 10);
     assert.deepEqual(coords, [1, 1]);
-    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH, pageY: CHAR_HEIGHT + 1 }, document.createElement('div'), charMeasure, 1, 10, 10);
+    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH - 1, pageY: CHAR_HEIGHT }, element, charMeasure, 1, 10, 10);
     assert.deepEqual(coords, [1, 2]);
-    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH + 1, pageY: CHAR_HEIGHT }, document.createElement('div'), charMeasure, 1, 10, 10);
+    coords = mouseHelper.getCoords({ pageX: CHAR_WIDTH, pageY: CHAR_HEIGHT - 1 }, element, charMeasure, 1, 10, 10);
     assert.deepEqual(coords, [2, 1]);
   });
 

--- a/src/utils/MouseHelper.ts
+++ b/src/utils/MouseHelper.ts
@@ -32,7 +32,7 @@ export class MouseHelper {
       y += element.scrollTop;
       element = <HTMLElement>element.parentElement;
     }
-    return [x, y];
+    return [x, y + 1];
   }
 
   /**
@@ -59,8 +59,8 @@ export class MouseHelper {
       return null;
     }
 
-    coords[0] = Math.ceil((coords[0] + (isSelection ? this._renderer.dimensions.actualCellWidth / 2 : 0)) / this._renderer.dimensions.actualCellWidth);
-    coords[1] = Math.ceil(coords[1] / this._renderer.dimensions.actualCellHeight);
+    coords[0] = Math.floor((coords[0] + (isSelection ? this._renderer.dimensions.actualCellWidth / 2 : 0)) / this._renderer.dimensions.actualCellWidth) + 1;
+    coords[1] = Math.floor(coords[1] / this._renderer.dimensions.actualCellHeight) + 1;
 
     // Ensure coordinates are within the terminal viewport. Note that selections
     // need an addition point of precision to cover the end point (as characters


### PR DESCRIPTION
Before the y from getCoords could be -1, a ceil call was also causing
a single pixel offset in each dimension

Related Microsoft/vscode#50128