### PR TITLE
Fix for Windows key printing "Meta" on Linux (and Windows?)

### DIFF
--- a/src/core/input/Keyboard.ts
+++ b/src/core/input/Keyboard.ts
@@ -350,7 +350,7 @@ export function evaluateKeyboardEvent(
           result.type = KeyboardResultType.SELECT_ALL;
         }
       } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey &&
-          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145) {
+          ev.keyCode >= 48 && ev.keyCode !== 144 && ev.keyCode !== 145 && ev.keyCode !== 91) {
         // Include only keys that that result in a character; don't include num lock and scroll lock
         result.key = ev.key;
       }


### PR DESCRIPTION
## Problem

On Linux, press the "Windows" key: The text "Meta" is sent to the terminal. Introduced in https://github.com/xtermjs/xterm.js/pull/1849

## Solution

Do not set `result.key` to "Meta" in `evaluateKeyboardEvent`

## Tests

 - [x] Doesn't send "Meta" anymore on Linux
 - [x] Key repeat still works
 - [ ] Sanity check MacOS

**only tested on Hyper**