### PR TITLE
reference isn't commented out properly

### DIFF
--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -7,7 +7,7 @@
  * to be stable and consumed by external programs.
  */
 
-/// <reference lib="dom"/>
+// <reference lib="dom"/>
 
 declare module 'xterm' {
   /**


### PR DESCRIPTION
Error is being thrown when installing xterm:

ERROR in node_modules/xterm/typings/xterm.d.ts(10,1): error TS1084: Invalid 'reference' directive syntax.