### PR TITLE
hold single AudioContext instance

### DIFF
--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -13,7 +13,7 @@ export const DEFAULT_BELL_SOUND = 'data:audio/wav;base64,UklGRigBAABXQVZFZm10IBA
 
 export class SoundManager implements ISoundManager {
   private static _audioContext: AudioContext;
-  
+
   static get audioContext(): AudioContext {
     if (!SoundManager._audioContext) {
       const audioContextCtor: typeof AudioContext = (<any>window).AudioContext || (<any>window).webkitAudioContext;

--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -21,7 +21,7 @@ export class SoundManager implements ISoundManager {
         console.warn('Web Audio API is not supported by this browser. Consider upgrading to the latest version');
         return null;
       }
-      this._audioContext = new audioContextCtor();
+      SoundManager._audioContext = new audioContextCtor();
     }
     return SoundManager._audioContext;
   }

--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -27,13 +27,12 @@ export class SoundManager implements ISoundManager {
   }
 
   constructor(
-    private _terminal: ITerminal,
-    private _audioContext?: AudioContext
+    private _terminal: ITerminal
   ) {
   }
 
   public playBellSound(): void {
-    const ctx = this._audioContext || SoundManager.audioContext;
+    const ctx = SoundManager.audioContext;
     if (!ctx) {
       return;
     }

--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -12,7 +12,19 @@ import { ITerminal, ISoundManager } from './Types';
 export const DEFAULT_BELL_SOUND = 'data:audio/wav;base64,UklGRigBAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQQBAADpAFgCwAMlBZoG/wdmCcoKRAypDQ8PbRDBEQQTOxRtFYcWlBePGIUZXhoiG88bcBz7HHIdzh0WHlMeZx51HmkeUx4WHs8dah0AHXwc3hs9G4saxRnyGBIYGBcQFv8U4RPAEoYRQBACD70NWwwHC6gJOwjWBloF7gOBAhABkf8b/qv8R/ve+Xf4Ife79W/0JfPZ8Z/wde9N7ijtE+wU6xvqM+lb6H7nw+YX5mrlxuQz5Mzje+Ma49fioeKD4nXiYeJy4pHitOL04j/jn+MN5IPkFOWs5U3mDefM55/ogOl36m7rdOyE7abuyu8D8Unyj/Pg9D/2qfcb+Yn6/vuK/Qj/lAAlAg==';
 
 export class SoundManager implements ISoundManager {
-  private _audioContext: AudioContext;
+  private static _audioContext: AudioContext;
+  
+  static get audioContext(): AudioContext {
+    if (!SoundManager._audioContext) {
+      const audioContextCtor: typeof AudioContext = (<any>window).AudioContext || (<any>window).webkitAudioContext;
+      if (!audioContextCtor) {
+        console.warn('Web Audio API is not supported by this browser. Consider upgrading to the latest version');
+        return null;
+      }
+      this._audioContext = new audioContextCtor();
+    }
+    return SoundManager._audioContext;
+  }
 
   constructor(
     private _terminal: ITerminal
@@ -20,22 +32,16 @@ export class SoundManager implements ISoundManager {
   }
 
   public playBellSound(): void {
-    const audioContextCtor: typeof AudioContext = (<any>window).AudioContext || (<any>window).webkitAudioContext;
-    if (!this._audioContext && audioContextCtor) {
-      this._audioContext = new audioContextCtor();
+    const context = SoundManager.audioContext;
+    if (!context) {
+      return;
     }
-
-    if (this._audioContext) {
-      const bellAudioSource = this._audioContext.createBufferSource();
-      const context = this._audioContext;
-      this._audioContext.decodeAudioData(this._base64ToArrayBuffer(this._removeMimeType(this._terminal.options.bellSound)), (buffer) => {
-        bellAudioSource.buffer = buffer;
-        bellAudioSource.connect(context.destination);
-        bellAudioSource.start(0);
-      });
-    } else {
-      console.warn('Sorry, but the Web Audio API is not supported by your browser. Please, consider upgrading to the latest version');
-    }
+    const bellAudioSource = context.createBufferSource();
+    context.decodeAudioData(this._base64ToArrayBuffer(this._removeMimeType(this._terminal.options.bellSound)), (buffer) => {
+      bellAudioSource.buffer = buffer;
+      bellAudioSource.connect(context.destination);
+      bellAudioSource.start(0);
+    });
   }
 
   private _base64ToArrayBuffer(base64: string): ArrayBuffer {

--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -14,7 +14,7 @@ export const DEFAULT_BELL_SOUND = 'data:audio/wav;base64,UklGRigBAABXQVZFZm10IBA
 export class SoundManager implements ISoundManager {
   private static _audioContext: AudioContext;
 
-  static get audioContext(): AudioContext {
+  static get audioContext(): AudioContext | null {
     if (!SoundManager._audioContext) {
       const audioContextCtor: typeof AudioContext = (<any>window).AudioContext || (<any>window).webkitAudioContext;
       if (!audioContextCtor) {
@@ -27,19 +27,20 @@ export class SoundManager implements ISoundManager {
   }
 
   constructor(
-    private _terminal: ITerminal
+    private _terminal: ITerminal,
+    private _audioContext?: AudioContext
   ) {
   }
 
   public playBellSound(): void {
-    const context = SoundManager.audioContext;
-    if (!context) {
+    const ctx = this._audioContext || SoundManager.audioContext;
+    if (!ctx) {
       return;
     }
-    const bellAudioSource = context.createBufferSource();
-    context.decodeAudioData(this._base64ToArrayBuffer(this._removeMimeType(this._terminal.options.bellSound)), (buffer) => {
+    const bellAudioSource = ctx.createBufferSource();
+    ctx.decodeAudioData(this._base64ToArrayBuffer(this._removeMimeType(this._terminal.options.bellSound)), (buffer) => {
       bellAudioSource.buffer = buffer;
-      bellAudioSource.connect(context.destination);
+      bellAudioSource.connect(ctx.destination);
       bellAudioSource.start(0);
     });
   }


### PR DESCRIPTION
Fixes #1694.

It should be save to just hold one `AudioContext` instance for all terminal instances within a document (created on the first bell request on `SoundManager`).

NB: ~The change will not work if there are still more audio contexts spawned than allowed on integrator side (e.g. vscode). If thats an issue we might want to refactor SoundManager to take an optional argument `context`. This way the integrator can maintain the audio contexts itself.~ Added optional ctor argument.