### PR TITLE
Prevent charsizechanged from firing unnecessarily

### DIFF
--- a/src/ui/CharMeasure.ts
+++ b/src/ui/CharMeasure.ts
@@ -46,9 +46,10 @@ export class CharMeasure extends EventEmitter implements ICharMeasure {
     if (geometry.width === 0 || geometry.height === 0) {
       return;
     }
-    if (this._width !== geometry.width || this._height !== geometry.height) {
+    const adjustedHeight = Math.ceil(geometry.height);
+    if (this._width !== geometry.width || this._height !== adjustedHeight) {
       this._width = geometry.width;
-      this._height = Math.ceil(geometry.height);
+      this._height = adjustedHeight;
       this.emit('charsizechanged');
     }
   }


### PR DESCRIPTION
## Problem

`charsizechanged` was being fired regardless of whether the actual char size changed or not. 

## Solution
 
Only fire the event when the "adjusted size" (rounded up) changes.


I ran into this bug because, when using the WebGL renderer, canvas resizes are very expensive on Chrome. This was causing the renderer to resize the canvas every time `measure` was called.

## Tests

 - [x] Terminal resizes up/down when changing the number of cols/rows
 - [x] Terminal resizes up/down when changing the font size