### PR TITLE
Replace prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "mocha": "gulp test",
     "prebuild": "tsc -b ./src/tsconfig.all.json",
     "build": "gulp build",
-    "prepublish": "npm run build",
+    "prepare": "npm run prebuild",
+    "prepublishOnly": "npm run build",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "watch": "tsc -b -w ./src/tsconfig.all.json --preserveWatchOutput"
   }


### PR DESCRIPTION
On prepublishOnly we want to do a full build, on prepare we want
to only build the ts projects so the .d.ts files are avilable.

Fixes #2019