### PR TITLE
feat: terminal.write returns a Promise<void>

### DIFF
--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -34,6 +34,7 @@ describe('xterm.js', () => {
     term.write = (data) => {
       term.writeBuffer.push(data);
       (<any>term)._innerWrite();
+      return Promise.resolve();
     };
     (<any>term).element = {
       classList: {

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -55,7 +55,7 @@ export class MockTerminal implements ITerminal {
   resize(columns: number, rows: number): void {
     throw new Error('Method not implemented.');
   }
-  writeln(data: string): void {
+  writeln(data: string): Promise<void> {
     throw new Error('Method not implemented.');
   }
   open(parent: HTMLElement): void {
@@ -106,7 +106,7 @@ export class MockTerminal implements ITerminal {
   clear(): void {
     throw new Error('Method not implemented.');
   }
-  write(data: string): void {
+  write(data: string): Promise<void> {
     throw new Error('Method not implemented.');
   }
   bracketedPasteMode: boolean;

--- a/src/public/Terminal.ts
+++ b/src/public/Terminal.ts
@@ -61,8 +61,8 @@ export class Terminal implements ITerminalApi {
   public resize(columns: number, rows: number): void {
     this._core.resize(columns, rows);
   }
-  public writeln(data: string): void {
-    this._core.writeln(data);
+  public writeln(data: string): Promise<void> {
+    return this._core.writeln(data);
   }
   public open(parent: HTMLElement): void {
     this._core.open(parent);
@@ -130,8 +130,8 @@ export class Terminal implements ITerminalApi {
   public clear(): void {
     this._core.clear();
   }
-  public write(data: string): void {
-    this._core.write(data);
+  public write(data: string): Promise<void> {
+    return this._core.write(data);
   }
   public getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'fontWeight' | 'fontWeightBold' | 'rendererType' | 'termName'): string;
   public getOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'screenKeys' | 'useFlowControl' | 'visualBell'): boolean;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -550,7 +550,7 @@ declare module 'xterm' {
      * Writes text to the terminal, followed by a break line character (\n).
      * @param data The text to write to the terminal.
      */
-    writeln(data: string): void;
+    writeln(data: string): Promise<void>;
 
     /**
      * Opens the terminal within an element.
@@ -735,7 +735,7 @@ declare module 'xterm' {
      * Writes text to the terminal.
      * @param data The text to write to the terminal.
      */
-    write(data: string): void;
+    write(data: string): Promise<void>;
 
     /**
      * Retrieves an option's value from the terminal.


### PR DESCRIPTION
in order to allow clients to observe completion of writes, the `refresh` event is insufficient; that event allows clients to know when pending animation frames are done, but there is still a race window due to the setTimeout in Terminal.write. this PR allows clients to await on that setTimeout; combining an await on Terminal.write with listens on `refresh`, a client can observe full completion of pending writes

Fixes #1650