### PR TITLE
Weblinks should not allow quotes at end of urls enclosed in quotes

### DIFF
--- a/src/addons/webLinks/webLinks.test.ts
+++ b/src/addons/webLinks/webLinks.test.ts
@@ -63,4 +63,28 @@ describe('webLinks addon', () => {
 
     assert.equal(uri, 'http://foo.com/colon:test');
   });
+
+  it('should not allow " character at the end of a URI enclosed with ""', () => {
+    const term = new MockTerminal();
+    webLinks.webLinksInit(<any>term);
+
+    const row = '"http://foo.com/"';
+
+    const match = row.match(term.regex);
+    const uri = match[term.options.matchIndex];
+
+    assert.equal(uri, 'http://foo.com/');
+  });
+
+  it('should not allow \' character at the end of a URI enclosed with \'\'', () => {
+    const term = new MockTerminal();
+    webLinks.webLinksInit(<any>term);
+
+    const row = '\'http://foo.com/\'';
+
+    const match = row.match(term.regex);
+    const uri = match[term.options.matchIndex];
+
+    assert.equal(uri, 'http://foo.com/');
+  });
 });

--- a/src/addons/webLinks/webLinks.ts
+++ b/src/addons/webLinks/webLinks.ts
@@ -14,7 +14,7 @@ const ipClause = '((\\d{1,3}\\.){3}\\d{1,3})';
 const localHostClause = '(localhost)';
 const portClause = '(:\\d{1,5})';
 const hostClause = '((' + domainBodyClause + '\\.' + tldClause + ')|' + ipClause + '|' + localHostClause + ')' + portClause + '?';
-const pathClause = '(\\/[\\/\\w\\.\\-%~:]*)*([^:\\s])';
+const pathClause = '(\\/[\\/\\w\\.\\-%~:]*)*([^:"\'\\s])';
 const queryStringHashFragmentCharacterSet = '[0-9\\w\\[\\]\\(\\)\\/\\?\\!#@$%&\'*+,:;~\\=\\.\\-]*';
 const queryStringClause = '(\\?' + queryStringHashFragmentCharacterSet + ')?';
 const hashFragmentClause = '(#' + queryStringHashFragmentCharacterSet + ')?';


### PR DESCRIPTION
Fixes https://github.com/xtermjs/xterm.js/issues/1845

Adds a few tests for the expected behavior. Not a comprehensive fix for enclosed URIs though. Could definitely use a better link parser as suggested in https://github.com/xtermjs/xterm.js/issues/583

