### PR TITLE
Fix restore cursor related tests

### DIFF
--- a/src/InputHandler.test.ts
+++ b/src/InputHandler.test.ts
@@ -18,6 +18,7 @@ describe('InputHandler', () => {
     const terminal = new MockInputHandlingTerminal();
     terminal.buffer.x = 1;
     terminal.buffer.y = 2;
+    terminal.buffer.ybase = 0;
     terminal.curAttrData.fg = 3;
     const inputHandler = new InputHandler(terminal);
     // Save cursor position

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -126,7 +126,6 @@ export class Buffer implements IBuffer {
   public clear(): void {
     this.ydisp = 0;
     this.ybase = 0;
-    this.savedY = 0;
     this.y = 0;
     this.x = 0;
     this.lines = new CircularList<IBufferLine>(this._getCorrectBufferLength(this._rows));


### PR DESCRIPTION
Weird failure happening sometimes after #2217, not sure why pipelines
didn't pick it up.