### PR TITLE
Clear selection state if selection doesn't exists

### DIFF
--- a/src/renderer/SelectionRenderLayer.ts
+++ b/src/renderer/SelectionRenderLayer.ts
@@ -55,6 +55,7 @@ export class SelectionRenderLayer extends BaseRenderLayer {
 
     // Selection does not exist
     if (!start || !end) {
+      this._clearState();
       return;
     }
 


### PR DESCRIPTION
Firstly, I've checked the issue of VSCode, https://github.com/Microsoft/vscode/issues/67438
While debugging, I've realised that is issue of xterm.js dependency.
Also, it is reproduced in demo mode (Chrome browser, mac os)
Problem is that previous selection state is saving, but not always clearing.
And while window is refreshing, new selection is comparing with previous state that not always correct.