### PR TITLE
Updated webLinks regex accept colons, fix vscode issue#60401

### DIFF
--- a/src/addons/webLinks/webLinks.test.ts
+++ b/src/addons/webLinks/webLinks.test.ts
@@ -32,11 +32,11 @@ describe('webLinks addon', () => {
     const term = new MockTerminal();
     webLinks.webLinksInit(<any>term);
 
-    const row = '  http://foo.com/a~b#c~d?e~f  ';
+    const row = '  http://foo.com/a~b#c~d?e~f:  ';
 
     const match = row.match(term.regex);
     const uri = match[term.options.matchIndex];
 
-    assert.equal(uri, 'http://foo.com/a~b#c~d?e~f');
+    assert.equal(uri, 'http://foo.com/a~b#c~d?e~f:');
   });
 });

--- a/src/addons/webLinks/webLinks.test.ts
+++ b/src/addons/webLinks/webLinks.test.ts
@@ -32,11 +32,35 @@ describe('webLinks addon', () => {
     const term = new MockTerminal();
     webLinks.webLinksInit(<any>term);
 
-    const row = '  http://foo.com/a~b#c~d?e~f:  ';
+    const row = '  http://foo.com/a~b#c~d?e~f  ';
 
     const match = row.match(term.regex);
     const uri = match[term.options.matchIndex];
 
-    assert.equal(uri, 'http://foo.com/a~b#c~d?e~f:');
+    assert.equal(uri, 'http://foo.com/a~b#c~d?e~f');
+  });
+
+  it('should allow : character in URI path', () => {
+    const term = new MockTerminal();
+    webLinks.webLinksInit(<any>term);
+
+    const row = '  http://foo.com/colon:test  ';
+
+    const match = row.match(term.regex);
+    const uri = match[term.options.matchIndex];
+
+    assert.equal(uri, 'http://foo.com/colon:test');
+  });
+
+  it('should not allow : character at the end of a URI path', () => {
+    const term = new MockTerminal();
+    webLinks.webLinksInit(<any>term);
+
+    const row = '  http://foo.com/colon:test:  ';
+
+    const match = row.match(term.regex);
+    const uri = match[term.options.matchIndex];
+
+    assert.equal(uri, 'http://foo.com/colon:test');
   });
 });

--- a/src/addons/webLinks/webLinks.ts
+++ b/src/addons/webLinks/webLinks.ts
@@ -14,7 +14,7 @@ const ipClause = '((\\d{1,3}\\.){3}\\d{1,3})';
 const localHostClause = '(localhost)';
 const portClause = '(:\\d{1,5})';
 const hostClause = '((' + domainBodyClause + '\\.' + tldClause + ')|' + ipClause + '|' + localHostClause + ')' + portClause + '?';
-const pathClause = '(\\/[\\/\\w\\.\\-%~:]*)*';
+const pathClause = '(\\/[\\/\\w\\.\\-%~:]*)*([^:\\s])';
 const queryStringHashFragmentCharacterSet = '[0-9\\w\\[\\]\\(\\)\\/\\?\\!#@$%&\'*+,:;~\\=\\.\\-]*';
 const queryStringClause = '(\\?' + queryStringHashFragmentCharacterSet + ')?';
 const hashFragmentClause = '(#' + queryStringHashFragmentCharacterSet + ')?';

--- a/src/addons/webLinks/webLinks.ts
+++ b/src/addons/webLinks/webLinks.ts
@@ -14,7 +14,7 @@ const ipClause = '((\\d{1,3}\\.){3}\\d{1,3})';
 const localHostClause = '(localhost)';
 const portClause = '(:\\d{1,5})';
 const hostClause = '((' + domainBodyClause + '\\.' + tldClause + ')|' + ipClause + '|' + localHostClause + ')' + portClause + '?';
-const pathClause = '(\\/[\\/\\w\\.\\-%~]*)*';
+const pathClause = '(\\/[\\/\\w\\.\\-%~:]*)*';
 const queryStringHashFragmentCharacterSet = '[0-9\\w\\[\\]\\(\\)\\/\\?\\!#@$%&\'*+,:;~\\=\\.\\-]*';
 const queryStringClause = '(\\?' + queryStringHashFragmentCharacterSet + ')?';
 const hashFragmentClause = '(#' + queryStringHashFragmentCharacterSet + ')?';


### PR DESCRIPTION
@Tyriar This PR should fix [issue #60401](https://github.com/Microsoft/vscode/issues/60401) for VS Code downstream.

I updated the `webLinks` `pathClause` regex https://github.com/xtermjs/xterm.js/blob/b9ab35dfe9f117e00133d6bb782cd298c1401d77/src/addons/webLinks/webLinks.ts#L17 to accept colons. So the new regex is now `(\\/[\\/\\w\\.\\-%~:]*)*`

I also updated the tests to test for the colon case in the path.

![image](https://user-images.githubusercontent.com/8349191/47318436-0ff4df00-d61a-11e8-918c-5a8d029631f2.png)


If there are any updates I should make please let me know.

