### PR TITLE
fix repeat preceding character sequence (REP)

### DIFF
--- a/src/InputHandler.api.ts
+++ b/src/InputHandler.api.ts
@@ -276,14 +276,14 @@ describe('InputHandler Integration Tests', function(): void {
       assert.deepEqual(await getLinesAsArray(2), ['##########', '######']);
       await page.evaluate(`
         window.term.reset();
-        window.term._core.wraparoundMode = false;
+        window.term.write('\x1b[?7l');  // disable wrap around
         window.term.write('#\x1b[15b');
       `);
       assert.deepEqual(await getLinesAsArray(2), ['##########', '']);
       // any successful sequence should reset REP
       await page.evaluate(`
         window.term.reset();
-        window.term._core.wraparoundMode = true;
+        window.term.write('\x1b[?7h');  // re-enable wrap around
         window.term.write('#\\n\x1b[3b');
         window.term.write('#\\r\x1b[3b');
         window.term.writeln('');
@@ -328,7 +328,7 @@ async function simulatePaste(text: string): Promise<string> {
 async function getCursor(): Promise<{col: number, row: number}> {
   return page.evaluate(`
   (function() {
-    return {col: term._core.buffer.x, row: term._core.buffer.y};
+    return {col: term.buffer.cursorX, row: term.buffer.cursorY};
   })();
   `);
 }

--- a/src/Terminal.integration.ts
+++ b/src/Terminal.integration.ts
@@ -107,7 +107,7 @@ if (os.platform() !== 'win32') {
     // for (let i = 0; i < files.length; ++i) console.debug(i, files[i]);
     // only successful tests for now
     const skip = [
-      10, 16, 17, 19, 32, 33, 34, 35, 36, 39,
+      10, 16, 17, 19, 32, 34, 35, 36, 39,
       40, 42, 43, 44, 45, 46, 47, 48, 49, 50,
       51, 52, 54, 55, 56, 57, 58, 59, 60, 61,
       63, 68

--- a/src/core/parser/Types.ts
+++ b/src/core/parser/Types.ts
@@ -103,6 +103,12 @@ export interface IDcsHandler {
 */
 export interface IEscapeSequenceParser extends IDisposable {
   /**
+   * Preceding codepoint to get REP working correctly.
+   * This must be set by the print handler as last action.
+   * It gets reset by the parser for any valid sequence beside REP itself.
+   */
+  precedingCodepoint: number;
+  /**
    * Reset the parser to its initial state (handlers are kept).
    */
   reset(): void;


### PR DESCRIPTION
Due to the change to `TERM=xterm-256color` ncurses based programs are likely to emit REP sequences to repeat the previous character in the data stream. We already had REP in `InputHandler` but it was broken in more than one way.
The changes are backed up with API tests and one integration test (test number 33).