### PR TITLE
linedata cache

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -337,6 +337,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     const insertMode: boolean = this._terminal.insertMode;
     const curAttr: number = this._terminal.curAttr;
     let bufferRow = buffer.lines.get(buffer.y + buffer.ybase);
+    bufferRow.invalidateCache();
 
     this._terminal.updateRange(buffer.y);
     for (let stringPosition = start; stringPosition < end; ++stringPosition) {
@@ -428,6 +429,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           }
           // row changed, get it again
           bufferRow = buffer.lines.get(buffer.y + buffer.ybase);
+          bufferRow.invalidateCache();
         } else {
           if (chWidth === 2) {
             // FIXME: check for xterm behavior

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -528,4 +528,5 @@ export interface IBufferLine {
   clone(): IBufferLine;
   getTrimmedLength(): number;
   translateToString(trimRight?: boolean, startCol?: number, endCol?: number): string;
+  invalidateCache(): void;
 }


### PR DESCRIPTION
This PR introduces line level cache for the trimmed length and the trimmed content string, which should greatly speedup any consumer of `translateToString`.
The caching is lazy, thus a value gets only saved upon requesting:
- trimmedLength
- trimmed full line string (important to start at col 0, this will also cache trimmed length as it relies on `getTrimmedLength()` internally)

@Tyriar I have no good real world test case for this. Could you test it with the lineFeed consumer in vscode and compare the runtime and memory consumption with and without this PR? Not sure yet whether its the right way to overcome the multiple string consumer problem. 