### PR TITLE
Remove one call to charCodeAt in a tight loop while parsing input

### DIFF
--- a/src/EscapeSequenceParser.ts
+++ b/src/EscapeSequenceParser.ts
@@ -378,8 +378,10 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
       // shortcut for most chars (print action)
       if (currentState === ParserState.GROUND && code > 0x1f && code < 0x80) {
         print = (~print) ? print : i;
-        do i++;
-        while (i < l && data.charCodeAt(i) > 0x1f && data.charCodeAt(i) < 0x80);
+        do {
+          ++i;
+          code = data.charCodeAt(i);
+        } while (i < l && code > 0x1f && code < 0x80);
         i--;
         continue;
       }


### PR DESCRIPTION
I've been profiling really long outputs on hyper and this is in the hot path. Not sure how much this helps (probably not a lot) but it doesn't hurt either.
