### PR TITLE
Reset isWrapped line flag.

### DIFF
--- a/src/WindowsMode.ts
+++ b/src/WindowsMode.ts
@@ -22,9 +22,7 @@ export function applyWindowsMode(terminal: ITerminal): IDisposable {
     const line = terminal.buffer.lines.get(terminal.buffer.ybase + terminal.buffer.y - 1);
     const lastChar = line.get(terminal.cols - 1);
 
-    if (lastChar[CHAR_DATA_CODE_INDEX] !== NULL_CELL_CODE && lastChar[CHAR_DATA_CODE_INDEX] !== WHITESPACE_CELL_CODE) {
-      const nextLine = terminal.buffer.lines.get(terminal.buffer.ybase + terminal.buffer.y);
-      nextLine.isWrapped = true;
-    }
+    const nextLine = terminal.buffer.lines.get(terminal.buffer.ybase + terminal.buffer.y);
+    nextLine.isWrapped = (lastChar[CHAR_DATA_CODE_INDEX] !== NULL_CELL_CODE && lastChar[CHAR_DATA_CODE_INDEX] !== WHITESPACE_CELL_CODE);
   });
 }


### PR DESCRIPTION
Setting of `isWrapped` line flag only to `true` causes false positive line wrapping for such tools as `tmux` where the same buffer's line is reused for the new output.

Related issues:

https://github.com/jumptrading/FluentTerminal/issues/128
https://github.com/felixse/FluentTerminal/issues/420

Fix can be tested with Fluent Terminal build https://ci.appveyor.com/api/buildjobs/umvd60x78ayousy8/artifacts/MsiInstaller%2FFluentTerminalInstaller-v1.1.239.0-62054e9.msi ( used patched XTerm.JS v.3.14.1 )