### PR TITLE
Fix test warning

### DIFF
--- a/bin/test.js
+++ b/bin/test.js
@@ -14,8 +14,7 @@ let testFiles = [
   './out/*test.js',
   './out/**/*test.js',
   './out/*integration.js',
-  './out/**/*integration.js',
-  './lib/**/*test.js'
+  './out/**/*integration.js'
 ];
 
 // ability to inject particular test files via


### PR DESCRIPTION
Fixes warning on `yarn test`:

> Warning: Cannot find any files matching pattern "./lib/**/*test.js"