### PR TITLE
Check for focus on document as well as on textarea

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -342,7 +342,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   }
 
   public get isFocused(): boolean {
-    return document.activeElement === this.textarea;
+    return document.activeElement === this.textarea && document.hasFocus();
   }
 
   /**


### PR DESCRIPTION
When clicking outside of the browser document area, the cursor does not
appear to get 'blurred'. This can be confusing as it implies that the
cursor is still active. This is caused by Terminal's isFocused getter
only checking if the textarea is the active element of the document.

Expand isFocused to also check that the document itself has focus.