### PR TITLE
Fix screen dpr change not refreshing canvas renderer

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -43,7 +43,7 @@ export class RenderService extends Disposable implements IRenderService {
     this.register(this._renderDebouncer);
 
     this._screenDprMonitor = new ScreenDprMonitor();
-    this._screenDprMonitor.setListener(() => this._renderer.onDevicePixelRatioChange());
+    this._screenDprMonitor.setListener(() => this.onDevicePixelRatioChange());
     this.register(this._screenDprMonitor);
 
     this.register(optionsService.onOptionChange(() => this._renderer.onOptionsChanged()));
@@ -51,7 +51,7 @@ export class RenderService extends Disposable implements IRenderService {
 
     // dprchange should handle this case, we need this as well for browsers that don't support the
     // matchMedia query.
-    this.register(addDisposableDomListener(window, 'resize', () => this._renderer.onDevicePixelRatioChange()));
+    this.register(addDisposableDomListener(window, 'resize', () => this.onDevicePixelRatioChange()));
 
     // Detect whether IntersectionObserver is detected and enable renderer pause
     // and resume based on terminal visibility if so
@@ -122,6 +122,7 @@ export class RenderService extends Disposable implements IRenderService {
 
   public onDevicePixelRatioChange(): void {
     this._renderer.onDevicePixelRatioChange();
+    this.refreshRows(0, this._rowCount);
   }
 
   public onResize(cols: number, rows: number): void {


### PR DESCRIPTION
Without this changing the zoom level would cause the canvas renderer to go blank