### PR TITLE
Fix for issue #812: Xterm.js's encoding of mouse coordinate

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -854,16 +854,11 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
         if (ch > 127) ch = 127;
         data.push(ch);
       } else {
-        if (ch === 2047) {
-          data.push(0);
+        if (ch > 2047) {
+          data.push(2047);
           return;
-        }
-        if (ch < 127) {
-          data.push(ch);
         } else {
-          if (ch > 2047) ch = 2047;
-          data.push(0xC0 | (ch >> 6));
-          data.push(0x80 | (ch & 0x3F));
+          data.push(ch);
         }
       }
     }

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -857,9 +857,8 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
         if (ch > 2047) {
           data.push(2047);
           return;
-        } else {
-          data.push(ch);
         }
+        data.push(ch);
       }
     }
 


### PR DESCRIPTION
Changed the utf-8 mouse encoding to match iTerm

Fixes https://github.com/xtermjs/xterm.js/issues/812