### PR TITLE
*actually* fix mouse handler before term attached

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1284,7 +1284,9 @@ export class InputHandler extends Disposable implements IInputHandler {
           if (this._terminal.element) {
             this._terminal.element.classList.add('enable-mouse-events');
           }
-          this._terminal.selectionManager.disable();
+          if (this._terminal.selectionManager) {
+            this._terminal.selectionManager.disable();
+          }
           this._terminal.log('Binding to mouse events.');
           break;
         case 1004: // send focusin/focusout events
@@ -1474,7 +1476,9 @@ export class InputHandler extends Disposable implements IInputHandler {
           if (this._terminal.element) {
             this._terminal.element.classList.remove('enable-mouse-events');
           }
-          this._terminal.selectionManager.enable();
+          if (this._terminal.selectionManager) {
+            this._terminal.selectionManager.enable();
+          }
           break;
         case 1004: // send focusin/focusout events
           this._terminal.sendFocus = false;

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -739,9 +739,9 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     // apply mouse event classes set by escape codes before terminal was attached
     this.element.classList.toggle('enable-mouse-events', this.mouseEvents);
     if (this.mouseEvents) {
-      this.selectionManager.disable()
+      this.selectionManager.disable();
     } else {
-      this.selectionManager.enable()
+      this.selectionManager.enable();
     }
 
     if (this.options.screenReaderMode) {

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -738,6 +738,11 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     this.mouseHelper = new MouseHelper(this.renderer);
     // apply mouse event classes set by escape codes before terminal was attached
     this.element.classList.toggle('enable-mouse-events', this.mouseEvents);
+    if (this.mouseEvents) {
+      this.selectionManager.disable()
+    } else {
+      this.selectionManager.enable()
+    }
 
     if (this.options.screenReaderMode) {
       // Note that this must be done *after* the renderer is created in order to


### PR DESCRIPTION
This is a follow-up for https://github.com/xtermjs/xterm.js/pull/1905, which I apparently didn't test properly -- turns out `_terminal.selectionManager` isn't initialized either until `terminal.open()` is called...

With this additional fix opening a tmux session in an un-`open`ed terminal works. 

It would probably be a good idea to test this somewhere, but I'm not sure where to put this kind of integration test.