### PR TITLE
fix mouse event listener change before term attached

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1291,7 +1291,9 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._terminal.vt200Mouse = params[0] === 1000;
           this._terminal.normalMouse = params[0] > 1000;
           this._terminal.mouseEvents = true;
-          this._terminal.element.classList.add('enable-mouse-events');
+          if (this._terminal.element) {
+            this._terminal.element.classList.add('enable-mouse-events');
+          }
           this._terminal.selectionManager.disable();
           this._terminal.log('Binding to mouse events.');
           break;
@@ -1479,7 +1481,9 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._terminal.vt200Mouse = false;
           this._terminal.normalMouse = false;
           this._terminal.mouseEvents = false;
-          this._terminal.element.classList.remove('enable-mouse-events');
+          if (this._terminal.element) {
+            this._terminal.element.classList.remove('enable-mouse-events');
+          }
           this._terminal.selectionManager.enable();
           break;
         case 1004: // send focusin/focusout events

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -733,6 +733,12 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     this.register(addDisposableDomListener(this._viewportElement, 'scroll', () => this.selectionManager.refresh()));
 
     this.mouseHelper = new MouseHelper(this.renderer);
+    // apply mouse event classes set by escape codes before terminal was attached
+    if (this.mouseEvents) {
+      this.element.classList.add('enable-mouse-events');
+    } else {
+      this.element.classList.remove('enable-mouse-events');
+    }
 
     if (this.options.screenReaderMode) {
       // Note that this must be done *after* the renderer is created in order to

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -734,11 +734,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
 
     this.mouseHelper = new MouseHelper(this.renderer);
     // apply mouse event classes set by escape codes before terminal was attached
-    if (this.mouseEvents) {
-      this.element.classList.add('enable-mouse-events');
-    } else {
-      this.element.classList.remove('enable-mouse-events');
-    }
+    this.element.classList.toggle('enable-mouse-events', this.mouseEvents);
 
     if (this.options.screenReaderMode) {
       // Note that this must be done *after* the renderer is created in order to


### PR DESCRIPTION
Whenever a terminal would receive a `\x1b[?1003h` or `\x1b[?1003l` escape code (e.g. when opening a tmux session) before being attached with `terminal.open(element)` the following internal error would be thrown:
```
Uncaught TypeError: Cannot read property 'classList' of undefined
    at InputHandler.resetMode (InputHandler.ts:1482)
    at Array.<anonymous> (InputHandler.ts:161)
    at EscapeSequenceParser.parse (EscapeSequenceParser.ts:507)
    at InputHandler.parse (InputHandler.ts:299)
    at Terminal._innerWrite (Terminal.ts:1382)
    at Terminal.ts:1351
```

This PR fixes that issue and should still apply the correct classes at all times.