### PR TITLE
Fix search addons: searchTerm should not be matched if the beginning of matching index < 0

### DIFF
--- a/src/addons/search/SearchHelper.ts
+++ b/src/addons/search/SearchHelper.ts
@@ -222,7 +222,9 @@ export class SearchHelper implements ISearchHelper {
       }
     } else {
       if (isReverseSearch) {
-        resultIndex = searchStringLine.lastIndexOf(searchTerm, col - searchTerm.length);
+        if (col - searchTerm.length >= 0) {
+          resultIndex = searchStringLine.lastIndexOf(searchTerm, col - searchTerm.length);
+        }
       } else {
         resultIndex = searchStringLine.indexOf(searchTerm, col);
       }


### PR DESCRIPTION
I tested using `find previous` function in search add-ons. It turns out that searching cannot go to previous line if the current result start at column index `0` as seen in the following picture:

<img width="875" alt="screen shot 2561-12-29 at 02 58 08" src="https://user-images.githubusercontent.com/10810463/50526756-d4ddc300-0b16-11e9-993a-f0e2e88e5997.png">

The current selection (the first `meow` at second line) is stuck and couldn't continue finding other results. I think it's because `lastIndexOf` function still do matching string at the beginning of `searchStringLine` although `searchStringLine`'s length is smaller than `searchTerm`, which should return `-1`. I fix the code by adding if clause to check whether the comparing range of `searchStringLine` is shorter than `searchTerm` or not.