### PR TITLE
READY option in attach addon v3 and demo

### DIFF
--- a/demo/client.ts
+++ b/demo/client.ts
@@ -154,8 +154,8 @@ function runRealTerminal(): void {
    * To run it with UTF8 binary transport, swap comment on
    * the lines below. (Must also be switched in server.js)
    */
-  term.loadAddon(new AttachAddon(socket));
-  // term.loadAddon(new AttachAddon(socket, {inputUtf8: true}));
+  term.loadAddon(new AttachAddon(socket, {sendReady: true}));
+  // term.loadAddon(new AttachAddon(socket, {sendReady: true, inputUtf8: true}));
 
   term._initialized = true;
 }

--- a/demo/server.js
+++ b/demo/server.js
@@ -108,15 +108,13 @@ function startServer() {
     }
     const send = USE_BINARY_UTF8 ? bufferUtf8(ws, 5) : buffer(ws, 5);
 
-    term.on('data', function(data) {
-      try {
-        send(data);
-      } catch (ex) {
-        // The WebSocket is not open, ignore
+    ws.once('message', msg => {
+      // wait once for READY message at the beginning
+      if (msg !== '#READY#') {
+        throw new Error(`excepted "#READY#" as first message, but got "${msg}"`);
       }
-    });
-    ws.on('message', function(msg) {
-      term.write(msg);
+      ws.on('message', msg => term.write(msg));
+      term.on('data', data => send(data));
     });
     ws.on('close', function () {
       term.kill();

--- a/src/addons/attach/attach.ts
+++ b/src/addons/attach/attach.ts
@@ -106,7 +106,7 @@ export function attach(term: Terminal, socket: WebSocket, bidirectional: boolean
       socket.send(READY_MSG);
     } else if (this._socket.readyState === 0) {
       // still connecting, thus wait for open event
-      addSocketListener(socket, 'open', () => socket.send(READY_MSG));
+      socket.addEventListener('open', () => socket.send(READY_MSG), {once: true});
     }
   }
 }


### PR DESCRIPTION
Backport of the READY message of the attach addon from here https://github.com/xtermjs/xterm-addon-attach/pull/10.

Changes:
- `sendReady` flag for `attach` method
- respect READY message in demo

Note: Since the demo already switch to v4 addons, https://github.com/xtermjs/xterm-addon-attach/pull/10 should be applied first.