### PR TITLE
Fix missing quotes in import statement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Addons are JavaScript modules that extend the `Terminal` prototype with new meth
 To use an addon, just import the JavaScript module and pass it to `Terminal`'s `applyAddon` method:
 
 ```javascript
-import { Terminal } from xterm;
+import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 
 


### PR DESCRIPTION
Fixes a small typo in the addons section of readme:

`import { Terminal } from xterm;`

should be

`import { Terminal } from 'xterm';`