### PR TITLE
Use new vscode serverReadyAction

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,11 @@
         "run",
         "start-debug"
       ],
-      "port": 9229
+      "port": 9229,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "App listening to (http://.*?:[0-9]+)"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding the new VS Code option to the project `launch.json` file

Reference
[Server Ready Action](https://code.visualstudio.com/updates/v1_32#_automatically-open-a-uri-when-debugging-a-server-program)

I'm using it and it works, what do you guys think?