### PR TITLE
Emoji fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^3.4.34",
+    "@types/dom-inputevent": "^1.0.3",
     "@types/glob": "^5.0.35",
     "@types/jsdom": "11.0.1",
     "@types/mocha": "^2.2.33",
@@ -65,8 +66,5 @@
     "watch": "concurrently --kill-others-on-fail --names \"lib,css\" \"tsc -w\" \"gulp watch-css\"",
     "watch-addons": "concurrently --kill-others-on-fail --names \"attach,fit,fullscreen,search,terminado,webLinks,winptyCompat,zmodem\" \"tsc -w -p ./src/addons/attach\" \"tsc -w -p ./src/addons/fit\" \"tsc -w -p ./src/addons/fullscreen\" \"tsc -w -p ./src/addons/search\" \"tsc -w -p ./src/addons/terminado\" \"tsc -w -p ./src/addons/webLinks\" \"tsc -w -p ./src/addons/winptyCompat\" \"tsc -w -p ./src/addons/zmodem\"",
     "layering": "concurrently --kill-others-on-fail --names \"common,core\" \"tsc -p ./src/common\" \"tsc -p ./src/core\""
-  },
-  "dependencies": {
-    "@types/dom-inputevent": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "watch": "concurrently --kill-others-on-fail --names \"lib,css\" \"tsc -w\" \"gulp watch-css\"",
     "watch-addons": "concurrently --kill-others-on-fail --names \"attach,fit,fullscreen,search,terminado,webLinks,winptyCompat,zmodem\" \"tsc -w -p ./src/addons/attach\" \"tsc -w -p ./src/addons/fit\" \"tsc -w -p ./src/addons/fullscreen\" \"tsc -w -p ./src/addons/search\" \"tsc -w -p ./src/addons/terminado\" \"tsc -w -p ./src/addons/webLinks\" \"tsc -w -p ./src/addons/winptyCompat\" \"tsc -w -p ./src/addons/zmodem\"",
     "layering": "concurrently --kill-others-on-fail --names \"common,core\" \"tsc -p ./src/common\" \"tsc -p ./src/core\""
+  },
+  "dependencies": {
+    "@types/dom-inputevent": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^3.4.34",
-    "@types/dom-inputevent": "^1.0.3",
     "@types/glob": "^5.0.35",
     "@types/jsdom": "11.0.1",
     "@types/mocha": "^2.2.33",

--- a/src/CompositionHelper.ts
+++ b/src/CompositionHelper.ts
@@ -4,7 +4,6 @@
  */
 
 import { ITerminal } from './Types';
-import { isEmoji } from './Emoji';
 
 interface IPosition {
   start: number;
@@ -126,7 +125,7 @@ export class CompositionHelper {
       // Cancel any delayed composition send requests and send the input immediately.
       this._isSendingComposition = false;
       const input = this._textarea.value.substring(this._compositionPosition.start, this._compositionPosition.end);
-      this._handler(input);
+      this._terminal.handler(input);
     } else {
       // Make a deep copy of the composition position here as a new compositionstart event may
       // fire before the setTimeout executes.
@@ -158,15 +157,9 @@ export class CompositionHelper {
             // (eg. 2) after a composition character.
             input = this._textarea.value.substring(currentCompositionPosition.start);
           }
-          this._handler(input);
+          this._terminal.handler(input);
         }
       }, 0);
-    }
-  }
-
-  private _handler(str: string): void {
-    if (!isEmoji(str)) {
-      this._terminal.handler(str);
     }
   }
 
@@ -184,7 +177,7 @@ export class CompositionHelper {
         const newValue = this._textarea.value;
         const diff = newValue.replace(oldValue, '');
         if (diff.length > 0) {
-          this._handler(diff);
+          this._terminal.handler(diff);
         }
       }
     }, 0);

--- a/src/Emoji.ts
+++ b/src/Emoji.ts
@@ -1,11 +1,19 @@
 // This function returns whether the first code point of the provided string is
 // within a range that contains emoji. Some of the codepoints in these ranges
 // are unassigned so this test is an approximation to the real thing.
