### PR TITLE
add tiny buffer to server part in demo

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -58,9 +58,25 @@ app.ws('/terminals/:pid', function (ws, req) {
   console.log('Connected to terminal ' + term.pid);
   ws.send(logs[term.pid]);
 
+  function buffer(socket, timeout) {
+    let s = '';
+    let sender = null;
+    return (data) => {
+      s += data;
+      if (!sender) {
+        sender = setTimeout(() => {
+          socket.send(s);
+          s = '';
+          sender = null;
+        }, timeout);
+      }
+    };
+  }
+  const send = buffer(ws, 5);
+
   term.on('data', function(data) {
     try {
-      ws.send(data);
+      send(data);
     } catch (ex) {
       // The WebSocket is not open, ignore
     }


### PR DESCRIPTION
This PR adds a tiny bit of buffering to the demo on the server side. This is mainly to get those unreliable numbers in browser perf tests somewhat more stable. A nice side effect is a major throughput boost for the demo app (~3x faster).
