### PR TITLE
Fix what branch coverage is sent with

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
     displayName: 'Lint'
   - script: |
       yarn test-coverage
-      export COVERALLS_GIT_BRANCH=$BUILD_SOURCEBRANCH
+      export COVERALLS_GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       yarn coveralls
     displayName: 'Generate and publish coverage'
 


### PR DESCRIPTION
This should fix the coveralls badge as it appears to be working now, just it's reporting against `refs/head/master` instead of `master`