### PR TITLE
Add typings for windowsMode

### DIFF
--- a/fixtures/typings-test/typings-test.ts
+++ b/fixtures/typings-test/typings-test.ts
@@ -21,7 +21,7 @@ namespace constructor {
       'disableStdin': false,
       'rows': 1,
       'scrollback': 10,
-      'tabStopWidth': 2,
+      'tabStopWidth': 2
     });
   }
 }
@@ -119,8 +119,8 @@ namespace methods_core {
     const t: Terminal = new Terminal();
     t.attachCustomKeyEventHandler((e: KeyboardEvent) => true);
     t.attachCustomKeyEventHandler((e: KeyboardEvent) => false);
-    const d1: IDisposable = t.addCsiHandler("x",
-       (params: number[], collect: string): boolean => params[0]===1);
+    const d1: IDisposable = t.addCsiHandler('x',
+       (params: number[], collect: string): boolean => params[0] === 1);
     d1.dispose();
     const d2: IDisposable = t.addOscHandler(199,
        (data: string): boolean => true);
@@ -155,6 +155,7 @@ namespace methods_core {
       const r25: string = t.getOption('fontWeightBold');
       const r26: boolean = t.getOption('allowTransparency');
       const r27: boolean = t.getOption('rightClickSelectsWord');
+      const r28: boolean = t.getOption('windowsMode');
     }
     {
       const t: Terminal = new Terminal();
@@ -177,6 +178,7 @@ namespace methods_core {
       t.setOption('useFlowControl', true);
       t.setOption('allowTransparency', true);
       t.setOption('visualBell', true);
+      t.setOption('windowsMode', true);
       t.setOption('colors', ['a', 'b']);
       t.setOption('letterSpacing', 1);
       t.setOption('cols', 1);

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -747,7 +747,7 @@ declare module 'xterm' {
      * Retrieves an option's value from the terminal.
      * @param key The option key.
      */
-    getOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'screenKeys' | 'useFlowControl' | 'visualBell'): boolean;
+    getOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'screenKeys' | 'useFlowControl' | 'visualBell' | 'windowsMode'): boolean;
     /**
      * Retrieves an option's value from the terminal.
      * @param key The option key.
@@ -798,7 +798,7 @@ declare module 'xterm' {
      * @param key The option key.
      * @param value The option value.
      */
-    setOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'popOnBell' | 'rightClickSelectsWord' | 'screenKeys' | 'useFlowControl' | 'visualBell', value: boolean): void;
+    setOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'debug' | 'disableStdin' | 'enableBold' | 'macOptionIsMeta' | 'popOnBell' | 'rightClickSelectsWord' | 'screenKeys' | 'useFlowControl' | 'visualBell' | 'windowsMode', value: boolean): void;
     /**
      * Sets an option on the terminal.
      * @param key The option key.


### PR DESCRIPTION
Missed this in 3.13.0, not a big deal it's just not presented as an option in editors, still compiles fine.