### PR TITLE
Refactored the CSS code of cursor blink

### DIFF
--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -174,9 +174,9 @@ export class DomRenderer extends Disposable implements IRenderer {
     // Blink animation
     styles +=
         `@keyframes blink {` +
-        ` 0 % { opacity: 1.0; }` +
+        ` 0% { opacity: 1.0; }` +
         ` 50% { opacity: 0.0; }` +
-        ` 100 % { opacity: 1.0; }` +
+        ` 100% { opacity: 1.0; }` +
         `}`;
     // Cursor
     styles +=


### PR DESCRIPTION
## Description

This PR refactored the CSS code of `@keyframes blink`.
`%` of `0 %` and `100 %` is not recognized by the browser.
It works without problems, but I corrected it just in case.

## Screenshot

### Currently

![NotRecognizedPercent](https://user-images.githubusercontent.com/11808736/57158081-7060a680-6e1d-11e9-9630-8446d0179a84.jpg)


### After

![RecognizedPercent](https://user-images.githubusercontent.com/11808736/57158100-78b8e180-6e1d-11e9-8cb4-0e552e5eac2e.jpg)
