### PR TITLE
Add publish dry run feature and automate addon released based on changed files

### DIFF
--- a/addons/xterm-addon-attach/package.json
+++ b/addons/xterm-addon-attach/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-attach",
-  "version": "0.1.0-beta11",
+  "version": "0.1.0",
   "author": {
     "name": "The xterm.js authors",
     "url": "https://xtermjs.org/"

--- a/addons/xterm-addon-fit/package.json
+++ b/addons/xterm-addon-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-fit",
-  "version": "0.1.0-beta3",
+  "version": "0.1.0",
   "author": {
     "name": "The xterm.js authors",
     "url": "https://xtermjs.org/"

--- a/addons/xterm-addon-search/package.json
+++ b/addons/xterm-addon-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-search",
-  "version": "0.1.0-beta6",
+  "version": "0.1.0",
   "author": {
     "name": "The xterm.js authors",
     "url": "https://xtermjs.org/"

--- a/addons/xterm-addon-web-links/package.json
+++ b/addons/xterm-addon-web-links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-web-links",
-  "version": "0.1.0-beta10",
+  "version": "0.1.0",
   "author": {
     "name": "The xterm.js authors",
     "url": "https://xtermjs.org/"

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -15,13 +15,6 @@ if (isDryRun) {
   console.log('Publish dry run');
 }
 
-const addonPackageDirs = [
-  path.resolve(__dirname, '../addons/xterm-addon-attach'),
-  path.resolve(__dirname, '../addons/xterm-addon-fit'),
-  path.resolve(__dirname, '../addons/xterm-addon-search'),
-  path.resolve(__dirname, '../addons/xterm-addon-web-links')
-];
-
 const changedFiles = getChangedFilesInCommit('HEAD');
 
 // Publish xterm if any files were changed outside of the addons directory
@@ -30,6 +23,12 @@ if (changedFiles.some(e => e.search(/^addons\//) === -1)) {
 }
 
 // Publish addons if any files were changed inside of the addon
+const addonPackageDirs = [
+  path.resolve(__dirname, '../addons/xterm-addon-attach'),
+  path.resolve(__dirname, '../addons/xterm-addon-fit'),
+  path.resolve(__dirname, '../addons/xterm-addon-search'),
+  path.resolve(__dirname, '../addons/xterm-addon-web-links')
+];
 addonPackageDirs.forEach(p => {
   const addon = path.basename(p);
   if (changedFiles.some(e => e.indexOf(addon) !== -1)) {


### PR DESCRIPTION
`node ./bin/publish.js --dry` can now be used to test publishing.

This change also scans the most recent merge commit for the files changed in it and will publish `xterm` when a file outside the `addons/` directory changed and will publish addons if a file/folder contains the addon name.

v0.1.0 of each addon should publish as part of this PR getting merged.