### PR TITLE
Revert "fix: don't use Math.floor in DomRenderer charWidth computation"

### DIFF
--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -90,7 +90,7 @@ export class DomRenderer extends Disposable implements IRenderer {
   }
 
   private _updateDimensions(): void {
-    this.dimensions.scaledCharWidth = this._terminal.charMeasure.width * window.devicePixelRatio;
+    this.dimensions.scaledCharWidth = Math.floor(this._terminal.charMeasure.width * window.devicePixelRatio);
     this.dimensions.scaledCharHeight = Math.ceil(this._terminal.charMeasure.height * window.devicePixelRatio);
     this.dimensions.scaledCellWidth = this.dimensions.scaledCharWidth + Math.round(this._terminal.options.letterSpacing);
     this.dimensions.scaledCellHeight = Math.floor(this.dimensions.scaledCharHeight * this._terminal.options.lineHeight);


### PR DESCRIPTION
This reverts commit 23bdb2a6c20d1df074ad54a92550ef4862b6669f (https://github.com/xtermjs/xterm.js/pull/2067)

I believe this caused https://github.com/microsoft/vscode/issues/74183 as it only happens in the DOM renderer.