### PR TITLE
Add vscode setting for single quote style

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.preferences.quoteStyle": "single"
+}


### PR DESCRIPTION
This will always use single quotes when TS server does auto imports,
implement interface, etc.

Pulled this from https://github.com/xtermjs/xterm.js/pull/2007