### PR TITLE
fix handling of length in BufferLine.resize

### DIFF
--- a/src/BufferLine.test.ts
+++ b/src/BufferLine.test.ts
@@ -133,31 +133,71 @@ describe('BufferLine', function(): void {
     const line3 = line.clone();
     chai.expect(TestBufferLine.prototype.toArray.apply(line3)).eql(line.toArray());
   });
-  it('resize enlarge', function(): void {
-    const line = new TestBufferLine(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)]);
-    chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
-  });
-  it('resize shrink(true)', function(): void {
-    const line = new TestBufferLine(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], true);
-    chai.expect(line.toArray()).eql(Array(5).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
-  });
-  it('resize shrink(false)', function(): void {
-    const line = new TestBufferLine(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    chai.expect(line.toArray()).eql(Array(5).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
-  });
-  it('resize shrink(false) + shrink(false)', function(): void {
-    const line = new TestBufferLine(20, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    chai.expect(line.toArray()).eql(Array(5).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
-  });
-  it('resize shrink(false) + enlarge', function(): void {
-    const line = new TestBufferLine(20, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
-    line.resize(15, [1, 'a', 0, 'a'.charCodeAt(0)]);
-    chai.expect(line.toArray()).eql(Array(15).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+  describe('resize', function(): void {
+    it('enlarge(false)', function(): void {
+      const line = new TestBufferLine(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)]);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('enlarge(true)', function(): void {
+      const line = new TestBufferLine(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], true);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(true) - should apply new size', function(): void {
+      const line = new TestBufferLine(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], true);
+      chai.expect(line.toArray()).eql(Array(5).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(false) - should not apply new size', function(): void {
+      const line = new TestBufferLine(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(false) + shrink(false) - should not apply new size', function(): void {
+      const line = new TestBufferLine(20, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      chai.expect(line.toArray()).eql(Array(20).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(false) + enlarge(false) to smaller than before', function(): void {
+      const line = new TestBufferLine(20, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(15, [1, 'a', 0, 'a'.charCodeAt(0)]);
+      chai.expect(line.toArray()).eql(Array(20).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(false) + enlarge(false) to bigger than before', function(): void {
+      const line = new TestBufferLine(20, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(25, [1, 'a', 0, 'a'.charCodeAt(0)]);
+      chai.expect(line.toArray()).eql(Array(25).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(false) + resize shrink=true should enforce shrinking', function(): void {
+      const line = new TestBufferLine(20, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], true);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('enlarge from 0 length', function(): void {
+      const line = new TestBufferLine(0, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink to 0 length', function(): void {
+      const line = new TestBufferLine(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(0, [1, 'a', 0, 'a'.charCodeAt(0)], true);
+      chai.expect(line.toArray()).eql(Array(0).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
+    it('shrink(false) to 0 and enlarge to different sizes', function(): void {
+      const line = new TestBufferLine(10, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      line.resize(0, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      line.resize(5, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      line.resize(7, [1, 'a', 0, 'a'.charCodeAt(0)], false);
+      chai.expect(line.toArray()).eql(Array(10).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      line.resize(7, [1, 'a', 0, 'a'.charCodeAt(0)], true);
+      chai.expect(line.toArray()).eql(Array(7).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+    });
   });
 });

--- a/src/BufferLine.ts
+++ b/src/BufferLine.ts
@@ -77,15 +77,15 @@ export class BufferLine implements IBufferLine {
 
   /** resize line to cols filling new cells with fill */
   public resize(cols: number, fillCharData: CharData, shrink: boolean = false): void {
+    while (this._data.length < cols) {
+      this._data.push(fillCharData);
+    }
     if (shrink) {
       while (this._data.length > cols) {
         this._data.pop();
       }
     }
-    while (this._data.length < cols) {
-      this._data.push(fillCharData);
-    }
-    this.length = cols;
+    this.length = this._data.length;
   }
 
   public fill(fillCharData: CharData): void {
@@ -141,11 +141,13 @@ export class BufferLineTypedArray implements IBufferLine {
     if (!fillCharData) {
       fillCharData = [0, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE];
     }
-    this._data = new Uint32Array(cols * CELL_SIZE);
-    for (let i = 0; i < cols; ++i) {
-      this.set(i, fillCharData);
+    if (cols) {
+      this._data = new Uint32Array(cols * CELL_SIZE);
+      for (let i = 0; i < cols; ++i) {
+        this.set(i, fillCharData);
+      }
     }
-    this.length = cols || 0;
+    this.length = cols;
   }
 
   public get(index: number): CharData {
@@ -212,12 +214,12 @@ export class BufferLineTypedArray implements IBufferLine {
   }
 
   public resize(cols: number, fillCharData: CharData, shrink: boolean = false): void {
-    if (cols === this.length) {
+    if (cols === this.length || (!shrink && cols < this.length)) {
       return;
     }
     if (cols > this.length) {
       const data = new Uint32Array(cols * CELL_SIZE);
-      if (this._data) {
+      if (this.length) {
         if (cols * CELL_SIZE < this._data.length) {
           data.set(this._data.subarray(0, cols * CELL_SIZE));
         } else {


### PR DESCRIPTION
Currently we do not trim buffer lines upon resizing. `BufferLine.resize` wrongly adjusted `.length` to the new shorter `cols` value, which makes the invisible content beyond `terminal.cols` non accessible for consumers like `Buffer.translateBufferLineToString`. This PR restores the behavior of v3.7.