### PR TITLE
Added PHP App Server to Real-world uses section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**Jumpserver**](https://github.com/jumpserver/luna): Jumpserver Luna project, Jumpserver is a bastion server project, Luna use xterm.js for web terminal emulation.
 - [**LxdMosaic**](https://github.com/turtle0x1/LxdMosaic): Uses xterm.js to give terminal access to containers through LXD
 - [**CodeInterview.io**](https://codeinterview.io): A coding interview platform in 25+ languages and many web frameworks. Uses xterm.js to provide shell access.
-- [**Bastillion**](https://www.bastillion.io): Bastillion is an open-source web-based SSH console that centrally manages administrative access to systems. 
+- [**Bastillion**](https://www.bastillion.io): Bastillion is an open-source web-based SSH console that centrally manages administrative access to systems.
+- [**PHP App Server**](https://github.com/cubiclesoft/php-app-server/): Create lightweight, installable almost-native applications for desktop OSes.  ExecTerminal (nicely wraps the xterm.js Terminal), TerminalManager, and RunProcessSDK are self-contained, reusable ES5+ compliant Javascript components.
 
 [And much more...](https://github.com/xtermjs/xterm.js/network/dependents)
 


### PR DESCRIPTION
I realize my addition is longer (line length) than the other entries.  I can remove the ExecTerminal, TerminalManager, and RunProcessSDK bit if you want.

The relevant components' source code is here:

https://github.com/cubiclesoft/php-app-server/blob/master/www/support/run-process/run_process.js

I recall seeing at least one issue on this issue tracker where it is mentioned that the primary project goal is terminal emulation but that doing what ExecTerminal does is certainly possible.  Most of the use cases definitely seem to be focused on the SSH universe, which is cool.  ExecTerminal transforms Terminal into a kind of a single-process backend monitoring thing with full ANSI escape code and process control support, which enables some interesting use-cases.  TerminalManager and RunProcessSDK provide the other bits of glue to actually connect everything up to a WebSocket but I tried to make all three components isolated in their own universes (but certainly compatible with each other) so that users don't _have_ to use PHP App Server to use any of them (i.e. they could extract one or more components for use with Node or whatever).

While I'm pretty sure what I'm doing is a fairly unique usage of XTerm.js, I can certainly remove that second sentence if it is too long.  Let me know.