### PR TITLE
Search from top of viewport when there is no selection

### DIFF
--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -33,7 +33,9 @@ export class SearchHelper implements ISearchHelper {
     let startRow = this._terminal._core.buffer.ydisp;
     if (this._terminal._core.selectionManager.selectionEnd) {
       // Start from the selection end if there is a selection
-      startRow = this._terminal._core.selectionManager.selectionEnd[1];
+      if (this._terminal.getSelection().length !== 0) {
+        startRow = this._terminal._core.selectionManager.selectionEnd[1];
+      }
     }
 
     // Search from ydisp + 1 to end
@@ -75,7 +77,9 @@ export class SearchHelper implements ISearchHelper {
     let startRow = this._terminal._core.buffer.ydisp;
     if (this._terminal._core.selectionManager.selectionStart) {
       // Start from the selection end if there is a selection
-      startRow = this._terminal._core.selectionManager.selectionStart[1];
+      if (this._terminal.getSelection().length !== 0) {
+        startRow = this._terminal._core.selectionManager.selectionStart[1];
+      }
     }
 
     // Search from ydisp + 1 to end
@@ -108,7 +112,7 @@ export class SearchHelper implements ISearchHelper {
    */
   private _isWholeWord(searchIndex: number, line: string, term: string): boolean {
     return (((searchIndex === 0) || (nonWordCharacters.indexOf(line[searchIndex - 1]) !== -1)) &&
-         (((searchIndex + term.length) === line.length) || (nonWordCharacters.indexOf(line[searchIndex + term.length]) !== -1)));
+      (((searchIndex + term.length) === line.length) || (nonWordCharacters.indexOf(line[searchIndex + term.length]) !== -1)));
   }
 
   /**

--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -112,7 +112,7 @@ export class SearchHelper implements ISearchHelper {
    */
   private _isWholeWord(searchIndex: number, line: string, term: string): boolean {
     return (((searchIndex === 0) || (nonWordCharacters.indexOf(line[searchIndex - 1]) !== -1)) &&
-      (((searchIndex + term.length) === line.length) || (nonWordCharacters.indexOf(line[searchIndex + term.length]) !== -1)));
+        (((searchIndex + term.length) === line.length) || (nonWordCharacters.indexOf(line[searchIndex + term.length]) !== -1)));
   }
 
   /**


### PR DESCRIPTION
@Tyriar , fixed it in two places to resolve issue #1749 .
The startRow is initialised to ydisp in both places, so just handled the case of changing it when selection length is not 0. 
Please review this , Thanks :)

Fixes #1749