### PR TITLE
DOM renderer: Don't output empty cells at end of a line

### DIFF
--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -111,6 +111,8 @@ export class DomRenderer extends EventEmitter implements IRenderer {
       element.style.width = `${this.dimensions.canvasWidth}px`;
       element.style.height = `${this.dimensions.actualCellHeight}px`;
       element.style.lineHeight = `${this.dimensions.actualCellHeight}px`;
+      // Make sure rows don't overflow onto following row
+      element.style.overflow = 'hidden';
     });
 
     if (!this._dimensionsStyleElement) {
@@ -330,7 +332,7 @@ export class DomRenderer extends EventEmitter implements IRenderer {
       const row = y + terminal.buffer.ydisp;
       const lineData = terminal.buffer.lines.get(row);
       const cursorStyle = terminal.options.cursorStyle;
-      rowElement.appendChild(this._rowFactory.createRow(lineData, row === cursorAbsoluteY, cursorStyle, cursorX, terminal.charMeasure.width, terminal.cols));
+      rowElement.appendChild(this._rowFactory.createRow(lineData, row === cursorAbsoluteY, cursorStyle, cursorX, this.dimensions.actualCellWidth, terminal.cols));
     }
 
     this._terminal.emit('refresh', {start, end});

--- a/src/renderer/dom/DomRendererRowFactory.test.ts
+++ b/src/renderer/dom/DomRendererRowFactory.test.ts
@@ -23,11 +23,10 @@ describe('DomRendererRowFactory', () => {
   });
 
   describe('createRow', () => {
-    it('should create an element for every character in the row', () => {
+    it('should not create anything for an empty row', () => {
       const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
       assert.equal(getFragmentHtml(fragment),
-        '<span> </span>' +
-        '<span> </span>'
+        ''
       );
     });
 
@@ -45,8 +44,7 @@ describe('DomRendererRowFactory', () => {
       for (const style of ['block', 'bar', 'underline']) {
         const fragment = rowFactory.createRow(lineData, true, style, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
-          `<span class="xterm-cursor xterm-cursor-${style}"> </span>` +
-          '<span> </span>'
+          `<span class="xterm-cursor xterm-cursor-${style}"> </span>`
         );
       }
     });
@@ -65,8 +63,7 @@ describe('DomRendererRowFactory', () => {
         lineData.set(0, [DEFAULT_ATTR | (FLAGS.BOLD << 18), 'a', 1, 'a'.charCodeAt(0)]);
         const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
-          '<span class="xterm-bold">a</span>' +
-          '<span> </span>'
+          '<span class="xterm-bold">a</span>'
         );
       });
 
@@ -74,8 +71,7 @@ describe('DomRendererRowFactory', () => {
         lineData.set(0, [DEFAULT_ATTR | (FLAGS.ITALIC << 18), 'a', 1, 'a'.charCodeAt(0)]);
         const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
-          '<span class="xterm-italic">a</span>' +
-          '<span> </span>'
+          '<span class="xterm-italic">a</span>'
         );
       });
 
@@ -85,8 +81,7 @@ describe('DomRendererRowFactory', () => {
           lineData.set(0, [defaultAttrNoFgColor | (i << 9), 'a', 1, 'a'.charCodeAt(0)]);
           const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
           assert.equal(getFragmentHtml(fragment),
-            `<span class="xterm-fg-${i}">a</span>` +
-            '<span> </span>'
+            `<span class="xterm-fg-${i}">a</span>`
           );
         }
       });
@@ -97,8 +92,7 @@ describe('DomRendererRowFactory', () => {
           lineData.set(0, [defaultAttrNoBgColor | (i << 0), 'a', 1, 'a'.charCodeAt(0)]);
           const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
           assert.equal(getFragmentHtml(fragment),
-            `<span class="xterm-bg-${i}">a</span>` +
-            '<span> </span>'
+            `<span class="xterm-bg-${i}">a</span>`
           );
         }
       });
@@ -107,8 +101,7 @@ describe('DomRendererRowFactory', () => {
         lineData.set(0, [(FLAGS.INVERSE << 18) | (2 << 9) | (1 << 0), 'a', 1, 'a'.charCodeAt(0)]);
         const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
-          '<span class="xterm-fg-1 xterm-bg-2">a</span>' +
-          '<span> </span>'
+          '<span class="xterm-fg-1 xterm-bg-2">a</span>'
         );
       });
 
