### PR TITLE
Deprecate JS array buffer

### DIFF
--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -7,7 +7,7 @@ import { CircularList } from './common/CircularList';
 import { CharData, ITerminal, IBuffer, IBufferLine, BufferIndex, IBufferStringIterator, IBufferStringIteratorResult, IBufferLineConstructor } from './Types';
 import { EventEmitter } from './common/EventEmitter';
 import { IMarker } from 'xterm';
-import { BufferLine, BufferLineTypedArray } from './BufferLine';
+import { BufferLine, BufferLineJSArray } from './BufferLine';
 import { DEFAULT_COLOR } from './renderer/atlas/Types';
 
 export const DEFAULT_ATTR = (0 << 18) | (DEFAULT_COLOR << 9) | (256 << 0);
@@ -57,9 +57,9 @@ export class Buffer implements IBuffer {
   }
 
   public setBufferLineFactory(type: string): void {
-    if (type === 'TypedArray') {
-      if (this._bufferLineConstructor !== BufferLineTypedArray) {
-        this._bufferLineConstructor = BufferLineTypedArray;
+    if (type === 'JsArray') {
+      if (this._bufferLineConstructor !== BufferLineJSArray) {
+        this._bufferLineConstructor = BufferLineJSArray;
         this._recreateLines();
       }
     } else {

--- a/src/BufferLine.ts
+++ b/src/BufferLine.ts
@@ -7,8 +7,9 @@ import { NULL_CELL_CODE, NULL_CELL_WIDTH, NULL_CELL_CHAR } from './Buffer';
 
 /**
  * Class representing a terminal line.
+ * @deprecated
  */
-export class BufferLine implements IBufferLine {
+export class BufferLineJSArray implements IBufferLine {
   protected _data: CharData[];
   public isWrapped = false;
   public length: number;
@@ -94,14 +95,14 @@ export class BufferLine implements IBufferLine {
     }
   }
 
-  public copyFrom(line: BufferLine): void {
+  public copyFrom(line: BufferLineJSArray): void {
     this._data = line._data.slice(0);
     this.length = line.length;
     this.isWrapped = line.isWrapped;
   }
 
   public clone(): IBufferLine {
-    const newLine = new BufferLine(0);
+    const newLine = new BufferLineJSArray(0);
     newLine.copyFrom(this);
     return newLine;
   }
@@ -129,7 +130,7 @@ const enum Cell {
  * TODO:
  *    - provide getData/setData to directly access the data
  */
-export class BufferLineTypedArray implements IBufferLine {
+export class BufferLine implements IBufferLine {
   protected _data: Uint32Array | null = null;
   protected _combined: {[index: number]: string} = {};
   public length: number;
@@ -248,7 +249,7 @@ export class BufferLineTypedArray implements IBufferLine {
   }
 
   /** alter to a full copy of line  */
-  public copyFrom(line: BufferLineTypedArray): void {
+  public copyFrom(line: BufferLine): void {
     if (this.length !== line.length) {
       this._data = new Uint32Array(line._data);
     } else {
@@ -265,7 +266,7 @@ export class BufferLineTypedArray implements IBufferLine {
 
   /** create a new clone */
   public clone(): IBufferLine {
-    const newLine = new BufferLineTypedArray(0);
+    const newLine = new BufferLine(0);
     // creation of new typed array from another is actually pretty slow :(
     // still faster than copying values one by one
     newLine._data = new Uint32Array(this._data);

--- a/src/BufferLine.ts
+++ b/src/BufferLine.ts
@@ -7,7 +7,8 @@ import { NULL_CELL_CODE, NULL_CELL_WIDTH, NULL_CELL_CHAR } from './Buffer';
 
 /**
  * Class representing a terminal line.
- * @deprecated
+ * 
+ * @deprecated to be removed with one of the next releases
  */
 export class BufferLineJSArray implements IBufferLine {
   protected _data: CharData[];
@@ -120,15 +121,6 @@ const enum Cell {
 
 /**
  * Typed array based bufferline implementation.
- * Note:  Unlike the JS variant the access to the data
- *        via set/get is always a copy action.
- *        Sloppy ref style coding will not work anymore:
- *           line = new BufferLine(10);
- *           char = line.get(0);        // char is a copy
- *           char[some_index] = 123;    // will not update the line
- *           line.set(0, ch);           // do this to update line data
- * TODO:
- *    - provide getData/setData to directly access the data
  */
 export class BufferLine implements IBufferLine {
   protected _data: Uint32Array | null = null;

--- a/src/BufferLine.ts
+++ b/src/BufferLine.ts
@@ -7,7 +7,7 @@ import { NULL_CELL_CODE, NULL_CELL_WIDTH, NULL_CELL_CHAR } from './Buffer';
 
 /**
  * Class representing a terminal line.
- * 
+ *
  * @deprecated to be removed with one of the next releases
  */
 export class BufferLineJSArray implements IBufferLine {

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -106,7 +106,7 @@ const DEFAULT_OPTIONS: ITerminalOptions = {
   theme: null,
   rightClickSelectsWord: Browser.isMac,
   rendererType: 'canvas',
-  experimentalBufferLineImpl: 'JsArray'
+  experimentalBufferLineImpl: 'TypedArray'
 };
 
 export class Terminal extends EventEmitter implements ITerminal, IDisposable, IInputHandlingTerminal {
@@ -1179,7 +1179,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
    */
   public scroll(isWrapped: boolean = false): void {
     let newLine: IBufferLine;
-    const useRecycling = this.options.experimentalBufferLineImpl === 'TypedArray';
+    const useRecycling = this.options.experimentalBufferLineImpl !== 'JsArray';
     if (useRecycling) {
       newLine = this._blankLine;
       if (!newLine || newLine.length !== this.cols || newLine.get(0)[CHAR_DATA_ATTR_INDEX] !== this.eraseAttr()) {

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -108,7 +108,7 @@ declare module 'xterm' {
      * - 'TypedArray': The new experimental implementation based on TypedArrays that is expected to
      *   significantly boost performance and memory consumption. Use at your own risk.
      *
-     * This option will be removed in the future.
+     * @deprecated This option will be removed in the future.
      */
     experimentalBufferLineImpl?: 'JsArray' | 'TypedArray';
 


### PR DESCRIPTION
Deprecates JS array buffer version. Part of #1811.

Note that this has a big implication on the tests - they now also run with the typed array buffer.