### PR TITLE
fix font scaling for non dpi-aware browsers

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -251,7 +251,9 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
 
   private _setup(): void {
     Object.keys(DEFAULT_OPTIONS).forEach((key) => {
-      if (this.options[key] === null || this.options[key] === undefined) {
+      if (key === 'fontSize' && this.options[key] === null) {
+        return;
+      } else if (this.options[key] === null || this.options[key] === undefined) {
         this.options[key] = DEFAULT_OPTIONS[key];
       }
     });
@@ -689,7 +691,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     this._compositionHelper = new CompositionHelper(this.textarea, this._compositionView, this);
     this._helperContainer.appendChild(this._compositionView);
 
-    this.charMeasure = new CharMeasure(document, this._helperContainer);
+    this.charMeasure = new CharMeasure(document, this._helperContainer, this.element);
 
     // Performance: Add viewport and helper elements from the fragment
     this.element.appendChild(fragment);

--- a/src/public/Terminal.ts
+++ b/src/public/Terminal.ts
@@ -119,8 +119,9 @@ export class Terminal implements ITerminalApi {
   public getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'fontWeight' | 'fontWeightBold' | 'rendererType' | 'termName'): string;
   public getOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'screenKeys' | 'useFlowControl' | 'visualBell'): boolean;
   public getOption(key: 'colors'): string[];
-  public getOption(key: 'cols' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;
+  public getOption(key: 'cols' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;
   public getOption(key: 'handler'): (data: string) => void;
+  public getOption(key: 'fontSize'): number | null;
   public getOption(key: string): any;
   public getOption(key: any): any {
     return this._core.getOption(key);
@@ -131,10 +132,11 @@ export class Terminal implements ITerminalApi {
   public setOption(key: 'cursorStyle', value: 'block' | 'underline' | 'bar'): void;
   public setOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'screenKeys' | 'useFlowControl' | 'visualBell', value: boolean): void;
   public setOption(key: 'colors', value: string[]): void;
-  public setOption(key: 'fontSize' | 'letterSpacing' | 'lineHeight' | 'tabStopWidth' | 'scrollback', value: number): void;
+  public setOption(key: 'letterSpacing' | 'lineHeight' | 'tabStopWidth' | 'scrollback', value: number): void;
   public setOption(key: 'handler', value: (data: string) => void): void;
   public setOption(key: 'theme', value: ITheme): void;
   public setOption(key: 'cols' | 'rows', value: number): void;
+  public setOption(key: 'fontSize', value: number | null): void;
   public setOption(key: string, value: any): void;
   public setOption(key: any, value: any): void {
     this._core.setOption(key, value);

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -341,7 +341,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     const fontWeight = isBold ? terminal.options.fontWeightBold : terminal.options.fontWeight;
     const fontStyle = isItalic ? 'italic' : '';
 
-    return `${fontStyle} ${fontWeight} ${terminal.options.fontSize * window.devicePixelRatio}px ${terminal.options.fontFamily}`;
+    return `${fontStyle} ${fontWeight} ${terminal.options.fontSize * window.devicePixelRatio}pt ${terminal.options.fontFamily}`;
   }
 }
 

--- a/src/renderer/BaseRenderLayer.ts
+++ b/src/renderer/BaseRenderLayer.ts
@@ -341,7 +341,11 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     const fontWeight = isBold ? terminal.options.fontWeightBold : terminal.options.fontWeight;
     const fontStyle = isItalic ? 'italic' : '';
 
-    return `${fontStyle} ${fontWeight} ${terminal.options.fontSize * window.devicePixelRatio}pt ${terminal.options.fontFamily}`;
+    if (terminal.options.fontSize === null) {
+      return `${fontStyle} ${fontWeight} ${terminal.element.style.fontSize} ${terminal.options.fontFamily}`;
+    } else {
+      return `${fontStyle} ${fontWeight} ${terminal.options.fontSize * window.devicePixelRatio}px ${terminal.options.fontFamily}`;
+    }
   }
 }
 

--- a/src/renderer/atlas/CharAtlasUtils.ts
+++ b/src/renderer/atlas/CharAtlasUtils.ts
@@ -19,13 +19,14 @@ export function generateConfig(scaledCharWidth: number, scaledCharHeight: number
     // dynamic character atlas.
     ansi: colors.ansi.slice(0, 16)
   };
+  let termStyle = window.getComputedStyle(terminal.element);
   return {
     type: terminal.options.experimentalCharAtlas,
     devicePixelRatio: window.devicePixelRatio,
     scaledCharWidth,
     scaledCharHeight,
     fontFamily: terminal.options.fontFamily,
-    fontSize: terminal.options.fontSize,
+    fontSize: terminal.options.fontSize || termStyle.fontSize,
     fontWeight: terminal.options.fontWeight,
     fontWeightBold: terminal.options.fontWeightBold,
     allowTransparency: terminal.options.allowTransparency,

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -245,7 +245,7 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     const fontWeight = glyph.bold ? this._config.fontWeightBold : this._config.fontWeight;
     const fontStyle = glyph.italic ? 'italic' : '';
     this._tmpCtx.font =
-      `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
+      `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}pt ${this._config.fontFamily}`;
     this._tmpCtx.textBaseline = 'top';
 
     this._tmpCtx.fillStyle = this._getForegroundColor(glyph).css;

--- a/src/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/renderer/atlas/DynamicCharAtlas.ts
@@ -244,8 +244,15 @@ export default class DynamicCharAtlas extends BaseCharAtlas {
     // draw the foreground/glyph
     const fontWeight = glyph.bold ? this._config.fontWeightBold : this._config.fontWeight;
     const fontStyle = glyph.italic ? 'italic' : '';
-    this._tmpCtx.font =
-      `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}pt ${this._config.fontFamily}`;
+
+    if (typeof this._config.fontSize === 'string') {
+      this._tmpCtx.font =
+        `${fontStyle} ${fontWeight} ${this._config.fontSize} ${this._config.fontFamily}`;
+    } else {
+      this._tmpCtx.font =
+        `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
+    }
+
     this._tmpCtx.textBaseline = 'top';
 
     this._tmpCtx.fillStyle = this._getForegroundColor(glyph).css;