-// Ranges taken from: https://stackoverflow.com/questions/30757193/
+// Ranges taken from:
+//   https://stackoverflow.com/questions/30757193/
 // For a complete list of all assigned codepoints, go to:
 //   https://unicode.org/Public/emoji/11.0/emoji-data.txt
 export function isEmoji(str: string): boolean {
+  if (str.codePointAt === undefined) {
+    return false;
+  }
   const codePoint = str.codePointAt(0);
+  // Short circuit for the most common case (i.e. non-emoji characters)
+  if (codePoint < 8400) {
+    return false;
+  }
   if ((codePoint >= 0x1F600 && codePoint <= 0x1F64F) || // Emoticons
       (codePoint >= 0x1F300 && codePoint <= 0x1F5FF) || // Misc Symbols and Pictographs
       (codePoint >= 0x1F680 && codePoint <= 0x1F6FF) || // Transport and Map

--- a/src/Emoji.ts
+++ b/src/Emoji.ts
@@ -1,0 +1,24 @@
+// This function returns whether the first code point of the provided string is
+// within a range that contains emoji. Some of the codepoints in these ranges
+// are unassigned so this test is an approximation to the real thing.
+// Ranges taken from: https://stackoverflow.com/questions/30757193/
+// For a complete list of all assigned codepoints, go to:
+//   https://unicode.org/Public/emoji/11.0/emoji-data.txt
+export function isEmoji(str: string): boolean {
+  const codePoint = str.codePointAt(0);
+  if ((codePoint >= 0x1F600 && codePoint <= 0x1F64F) || // Emoticons
+      (codePoint >= 0x1F300 && codePoint <= 0x1F5FF) || // Misc Symbols and Pictographs
+      (codePoint >= 0x1F680 && codePoint <= 0x1F6FF) || // Transport and Map
+      (codePoint >= 0x1F1E6 && codePoint <= 0x1F1FF) || // Regional country flags
+      (codePoint >= 0x2600 && codePoint <= 0x26FF) ||   // Misc symbols
+      (codePoint >= 0x2700 && codePoint <= 0x27BF) ||   // Dingbats
+      (codePoint >= 0xFE00 && codePoint <= 0xFE0F) ||   // Variation Selectors
+      (codePoint >= 0x1F900 && codePoint <= 0x1F9FF) || // Supplemental Symbols and Pictographs
+      (codePoint >= 127000 && codePoint <= 127600) ||   // Various asian characters
+      (codePoint >= 65024 && codePoint <= 65039) ||     // Variation selector
+      (codePoint >= 9100 && codePoint <= 9300) ||       // Misc items
+      (codePoint >= 8400 && codePoint <= 8447)) {       // Combining Diacritical Marks for Symbols
+    return true;
+  }
+  return false;
+}

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1508,7 +1508,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   }
 
   protected _onInput(event: InputEvent) {
-    if (isEmoji(event.data)) {
+    if (event.inputType === 'insertText' && isEmoji(event.data)) {
       this.showCursor();
       this.handler(event.data);
     }

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -52,6 +52,7 @@ import { IKeyboardEvent } from './common/Types';
 import { evaluateKeyboardEvent } from './core/input/Keyboard';
 import { KeyboardResultType, ICharset } from './core/Types';
 import { clone } from './common/Clone';
+import { isEmoji } from './Emoji';
 
 // Let it work inside Node.js for automated testing purposes.
 const document = (typeof window !== 'undefined') ? window.document : null;
@@ -591,6 +592,14 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
    */
   private _bindKeys(): void {
     const self = this;
+
+    this.register(addDisposableDomListener(this.element, 'input', function (ev: InputEvent): void {
+      if (document.activeElement !== this) {
+        return;
+      }
+      self._onInput(ev);
+    }, true));
+
     this.register(addDisposableDomListener(this.element, 'keydown', function (ev: KeyboardEvent): void {
       if (document.activeElement !== this) {
         return;
@@ -613,6 +622,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
       self._keyUp(ev);
     }, true));
 
+    this.register(addDisposableDomListener(this.textarea, 'input', (ev: InputEvent) => this._onInput(ev), true));
     this.register(addDisposableDomListener(this.textarea, 'keydown', (ev: KeyboardEvent) => this._keyDown(ev), true));
     this.register(addDisposableDomListener(this.textarea, 'keypress', (ev: KeyboardEvent) => this._keyPress(ev), true));
     this.register(addDisposableDomListener(this.textarea, 'compositionstart', () => this._compositionHelper.compositionstart()));
@@ -1494,6 +1504,13 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   public selectLines(start: number, end: number): void {
     if (this.selectionManager) {
       this.selectionManager.selectLines(start, end);
+    }
+  }
+
+  protected _onInput(event: InputEvent) {
+    if (isEmoji(event.data)) {
+      this.showCursor();
+      this.handler(event.data);
     }
   }
 

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -48,7 +48,7 @@ import { ScreenDprMonitor } from './ui/ScreenDprMonitor';
 import { ITheme, IMarker, IDisposable } from 'xterm';
 import { removeTerminalFromCache } from './renderer/atlas/CharAtlasCache';
 import { DomRenderer } from './renderer/dom/DomRenderer';
-import { IKeyboardEvent } from './common/Types';
+import { IKeyboardEvent, IInputEvent } from './common/Types';
 import { evaluateKeyboardEvent } from './core/input/Keyboard';
 import { KeyboardResultType, ICharset } from './core/Types';
 import { clone } from './common/Clone';
@@ -593,7 +593,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
   private _bindKeys(): void {
     const self = this;
 
-    this.register(addDisposableDomListener(this.element, 'input', function (ev: InputEvent): void {
+    this.register(addDisposableDomListener(this.element, 'input', function (ev: IInputEvent): void {
       if (document.activeElement !== this) {
         return;
       }
@@ -622,7 +622,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
       self._keyUp(ev);
     }, true));
 
-    this.register(addDisposableDomListener(this.textarea, 'input', (ev: InputEvent) => this._onInput(ev), true));
+    this.register(addDisposableDomListener(this.textarea, 'input', (ev: IInputEvent) => this._onInput(ev), true));
     this.register(addDisposableDomListener(this.textarea, 'keydown', (ev: KeyboardEvent) => this._keyDown(ev), true));
     this.register(addDisposableDomListener(this.textarea, 'keypress', (ev: KeyboardEvent) => this._keyPress(ev), true));
     this.register(addDisposableDomListener(this.textarea, 'compositionstart', () => this._compositionHelper.compositionstart()));
@@ -1507,7 +1507,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     }
   }
 
-  protected _onInput(event: InputEvent) {
+  protected _onInput(event: IInputEvent) {
     if (event.inputType === 'insertText' && isEmoji(event.data)) {
       this.showCursor();
       this.handler(event.data);

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -21,6 +21,15 @@ export interface IKeyboardEvent {
   type: string;
 }
 
+/**
+ * There's a @types/dom-inputevent but at the moment it's outdated and missing
+ * some properties (e.g. inputType). So in the meantime we're using this instead
+ */
+export interface IInputEvent {
+  readonly data?: string;
+  readonly inputType?: string;
+}
+
 export interface ICircularList<T> extends IEventEmitter {
   length: number;
   maxLength: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.5.2.tgz#c11cd2817d3a401b7ba0f5a420f35c56139b1c1e"
   integrity sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=
 
+"@types/dom-inputevent@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/dom-inputevent/-/dom-inputevent-1.0.3.tgz#7831e0628a98a04bbac450c95220ded6e04a1f84"
+  integrity sha512-xuBw5JB6s3JGRv1w4O1Gz5Ryr7Y3GJbEHtrGNpuQAkrw3YR3IYEYbDPTaCPWf33tcXoeRwSYbkaHt4zE6xe14w==
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"


### PR DESCRIPTION
## Problems
There were multiple problems with emoji

 1. Opening the emoji dialog was possible but it appeared at a weird location. This was due to the textarea we use for input was not being kept in sync with the cursor position unless a composition (i.e. IME input) was underway.
 1. No emoji was received by the terminal.

## Solutions

 1. Now the textarea always moves with the cursor.
 1. Added handler for the `input` event, only for emoji handling. Also, the textarea needs to have a `lineheight > 0` for this event to fire, at least in Chromium.

## Testing

 - [ ] MacOS
   - [x] Emojis are inserted from the emoji input popup
   - [x] The popup shows at the right location
   - [x] Pasting still works fine. Including pasting emoji
   - [x] Chrome
   - [ ] Firefox
   - [x] Safari
   - [x] IMEs still work (jp/ko/ch) including inserting emoji from Pinyin IME
 - [ ] Windows
   - [ ] Emojis are inserted from the emoji input popup
   - [ ] The popup shows at the right location
   - [ ] Pasting still works fine. Including pasting emoji
   - [ ] Chrome
   - [ ] Firefox
   - [ ] Safari
   - [x] ~~IE (support dropped)~~
   - [ ] IMEs still work (jp/ko/ch) including inserting emoji from Pinyin IME
 - [x] Electron (via Hyper)

![2019-01-04_16-24](https://user-images.githubusercontent.com/1410520/50711787-477dff80-103d-11e9-81e3-e445ad383531.png)