### PR TITLE
Remove underscore from non word characters list

### DIFF
--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISearchHelper, ISearchAddonTerminal, ISearchOptions, ISearchResult } from './Interfaces';
-const nonWordCharacters = ' ~!@#$%^&*()_+`-=[]{}|\;:"\',./<>?';
+const nonWordCharacters = ' ~!@#$%^&*()+`-=[]{}|\;:"\',./<>?';
 
 /**
  * A class that knows how to search the terminal and how to display the results.


### PR DESCRIPTION
Underscore shouldn't be considered a word delimiter.

This is the upstream fix for Microsoft/vscode#59379