### PR TITLE
Build sourcemaps in lib

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,17 @@ const path = require('path');
  */
 module.exports = {
   entry: './out/public/Terminal.js',
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: ["source-map-loader"],
+        enforce: "pre",
+        exclude: /node_modules/
+      }
+    ]
+  },
   resolve: {
     modules: ['./node_modules'],
     extensions: [ '.js' ],


### PR DESCRIPTION
Fixes #2158

---

Verified by switching out `Terminal` in client.ts, it resolves to the TS correctly skipping over the out/ files which won't be included in the npm package.