### PR TITLE
fix: Renderer: IntersectionObserver can produce more then 1 entry

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -70,7 +70,7 @@ export class Renderer extends EventEmitter implements IRenderer {
     // Detect whether IntersectionObserver is detected and enable renderer pause
     // and resume based on terminal visibility if so
     if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver(e => this.onIntersectionChange(e[0]), { threshold: 0 });
+      const observer = new IntersectionObserver(e => this.onIntersectionChange(e[e.length - 1]), { threshold: 0 });
       observer.observe(this._terminal.element);
       this.register({ dispose: () => observer.disconnect() });
     }


### PR DESCRIPTION
[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) can produce more than 1 entry, and latest is the most true, then first.

I'm using `xterm.js` in [Cloud Commander](cloudcmd.io) as [gritty](https://github.com/cloudcmd/gritty) middleware in a [modal](https://github.com/cloudcmd/modal) window. And I have a bug which is reproduced in the latest version of chrome but not in firefox. The thing is firefox shows modal with a terminal and output information because it has exactly one entry, and chrome has two entries, and second has `intersectionRatio=1`, but first has `intersectionRatio=0` so it shows empty screen.(https://github.com/coderaiser/cloudcmd/issues/214).