### PR TITLE
Run tests & tslint for src/addons directory

### DIFF
--- a/src/addons/attach/attach.test.ts
+++ b/src/addons/attach/attach.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as attach from './attach';
 

--- a/src/addons/fit/fit.test.ts
+++ b/src/addons/fit/fit.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as fit from './fit';
 

--- a/src/addons/fullscreen/fullscreen.test.ts
+++ b/src/addons/fullscreen/fullscreen.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as fullscreen from './fullscreen';
 

--- a/src/addons/fullscreen/fullscreen.ts
+++ b/src/addons/fullscreen/fullscreen.ts
@@ -11,7 +11,7 @@ import { Terminal } from 'xterm';
  * @param fullscreen Toggle fullscreen on (true) or off (false)
  */
 export function toggleFullScreen(term: Terminal, fullscreen: boolean): void {
-  let fn: Function;
+  let fn: (...tokens: string[]) => void;
 
   if (typeof fullscreen === 'undefined') {
     fn = (term.element.classList.contains('fullscreen')) ?

--- a/src/addons/fullscreen/fullscreen.ts
+++ b/src/addons/fullscreen/fullscreen.ts
@@ -11,17 +11,18 @@ import { Terminal } from 'xterm';
  * @param fullscreen Toggle fullscreen on (true) or off (false)
  */
 export function toggleFullScreen(term: Terminal, fullscreen: boolean): void {
-  let fn: string;
+  let fn: Function;
 
   if (typeof fullscreen === 'undefined') {
-    fn = (term.element.classList.contains('fullscreen')) ? 'remove' : 'add';
+    fn = (term.element.classList.contains('fullscreen')) ?
+      term.element.classList.remove : term.element.classList.add;
   } else if (!fullscreen) {
-    fn = 'remove';
+    fn = term.element.classList.remove;
   } else {
-    fn = 'add';
+    fn = term.element.classList.add;
   }
 
-  term.element.classList[fn]('fullscreen');
+  fn('fullscreen');
 }
 
 export function apply(terminalConstructor: typeof Terminal): void {

--- a/src/addons/search/search.test.ts
+++ b/src/addons/search/search.test.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 The xterm.js authors. All rights reserved.
  * @license MIT
  */
+declare var require: any;
 
 import { assert, expect } from 'chai';
 import * as search from './search';

--- a/src/addons/search/tsconfig.json
+++ b/src/addons/search/tsconfig.json
@@ -18,8 +18,5 @@
   },
   "include": [
     "**/*.ts"
-  ],
-  "exclude": [
-    "**/*.test.ts"
   ]
 }

--- a/src/addons/terminado/terminado.test.ts
+++ b/src/addons/terminado/terminado.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as terminado from './terminado';
 

--- a/src/addons/webLinks/webLinks.test.ts
+++ b/src/addons/webLinks/webLinks.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as webLinks from './webLinks';
 

--- a/src/addons/winptyCompat/winptyCompat.test.ts
+++ b/src/addons/winptyCompat/winptyCompat.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as winptyCompat from './winptyCompat';
 

--- a/src/addons/zmodem/zmodem.test.ts
+++ b/src/addons/zmodem/zmodem.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 
 import * as zmodem from './zmodem';
 

--- a/src/addons/zmodem/zmodem.ts
+++ b/src/addons/zmodem/zmodem.ts
@@ -34,7 +34,7 @@ import { Terminal } from 'xterm';
  *  via `detach()` and a re-`attach()`.)
  */
 
-let zmodem;
+let zmodem: any;
 
 export interface IZmodemOptions {
   noTerminalWriteOutsideSession?: boolean;
@@ -44,7 +44,7 @@ function zmodemAttach(ws: WebSocket, opts: IZmodemOptions = {}): void {
   const term = this;
   const senderFunc = (octets: ArrayLike<number>) => ws.send(new Uint8Array(octets));
 
-  let zsentry;
+  let zsentry: any;
 
   function shouldWrite(): boolean {
     return !!zsentry.get_confirmed_session() || !opts.noTerminalWriteOutsideSession;


### PR DESCRIPTION
Long story short, I wanted to work on a bug but I noticed that tests and the tslint are not running for `src/addons` directory (intentionally?), this is my attempt to fix this 

- removed `src/addons` from `exclude` from tsconfig.js
- fixed tslint errors
- before the change there were 549 passing tests, now there are 560