### PR TITLE
Allow holding key on mac to send multiple keys to terminal

### DIFF
--- a/src/core/input/Keyboard.test.ts
+++ b/src/core/input/Keyboard.test.ts
@@ -289,6 +289,7 @@ describe('Keyboard', () => {
 
     it('should handle uppercase letters', () => {
       assert.equal(testEvaluateKeyboardEvent({ shiftKey: true, keyCode: 65, key: 'A' }).key, 'A');
+      assert.equal(testEvaluateKeyboardEvent({ shiftKey: true, keyCode: 49, key: '!' }).key, '!');
     });
 
   });

--- a/src/core/input/Keyboard.test.ts
+++ b/src/core/input/Keyboard.test.ts
@@ -281,5 +281,15 @@ describe('Keyboard', () => {
       assert.equal(testEvaluateKeyboardEvent({ keyCode: 0, key: 'UIKeyInputDownArrow' }).key, '\x1b[B');
       assert.equal(testEvaluateKeyboardEvent({ keyCode: 0, key: 'UIKeyInputDownArrow' }, { applicationCursorMode: true }).key, '\x1bOB');
     });
+
+    it('should handle lowercase letters', () => {
+      assert.equal(testEvaluateKeyboardEvent({ keyCode: 65, key: 'a' }).key, 'a');
+      assert.equal(testEvaluateKeyboardEvent({ keyCode: 189, key: '-' }).key, '-');
+    });
+
+    it('should handle uppercase letters', () => {
+      assert.equal(testEvaluateKeyboardEvent({ shiftKey: true, keyCode: 65, key: 'A' }).key, 'A');
+    });
+
   });
 });

--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -349,6 +349,8 @@ export function evaluateKeyboardEvent(
         if (ev.keyCode === 65) { // cmd + a
           result.type = KeyboardResultType.SELECT_ALL;
         }
+      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.key !== 'Shift') {
+        result.key = ev.key;
       }
       break;
   }

--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -349,7 +349,7 @@ export function evaluateKeyboardEvent(
         if (ev.keyCode === 65) { // cmd + a
           result.type = KeyboardResultType.SELECT_ALL;
         }
-      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.key !== 'Shift') {
+      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 65) {
         result.key = ev.key;
       }
       break;

--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -349,7 +349,8 @@ export function evaluateKeyboardEvent(
         if (ev.keyCode === 65) { // cmd + a
           result.type = KeyboardResultType.SELECT_ALL;
         }
-      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 48) {
+      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 48
+        && ev.keyCode !== 144 && ev.keyCode !== 145) { // Include only keys that that result in a character; don't include num lock and scroll lock
         result.key = ev.key;
       }
       break;

--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -349,7 +349,7 @@ export function evaluateKeyboardEvent(
         if (ev.keyCode === 65) { // cmd + a
           result.type = KeyboardResultType.SELECT_ALL;
         }
-      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 65) {
+      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 48) {
         result.key = ev.key;
       }
       break;

--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -349,8 +349,9 @@ export function evaluateKeyboardEvent(
         if (ev.keyCode === 65) { // cmd + a
           result.type = KeyboardResultType.SELECT_ALL;
         }
-      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 48
-        && ev.keyCode !== 144 && ev.keyCode !== 145) { // Include only keys that that result in a character; don't include num lock and scroll lock
+      } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey &&
+          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145) {
+        // Include only keys that that result in a character; don't include num lock and scroll lock
         result.key = ev.key;
       }
       break;


### PR DESCRIPTION
Fixes #265 - Holding down a key only sends a single key on Mac 
Also see https://github.com/Microsoft/vscode/issues/65436

![2018-12-20 09 46 01](https://user-images.githubusercontent.com/1689183/50291273-18ac3a80-043c-11e9-8e49-dcc2eb544018.gif)