@@ -116,8 +109,7 @@ describe('DomRendererRowFactory', () => {
         lineData.set(0, [(FLAGS.INVERSE << 18) | (257 << 9) | (1 << 0), 'a', 1, 'a'.charCodeAt(0)]);
         const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
-          '<span class="xterm-fg-1 xterm-bg-15">a</span>' +
-          '<span> </span>'
+          '<span class="xterm-fg-1 xterm-bg-15">a</span>'
         );
       });
 
@@ -125,8 +117,7 @@ describe('DomRendererRowFactory', () => {
         lineData.set(0, [(FLAGS.INVERSE << 18) | (1 << 9) | (256 << 0), 'a', 1, 'a'.charCodeAt(0)]);
         const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
         assert.equal(getFragmentHtml(fragment),
-          '<span class="xterm-fg-0 xterm-bg-1">a</span>' +
-          '<span> </span>'
+          '<span class="xterm-fg-0 xterm-bg-1">a</span>'
         );
       });
 
@@ -135,8 +126,7 @@ describe('DomRendererRowFactory', () => {
           lineData.set(0, [(FLAGS.BOLD << 18) | (i << 9) | (256 << 0), 'a', 1, 'a'.charCodeAt(0)]);
           const fragment = rowFactory.createRow(lineData, false, undefined, 0, 5, 20);
           assert.equal(getFragmentHtml(fragment),
-            `<span class="xterm-bold xterm-fg-${i + 8}">a</span>` +
-            '<span> </span>'
+            `<span class="xterm-bold xterm-fg-${i + 8}">a</span>`
           );
         }
       });

--- a/src/renderer/dom/DomRendererRowFactory.ts
+++ b/src/renderer/dom/DomRendererRowFactory.ts
@@ -29,7 +29,7 @@ export class DomRendererRowFactory {
     // properly support reflow and disallow data to go beyond the right-side of
     // the viewport).
     let lineLength = 0;
-    for (let x = lineData.length - 1; x >= 0; x--) {
+    for (let x = Math.min(lineData.length, cols) - 1; x >= 0; x--) {
       const charData = lineData.get(x);
       const code = charData[CHAR_DATA_CODE_INDEX];
       if (code !== NULL_CELL_CODE || (isCursorRow && x === cursorX)) {
@@ -38,13 +38,7 @@ export class DomRendererRowFactory {
       }
     }
 
-    let colCount = 0;
     for (let x = 0; x < lineLength; x++) {
-      // Don't allow any buffer to the right to be displayed
-      if (colCount >= cols) {
-        continue;
-      }
-
       const charData = lineData.get(x);
       const char = charData[CHAR_DATA_CHAR_INDEX];
       const attr = charData[CHAR_DATA_ATTR_INDEX];
@@ -113,7 +107,6 @@ export class DomRendererRowFactory {
         charElement.classList.add(`xterm-bg-${bg}`);
       }
       fragment.appendChild(charElement);
-      colCount += width;
     }
     return fragment;
   }

--- a/src/renderer/dom/DomRendererRowFactory.ts
+++ b/src/renderer/dom/DomRendererRowFactory.ts
@@ -29,11 +29,12 @@ export class DomRendererRowFactory {
     // properly support reflow and disallow data to go beyond the right-side of
     // the viewport).
     let lineLength = 0;
-    for (let x = 0; x < lineData.length; x++) {
+    for (let x = lineData.length - 1; x >= 0; x--) {
       const charData = lineData.get(x);
       const code = charData[CHAR_DATA_CODE_INDEX];
       if (code !== NULL_CELL_CODE || (isCursorRow && x === cursorX)) {
         lineLength = x + 1;
+        break;
       }
     }
 


### PR DESCRIPTION
Fixes #1609

---

This is an optimization to help make the DOM renderer more viable if the canvas renderer is replaced by https://github.com/xtermjs/xterm.js/pull/1790

---

Using the testing process outlined in https://github.com/xtermjs/xterm.js/wiki/Performance-testing#renderer (numbers measured on dc077a1)

**87x26 viewport**

Before: frames 16, average 11.53ms
After: frames 24, average 5.88ms

**300x80 viewport**

Before: frames 11, average 115.83ms
After: frames 13, average 17.12ms