### PR TITLE
Fix npm scripts crashing when using node 10+

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4479,9 +4479,9 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 natives@^1.1.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.4.tgz#2f0f224fc9a7dd53407c7667c84cf8dbe773de58"
-  integrity sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 needle@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
When using node 10+, several npm scripts crash with the following:

```
fs.js:25
'use strict';
^

ReferenceError: internalBinding is not defined
     at fs.js:25:1
```

To reproduce, try running `yarn` when using node 10 or 11

Updating `natives` to version `1.1.6` fixes this