### PR TITLE
Add sanity checks to dom renderer underline code

### DIFF
--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -364,9 +364,11 @@ export class DomRenderer extends EventEmitter implements IRenderer {
         return;
       }
       const span = <HTMLElement>row.children[x];
-      span.style.textDecoration = enabled ? 'underline' : 'none';
-      x = (x + 1) % cols;
-      if (x === 0) {
+      if (span) {
+        span.style.textDecoration = enabled ? 'underline' : 'none';
+      }
+      if (++x >= cols) {
+        x = 0;
         y++;
       }
     }


### PR DESCRIPTION
Fixes #1860 

---

I had trouble reproducing on this PC so I couldn't root cause the problem, I changed it  to add some sanity checks to make sure we don't go over cols and that the span exists.