### PR TITLE
bind classList function before calling in toggleFullScreen

### DIFF
--- a/src/addons/fullscreen/fullscreen.ts
+++ b/src/addons/fullscreen/fullscreen.ts
@@ -22,6 +22,7 @@ export function toggleFullScreen(term: Terminal, fullscreen: boolean): void {
     fn = term.element.classList.add;
   }
 
+  fn = fn.bind(term.element.classList);
   fn('fullscreen');
 }
 


### PR DESCRIPTION
```
fn = term.element.classList.add;
fn('fullscreen'); 
```
Can result in a "Illegal invocation" error in Chrome and an "Invalid calling object" error in Edge. 
Adding fn = fn.bind(term.element.classList) fixes this.