### PR TITLE
Disable reflow when winptyCompat is on

### DIFF
--- a/src/Buffer.ts
+++ b/src/Buffer.ts
@@ -211,7 +211,7 @@ export class Buffer implements IBuffer {
 
     this.scrollBottom = newRows - 1;
 
-    if (this._hasScrollback) {
+    if (this._isReflowEnabled) {
       this._reflow(newCols, newRows);
 
       // Trim the end of the line off if cols shrunk
@@ -224,6 +224,10 @@ export class Buffer implements IBuffer {
 
     this._cols = newCols;
     this._rows = newRows;
+  }
+
+  private get _isReflowEnabled(): boolean {
+    return this._hasScrollback && !(this._terminal as any).isWinptyCompatEnabled;
   }
 
   private _reflow(newCols: number, newRows: number): void {

--- a/src/addons/winptyCompat/winptyCompat.ts
+++ b/src/addons/winptyCompat/winptyCompat.ts
@@ -19,6 +19,8 @@ export function winptyCompatInit(terminal: Terminal): void {
     return;
   }
 
+  (addonTerminal._core as any).isWinptyCompatEnabled = true;
+
   // Winpty does not support wraparound mode which means that lines will never
   // be marked as wrapped. This causes issues for things like copying a line
   // retaining the wrapped new line characters or if consumers are listening


### PR DESCRIPTION
Fixes #1943

---

This is a quick and dirty fix that should completely disable reflow when winptyCompat is on (ie. the terminal backend is Windows-based). This prevents a potential crash.