### PR TITLE
Remove path mapping to self modules

### DIFF
--- a/src/common/tsconfig.json
+++ b/src/common/tsconfig.json
@@ -5,10 +5,7 @@
     "types": [
       "../../node_modules/@types/mocha"
     ],
-    "baseUrl": "..",
-    "paths": {
-      "common/*": [ "./common/*" ]
-    }
+    "baseUrl": ".."
   },
   "include": [ "./**/*" ]
 }

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -7,8 +7,7 @@
     ],
     "baseUrl": "..",
     "paths": {
-      "common/*": [ "./common/*" ],
-      "core/*": [ "./core/*" ]
+      "common/*": [ "./common/*" ]
     }
   },
   "include": [ "./**/*" ],

--- a/src/ui/tsconfig.json
+++ b/src/ui/tsconfig.json
@@ -11,8 +11,7 @@
     ],
     "baseUrl": "..",
     "paths": {
-      "common/*": [ "./common/*" ],
-      "ui/*": [ "./ui/*" ]
+      "common/*": [ "./common/*" ]
     }
   },
   "include": [ "./**/*" ],


### PR DESCRIPTION
This would cause imports in the common module to reference out/ instead
of src/, this leads to weird behavior when errors are introduced.