### PR TITLE
Improve types for listener args in .d.ts

### DIFF
--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -388,37 +388,37 @@ declare module 'xterm' {
      * @param type The type of the event.
      * @param listener The listener.
      */
-    on(type: 'key', listener: (key?: string, event?: KeyboardEvent) => void): void;
+    on(type: 'key', listener: (key: string, event: KeyboardEvent) => void): void;
     /**
      * Registers an event listener.
      * @param type The type of the event.
      * @param listener The listener.
      */
-    on(type: 'keypress' | 'keydown', listener: (event?: KeyboardEvent) => void): void;
+    on(type: 'keypress' | 'keydown', listener: (event: KeyboardEvent) => void): void;
     /**
      * Registers an event listener.
      * @param type The type of the event.
      * @param listener The listener.
      */
-    on(type: 'refresh', listener: (data?: {start: number, end: number}) => void): void;
+    on(type: 'refresh', listener: (data: {start: number, end: number}) => void): void;
     /**
      * Registers an event listener.
      * @param type The type of the event.
      * @param listener The listener.
      */
-    on(type: 'resize', listener: (data?: {cols: number, rows: number}) => void): void;
+    on(type: 'resize', listener: (data: {cols: number, rows: number}) => void): void;
     /**
      * Registers an event listener.
      * @param type The type of the event.
      * @param listener The listener.
      */
-    on(type: 'scroll', listener: (ydisp?: number) => void): void;
+    on(type: 'scroll', listener: (ydisp: number) => void): void;
     /**
      * Registers an event listener.
      * @param type The type of the event.
      * @param listener The listener.
      */
-    on(type: 'title', listener: (title?: string) => void): void;
+    on(type: 'title', listener: (title: string) => void): void;
     /**
      * Registers an event listener.
      * @param type The type of the event.


### PR DESCRIPTION
Without this consumers need an undefined check with strictNullChecks turned on.