### PR TITLE
Exclude tslint and devcontainer from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -38,6 +38,7 @@
 *.test.js
 *.test.js.map
 lib/test/
+tslint.json
 
 docs/
 /.idea/
@@ -46,3 +47,4 @@ bin/
 build/
 fixtures/
 demo/
+.devcontainer/


### PR DESCRIPTION
Fixes #2152