### PR TITLE
Fix emoji width

### DIFF
--- a/src/CharWidth.test.ts
+++ b/src/CharWidth.test.ts
@@ -76,6 +76,20 @@ describe('getStringCellWidth', function(): void {
     assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
   });
   // TODO: multiline tests once #1685 is resolved
+  it('emojis', function(): void {
+    const input = '😁😁😁😁😁😁#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
+  it('emojis with combining chars', function(): void {
+    const input = 'e\u0301e\u0301😁😁😁😁😁😁#';
+    terminal.writeSync(input);
+    const s = terminal.buffer.iterator(true).next().content;
+    assert.equal(input, s);
+    assert.equal(getStringCellWidth(s), sumWidths(terminal.buffer, 0, 1, '#'));
+  });
 });
 
 it('wcwidth should match all values from the old implementation', function(): void {

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -9,7 +9,7 @@ import { C0, C1 } from './common/data/EscapeSequences';
 import { CHARSETS, DEFAULT_CHARSET } from './core/data/Charsets';
 import { CHAR_DATA_CHAR_INDEX, CHAR_DATA_WIDTH_INDEX, CHAR_DATA_CODE_INDEX, DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE } from './Buffer';
 import { FLAGS } from './renderer/Types';
-import { wcwidth } from './CharWidth';
+import { getStringCellWidth } from './CharWidth';
 import { EscapeSequenceParser } from './EscapeSequenceParser';
 import { ICharset } from './core/Types';
 import { IDisposable } from 'xterm';
@@ -332,7 +332,7 @@ export class InputHandler extends Disposable implements IInputHandler {
 
       // calculate print space
       // expensive call, therefore we save width in line buffer
-      chWidth = wcwidth(code);
+      chWidth = getStringCellWidth(char);
 
       // get charset replacement character
       // charset are only defined for ASCII, therefore we only
@@ -491,6 +491,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * Backspace (Ctrl-H).
    */
   public backspace(): void {
+    // console.log('←', this._terminal.buffer);
     if (this._terminal.buffer.x > 0) {
       this._terminal.buffer.x--;
     }


### PR DESCRIPTION
## Problem
As described in https://github.com/xtermjs/xterm.js/issues/469#issuecomment-451789158, emoji width is 1 when added then displayed in half, and delete width is 2 when it is deleted which caused character in the left is deleted by mistake.

### Conditions
1. Most emoji are 2 in cell width like😂, whose unicode is `\u55357`+`\u56834`
2. Some symbol emoji like ❌ is single unicode `\u10060`.
3. The monstrous zero code joiner 👩‍❤️‍💋‍👩 is `\u{200D}`, so`'👩‍❤️‍💋‍👩'.length === 11`, when copy & paste in Chrome address, it becomes  👩‍ ❤️‍ 💋‍ 👩 separated by `\u8205`

This only fix emoji width, IME support is WIP here https://github.com/xtermjs/xterm.js/pull/1890

## Solution
Single 'string' width is calculated by `wcwidth` which doesn't consider emojis. 
By extending `getStringCellWidth`, it can calculate both single 'string' and normal string width, containing either `wcwidth` standing characters and unicode emojis. Terminal should use `getStringCellWidth` other than `wcwidth` to cover emoji width calculation.

## References
https://mathiasbynens.be/notes/javascript-unicode
https://blog.jonnew.com/posts/poo-dot-length-equals-two

## Testing
- [x] Normal double-width emoji as 😂
- [ ] Normal single-width emoji as ❌
- [ ] Emoji with zero code joiner as 👩‍❤️‍💋‍👩, which is 👩‍ ❤️‍ 💋‍ 👩
- [ ] Cell width break `Buffer stringIndexToBufferIndex fullwidth combining with emoji - match emoji cell`. 'Lots of ￥\u0301 make me 😃.'  is 3 lines in `terminal.buffer.lines.get(some_line_index)` like:
```
Lots of ￥́
 make me 
😃.
```