--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -142,14 +142,23 @@ export class DomRenderer extends EventEmitter implements IRenderer {
       this._terminal.screenElement.appendChild(this._themeStyleElement);
     }
 
+    let fontSize = this._terminal.getOption('fontSize');
+    let fontSizeStyle: string;
+    if (typeof fontSize === null) {
+      fontSizeStyle = this._terminal.element.style.fontSize;
+    } else {
+      fontSizeStyle = `${fontSize}px`
+    }
+
     // Base CSS
     let styles =
         `${this._terminalSelector} .${ROW_CONTAINER_CLASS} {` +
         ` color: ${this.colorManager.colors.foreground.css};` +
         ` background-color: ${this.colorManager.colors.background.css};` +
         ` font-family: ${this._terminal.getOption('fontFamily')};` +
-        ` font-size: ${this._terminal.getOption('fontSize')}pt;` +
+        ` font-size: ${fontSizeStyle};` +
         `}`;
+    
     // Text styles
     styles +=
         `${this._terminalSelector} span:not(.${BOLD_CLASS}) {` +

--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -148,7 +148,7 @@ export class DomRenderer extends EventEmitter implements IRenderer {
         ` color: ${this.colorManager.colors.foreground.css};` +
         ` background-color: ${this.colorManager.colors.background.css};` +
         ` font-family: ${this._terminal.getOption('fontFamily')};` +
-        ` font-size: ${this._terminal.getOption('fontSize')}px;` +
+        ` font-size: ${this._terminal.getOption('fontSize')}pt;` +
         `}`;
     // Text styles
     styles +=

--- a/src/shared/atlas/CharAtlasGenerator.ts
+++ b/src/shared/atlas/CharAtlasGenerator.ts
@@ -139,5 +139,9 @@ export function clearColor(imageData: ImageData, color: IColor): boolean {
 }
 
 function getFont(fontWeight: FontWeight, config: ICharAtlasConfig): string {
-  return `${fontWeight} ${config.fontSize * config.devicePixelRatio}pt ${config.fontFamily}`;
+  if (typeof config.fontSize === 'string') {
+    return `${fontWeight} ${config.fontSize} ${config.fontFamily}`;
+  } else {
+    return `${fontWeight} ${config.fontSize * config.devicePixelRatio}px ${config.fontFamily}`;
+  }
 }

--- a/src/shared/atlas/CharAtlasGenerator.ts
+++ b/src/shared/atlas/CharAtlasGenerator.ts
@@ -139,5 +139,5 @@ export function clearColor(imageData: ImageData, color: IColor): boolean {
 }
 
 function getFont(fontWeight: FontWeight, config: ICharAtlasConfig): string {
-  return `${fontWeight} ${config.fontSize * config.devicePixelRatio}px ${config.fontFamily}`;
+  return `${fontWeight} ${config.fontSize * config.devicePixelRatio}pt ${config.fontFamily}`;
 }

--- a/src/shared/atlas/Types.ts
+++ b/src/shared/atlas/Types.ts
@@ -11,7 +11,7 @@ export const CHAR_ATLAS_CELL_SPACING = 1;
 export interface ICharAtlasConfig {
   type: 'none' | 'static' | 'dynamic';
   devicePixelRatio: number;
-  fontSize: number;
+  fontSize: number | string;
   fontFamily: string;
   fontWeight: FontWeight;
   fontWeightBold: FontWeight;

--- a/src/ui/CharMeasure.test.ts
+++ b/src/ui/CharMeasure.test.ts
@@ -21,7 +21,7 @@ describe('CharMeasure', () => {
     document = window.document;
     container = document.createElement('div');
     document.body.appendChild(container);
-    charMeasure = new CharMeasure(document, container);
+    charMeasure = new CharMeasure(document, container, container);
   });
 
   describe('measure', () => {

--- a/src/ui/CharMeasure.ts
+++ b/src/ui/CharMeasure.ts
@@ -39,7 +39,7 @@ export class CharMeasure extends EventEmitter implements ICharMeasure {
 
   public measure(options: ITerminalOptions): void {
   this._measureElement.style.fontFamily = options.fontFamily;
-    this._measureElement.style.fontSize = `${options.fontSize}px`;
+    this._measureElement.style.fontSize = `${options.fontSize}pt`;
     const geometry = this._measureElement.getBoundingClientRect();
     // The element is likely currently display:none, we should retain the
     // previous value.

--- a/src/ui/CharMeasure.ts
+++ b/src/ui/CharMeasure.ts
@@ -15,10 +15,11 @@ export class CharMeasure extends EventEmitter implements ICharMeasure {
   private _document: Document;
   private _parentElement: HTMLElement;
   private _measureElement: HTMLElement;
+  private _containerElement: HTMLElement;
   private _width: number;
   private _height: number;
 
-  constructor(document: Document, parentElement: HTMLElement) {
+  constructor(document: Document, parentElement: HTMLElement, containerElement: HTMLElement) {
     super();
     this._document = document;
     this._parentElement = parentElement;
@@ -27,6 +28,7 @@ export class CharMeasure extends EventEmitter implements ICharMeasure {
     this._measureElement.textContent = 'W';
     this._measureElement.setAttribute('aria-hidden', 'true');
     this._parentElement.appendChild(this._measureElement);
+    this._containerElement = containerElement;
   }
 
   public get width(): number {
@@ -39,7 +41,11 @@ export class CharMeasure extends EventEmitter implements ICharMeasure {
 
   public measure(options: ITerminalOptions): void {
   this._measureElement.style.fontFamily = options.fontFamily;
-    this._measureElement.style.fontSize = `${options.fontSize}pt`;
+    if (options.fontSize === null) {
+      this._measureElement.style.fontSize = window.getComputedStyle(this._containerElement).fontSize;
+    } else {
+      this._measureElement.style.fontSize = `${options.fontSize}px`;
+    }
     const geometry = this._measureElement.getBoundingClientRect();
     // The element is likely currently display:none, we should retain the
     // previous value.

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -102,7 +102,7 @@ declare module 'xterm' {
     /**
      * The font size used to render text.
      */
-    fontSize?: number;
+    fontSize?: number | null;
 
     /**
      * The font family used to render text.
@@ -631,12 +631,17 @@ declare module 'xterm' {
      * Retrieves an option's value from the terminal.
      * @param key The option key.
      */
-    getOption(key: 'cols' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;
+    getOption(key: 'cols' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;
     /**
      * Retrieves an option's value from the terminal.
      * @param key The option key.
      */
     getOption(key: 'handler'): (data: string) => void;
+    /**
+     * Retrieves an option's value from the terminal.
+     * @param key The option key.
+     */
+    getOption(key: 'fontSize'): number | null;
     /**
      * Retrieves an option's value from the terminal.
      * @param key The option key.
@@ -684,7 +689,13 @@ declare module 'xterm' {
      * @param key The option key.
      * @param value The option value.
      */
-    setOption(key: 'fontSize' | 'letterSpacing' | 'lineHeight' | 'tabStopWidth' | 'scrollback', value: number): void;
+    setOption(key: 'letterSpacing' | 'lineHeight' | 'tabStopWidth' | 'scrollback', value: number): void;
+    /**
+     * Sets an option on the terminal.
+     * @param key The option key.
+     * @param value The option value.
+     */
+    setOption(key: 'fontSize', value: number | null): void;
     /**
      * Sets an option on the terminal.
      * @param key The option key.


### PR DESCRIPTION
Certain browser scenarios (such as IE11 when hosted in WPF) are not fully DPI-aware. This creates odd scaling issues where the terminal font is far too small on HiDPI displays. This is due to the fact that as of version 3.0 font sizes were specified in pixel amounts instead of point sizes. This PR fixes the issue by changing the font sizes to use point instead of pixel. This does change the semantics slightly because px and pt are not the same scale but I would expect that using pt is actually more in line with what users expect.

Here is an example of the issue, the terminal window is at the bottom:
![bad-scaling](https://user-images.githubusercontent.com/8010244/46430305-7793ca80-c6fd-11e8-90a2-6cff0e8e24ef.PNG)
