### PR TITLE
Add a dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:10
+
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+# Verify git and process tools are installed
+RUN apt-get install -y git procps
+
+# Install yarn
+RUN apt-get install -y curl apt-transport-https lsb-release \
+    && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+    && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends yarn
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "xterm.js",
+  "dockerFile": "Dockerfile",
+  "appPort": 3000,
+  "extensions": [
+    "editorconfig.editorconfig",
+    "ms-vscode.vscode-typescript-tslint-plugin"
+  ]
+}


### PR DESCRIPTION
This lets users using VS Code/Docker avoid installing node and the C++
dependencies necessary for running xterm.js.

---

I can add some info on this to the docs afterwards.