### PR TITLE
Support RTL languages in the canvas renderer

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -52,6 +52,7 @@ import { IKeyboardEvent } from './common/Types';
 import { evaluateKeyboardEvent } from './core/input/Keyboard';
 import { KeyboardResultType, ICharset } from './core/Types';
 import { clone } from './common/Clone';
+import { registerRtlCharacterJoiners } from './Unicode';
 
 // Let it work inside Node.js for automated testing purposes.
 const document = (typeof window !== 'undefined') ? window.document : null;
@@ -752,7 +753,6 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     // Listen for mouse events and translate
     // them into terminal mouse protocols.
     this.bindMouse();
-
   }
 
   private _setupRenderer(): void {
@@ -762,6 +762,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
       default: throw new Error(`Unrecognized rendererType "${this.options.rendererType}"`);
     }
     this.register(this.renderer);
+    registerRtlCharacterJoiners(this);
   }
 
   /**

--- a/src/Unicode.test.ts
+++ b/src/Unicode.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { createUnicodeRangeJoiner } from './Unicode';
+
+describe('createUnicodeRangeJoiner', () => {
+  it('should join charcaters within the range', () => {
+    // Join a-z
+    const joiner = createUnicodeRangeJoiner(97, 122);
+    assert.deepEqual(joiner('ABCabc aBc abC Abc'), [
+      [3, 6],   // abc
+      [11, 13], // ab
+      [16, 18]  // bc
+    ]);
+  });
+});

--- a/src/Unicode.ts
+++ b/src/Unicode.ts
@@ -47,5 +47,5 @@ function createUnicodeRangeJoiner(rangeStart: number, rangeEnd: number): (text: 
       result.push([start, start + length + 1]);
     }
     return result;
-  }
+  };
 }

--- a/src/Unicode.ts
+++ b/src/Unicode.ts
@@ -25,7 +25,7 @@ export function registerRtlCharacterJoiners(terminal: Terminal): void {
   terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x1EE00, 0x1EEFF));
 }
 
-function createUnicodeRangeJoiner(rangeStart: number, rangeEnd: number): (text: string) => [number, number][] {
+export function createUnicodeRangeJoiner(rangeStart: number, rangeEnd: number): (text: string) => [number, number][] {
   return (text: string) => {
     let start = -1;
     let length = 0;
@@ -33,18 +33,23 @@ function createUnicodeRangeJoiner(rangeStart: number, rangeEnd: number): (text: 
     for (let i = 0; i < text.length; i++) {
       const code = text.charCodeAt(i);
       if (code >= rangeStart && code <= rangeEnd) {
+        // Add to range
         if (start === -1) {
           start = i;
         }
         length++;
-      } else if (length > 1) {
-        result.push([start, start + length + 1]);
+      } else {
+        if (length > 1) {
+          // Finish range
+          result.push([start, start + length]);
+        }
+        // Clear a single match
         start = -1;
         length = 0;
       }
     }
     if (length > 0) {
-      result.push([start, start + length + 1]);
+      result.push([start, start + length]);
     }
     return result;
   };

--- a/src/Unicode.ts
+++ b/src/Unicode.ts
@@ -32,7 +32,7 @@ export function createUnicodeRangeJoiner(rangeStart: number, rangeEnd: number): 
     const result: [number, number][] = [];
     for (let i = 0; i < text.length; i++) {
       const code = text.charCodeAt(i);
-      if (code >= rangeStart && code <= rangeEnd) {
+      if (code >= rangeStart && code <= rangeEnd || code === 32) {
         // Add to range
         if (start === -1) {
           start = i;

--- a/src/Unicode.ts
+++ b/src/Unicode.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ */
+
+import { Terminal } from 'xterm';
+
+export function registerRtlCharacterJoiners(terminal: Terminal): void {
+  // Hebrew
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x0590, 0x05FF));
+  // Arabic (Kurdish, Persian, Urdu)
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x0600, 0x06FF));
+  // Arabic Supplement
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x0750, 0x077F));
+  // Thanana (Dhivehi, Maldavian)
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x0780, 0x07BF));
+  // Arabic Extended-A
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x08A0, 0x08FF));
+  // Arabic Presentation Forms-A
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0xFB50, 0xFDFF));
+  // Arabic Presentation Forms-B
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0xFE70, 0xFEFF));
+  // Rumi Numeral Symbols
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x10E60, 0x10E60));
+  // Arabic Mathematical Alphabetic Symbols
+  terminal.registerCharacterJoiner(createUnicodeRangeJoiner(0x1EE00, 0x1EEFF));
+}
+
+function createUnicodeRangeJoiner(rangeStart: number, rangeEnd: number): (text: string) => [number, number][] {
+  return (text: string) => {
+    let start = -1;
+    let length = 0;
+    const result: [number, number][] = [];
+    for (let i = 0; i < text.length; i++) {
+      const code = text.charCodeAt(i);
+      if (code >= rangeStart && code <= rangeEnd) {
+        if (start === -1) {
+          start = i;
+        }
+        length++;
+      } else if (length > 1) {
+        result.push([start, start + length + 1]);
+        start = -1;
+        length = 0;
+      }
+    }
+    if (length > 0) {
+      result.push([start, start + length + 1]);
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Part of #701 

Before:

<img width="145" alt="screen shot 2019-01-17 at 9 15 13 am" src="https://user-images.githubusercontent.com/2193314/51336035-72525580-1a38-11e9-8298-5aeecc0ec5b4.png">

After:

<img width="175" alt="screen shot 2019-01-17 at 9 15 21 am" src="https://user-images.githubusercontent.com/2193314/51336047-767e7300-1a38-11e9-9ba6-2a8bace03da8.png">

This does slow things down (~50% slower) but I think @jerch is working on improving the character joiner code to be faster, if the registerCharacterJoiner API works with codes instead of a big string it shouldn't make much difference.

DOM/WebGL renderer support will work when they support the character joiner API.