### PR TITLE
Improve types of fill polyfill and test fallback

### DIFF
--- a/src/core/TypedArrayUtils.test.ts
+++ b/src/core/TypedArrayUtils.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 import { assert } from 'chai';
-import { fill } from './TypedArrayUtils';
+import { fillFallback } from './TypedArrayUtils';
 
 type TypedArray = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray
   | Int8Array | Int16Array | Int32Array
@@ -42,42 +42,42 @@ describe('polyfill conformance tests', function(): void {
     it('should work with all typed array types', function(): void {
       const u81 = new Uint8Array(5);
       const u82 = new Uint8Array(5);
-      deepEquals(fill(u81, 2), u82.fill(2));
-      deepEquals(fill(u81, -1), u82.fill(-1));
+      deepEquals(fillFallback(u81, 2), u82.fill(2));
+      deepEquals(fillFallback(u81, -1), u82.fill(-1));
       const u161 = new Uint16Array(5);
       const u162 = new Uint16Array(5);
-      deepEquals(fill(u161, 2), u162.fill(2));
-      deepEquals(fill(u161, 65535), u162.fill(65535));
-      deepEquals(fill(u161, -1), u162.fill(-1));
+      deepEquals(fillFallback(u161, 2), u162.fill(2));
+      deepEquals(fillFallback(u161, 65535), u162.fill(65535));
+      deepEquals(fillFallback(u161, -1), u162.fill(-1));
       const u321 = new Uint32Array(5);
       const u322 = new Uint32Array(5);
-      deepEquals(fill(u321, 2), u322.fill(2));
-      deepEquals(fill(u321, 65537), u322.fill(65537));
-      deepEquals(fill(u321, -1), u322.fill(-1));
+      deepEquals(fillFallback(u321, 2), u322.fill(2));
+      deepEquals(fillFallback(u321, 65537), u322.fill(65537));
+      deepEquals(fillFallback(u321, -1), u322.fill(-1));
       const i81 = new Int8Array(5);
       const i82 = new Int8Array(5);
-      deepEquals(fill(i81, 2), i82.fill(2));
-      deepEquals(fill(i81, -1), i82.fill(-1));
+      deepEquals(fillFallback(i81, 2), i82.fill(2));
+      deepEquals(fillFallback(i81, -1), i82.fill(-1));
       const i161 = new Int16Array(5);
       const i162 = new Int16Array(5);
-      deepEquals(fill(i161, 2), i162.fill(2));
-      deepEquals(fill(i161, 65535), i162.fill(65535));
-      deepEquals(fill(i161, -1), i162.fill(-1));
+      deepEquals(fillFallback(i161, 2), i162.fill(2));
+      deepEquals(fillFallback(i161, 65535), i162.fill(65535));
+      deepEquals(fillFallback(i161, -1), i162.fill(-1));
       const i321 = new Int32Array(5);
       const i322 = new Int32Array(5);
-      deepEquals(fill(i321, 2), i322.fill(2));
-      deepEquals(fill(i321, 65537), i322.fill(65537));
-      deepEquals(fill(i321, -1), i322.fill(-1));
+      deepEquals(fillFallback(i321, 2), i322.fill(2));
+      deepEquals(fillFallback(i321, 65537), i322.fill(65537));
+      deepEquals(fillFallback(i321, -1), i322.fill(-1));
       const f321 = new Float32Array(5);
       const f322 = new Float32Array(5);
-      deepEquals(fill(f321, 1.2345), f322.fill(1.2345));
+      deepEquals(fillFallback(f321, 1.2345), f322.fill(1.2345));
       const f641 = new Float64Array(5);
       const f642 = new Float64Array(5);
-      deepEquals(fill(f641, 1.2345), f642.fill(1.2345));
+      deepEquals(fillFallback(f641, 1.2345), f642.fill(1.2345));
       const u8Clamped1 = new Uint8ClampedArray(5);
       const u8Clamped2 = new Uint8ClampedArray(5);
-      deepEquals(fill(u8Clamped1, 2), u8Clamped2.fill(2));
-      deepEquals(fill(u8Clamped1, 257), u8Clamped2.fill(257));
+      deepEquals(fillFallback(u8Clamped1, 2), u8Clamped2.fill(2));
+      deepEquals(fillFallback(u8Clamped1, 257), u8Clamped2.fill(257));
     });
     it('should work with all typed array types - explicit looping', function(): void {
       const u81 = new Uint8Array(5);
@@ -124,8 +124,8 @@ describe('polyfill conformance tests', function(): void {
         const u81 = new Uint8Array(5);
         const u82 = new Uint8Array(5);
         const u83 = new Uint8Array(5);
-        deepEquals(fill(u81, 2, i), u83.fill(2, i));
-        deepEquals(fill(u81, -1, i), u83.fill(-1, i));
+        deepEquals(fillFallback(u81, 2, i), u83.fill(2, i));
+        deepEquals(fillFallback(u81, -1, i), u83.fill(-1, i));
         deepEquals(loopFill(u82, 2, i), u83.fill(2, i));
         deepEquals(loopFill(u82, -1, i), u83.fill(-1, i));
       }
@@ -135,8 +135,8 @@ describe('polyfill conformance tests', function(): void {
         const u81 = new Uint8Array(5);
         const u82 = new Uint8Array(5);
         const u83 = new Uint8Array(5);
-        deepEquals(fill(u81, 2, 0, i), u83.fill(2, 0, i));
-        deepEquals(fill(u81, -1, 0, i), u83.fill(-1, 0, i));
+        deepEquals(fillFallback(u81, 2, 0, i), u83.fill(2, 0, i));
+        deepEquals(fillFallback(u81, -1, 0, i), u83.fill(-1, 0, i));
         deepEquals(loopFill(u82, 2, 0, i), u83.fill(2, 0, i));
         deepEquals(loopFill(u82, -1, 0, i), u83.fill(-1, 0, i));
       }
@@ -147,8 +147,8 @@ describe('polyfill conformance tests', function(): void {
           const u81 = new Uint8Array(5);
           const u82 = new Uint8Array(5);
           const u83 = new Uint8Array(5);
-          deepEquals(fill(u81, 2, i, j), u83.fill(2, i, j));
-          deepEquals(fill(u81, -1, i, j), u83.fill(-1, i, j));
+          deepEquals(fillFallback(u81, 2, i, j), u83.fill(2, i, j));
+          deepEquals(fillFallback(u81, -1, i, j), u83.fill(-1, i, j));
           deepEquals(loopFill(u82, 2, i, j), u83.fill(2, i, j));
           deepEquals(loopFill(u82, -1, i, j), u83.fill(-1, i, j));
         }

--- a/src/core/TypedArrayUtils.ts
+++ b/src/core/TypedArrayUtils.ts
@@ -12,11 +12,15 @@ type TypedArray = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray
   | Int8Array | Int16Array | Int32Array
   | Float32Array | Float64Array;
 
-export function fill(array: TypedArray, value: number, start: number = 0, end?: number | undefined): TypedArray {
+export function fill<T extends TypedArray>(array: T, value: number, start: number = 0, end?: number | undefined): T {
   // all modern engines that support .fill
   if (array.fill) {
-    return array.fill(value, start, end);
+    return array.fill(value, start, end) as T;
   }
+  return fillFallback(array, value, start, end);
+}
+
+export function fillFallback<T extends TypedArray>(array: T, value: number, start: number = 0, end?: number | undefined): T {
   // safari and IE 11
   // since IE 11 does not support Array.prototype.fill either
   // we cannot use the suggested polyfill from MDN


### PR DESCRIPTION
The polyfill will now return the T instead of the TypedArray union
type. Tests now target the fallback only so engines that support fill
will run tests against the fallback code.