### PR TITLE
Remove unused var and unneeded defensive check

### DIFF
--- a/demo/start.js
+++ b/demo/start.js
@@ -5,7 +5,6 @@
  * This file is the entry point for browserify.
  */
 
-const cp = require('child_process');
 const path = require('path');
 const webpack = require('webpack');
 const startServer = require('./server.js');

--- a/src/common/CircularList.ts
+++ b/src/common/CircularList.ts
@@ -144,24 +144,22 @@ export class CircularList<T> extends EventEmitter implements ICircularList<T> {
       this._length -= deleteCount;
     }
 
-    if (items && items.length) {
-      // Add items
-      for (let i = this._length - 1; i >= start; i--) {
-        this._array[this._getCyclicIndex(i + items.length)] = this._array[this._getCyclicIndex(i)];
-      }
-      for (let i = 0; i < items.length; i++) {
-        this._array[this._getCyclicIndex(start + i)] = items[i];
-      }
+    // Add items
+    for (let i = this._length - 1; i >= start; i--) {
+      this._array[this._getCyclicIndex(i + items.length)] = this._array[this._getCyclicIndex(i)];
+    }
+    for (let i = 0; i < items.length; i++) {
+      this._array[this._getCyclicIndex(start + i)] = items[i];
+    }
 
-      // Adjust length as needed
-      if (this._length + items.length > this._maxLength) {
-        const countToTrim = (this._length + items.length) - this._maxLength;
-        this._startIndex += countToTrim;
-        this._length = this._maxLength;
-        this.emit('trim', countToTrim);
-      } else {
-        this._length += items.length;
-      }
+    // Adjust length as needed
+    if (this._length + items.length > this._maxLength) {
+      const countToTrim = (this._length + items.length) - this._maxLength;
+      this._startIndex += countToTrim;
+      this._length = this._maxLength;
+      this.emit('trim', countToTrim);
+    } else {
+      this._length += items.length;
     }
   }
 


### PR DESCRIPTION
...items as an arg will always be an array

<img width="341" alt="screen shot 2019-01-17 at 9 48 13 am" src="https://user-images.githubusercontent.com/2193314/51337844-0faf8880-1a3d-11e9-8a67-f37a40fa9897.png">

Spotted these in https://lgtm.com/projects/g/xtermjs/xterm.js/alerts/?mode=list