### PR TITLE
stop AltGraph/Meta from being written to terminal

### DIFF
--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -350,8 +350,10 @@ export function evaluateKeyboardEvent(
           result.type = KeyboardResultType.SELECT_ALL;
         }
       } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey &&
-          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145  && ev.keyCode !== 225) {
-        // Include only keys that that result in a character; don't include num lock, scroll lock, and AltGraph
+          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145 &&
+          ev.keyCode !== 225 && ev.keyCode != 91) {
+        // Include only keys that that result in a character; don't include num lock,
+        // scroll lock, AltGraph, or Meta keys
         result.key = ev.key;
       }
       break;

--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -350,8 +350,8 @@ export function evaluateKeyboardEvent(
           result.type = KeyboardResultType.SELECT_ALL;
         }
       } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey &&
-          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145) {
-        // Include only keys that that result in a character; don't include num lock and scroll lock
+          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145  && ev.keyCode !== 225) {
+        // Include only keys that that result in a character; don't include num lock, scroll lock, and AltGraph
         result.key = ev.key;
       }
       break;


### PR DESCRIPTION
Fixes regression introduced in https://github.com/xtermjs/xterm.js/pull/1849 where pressing the `AltGraph` key (to e.g. input a `]` on a german keyboard) results in a literal `AltGraph` being input in the terminal. Same goes for `Meta` -- not sure if either of those are Linux-only problems though.

![image](https://user-images.githubusercontent.com/6735977/50631755-d1e33800-0f45-11e9-87de-38ac67d62233.png)


