### PR TITLE
Centers search scroll in viewport

### DIFF
--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -4,7 +4,6 @@
  */
 
 import { Terminal, IDisposable, ITerminalAddon } from 'xterm';
-import { floor } from 'mathjs';
 
 export interface ISearchOptions {
   regex?: boolean;
@@ -375,7 +374,7 @@ export class SearchAddon implements ITerminalAddon {
     }
     terminal.select(result.col, result.row, result.term.length);
     let scroll = result.row - terminal.buffer.viewportY;
-    scroll = scroll - floor(terminal.rows / 2);
+    scroll = scroll - Math.floor(terminal.rows / 2);
     terminal.scrollLines(scroll);
     return true;
   }

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -4,6 +4,7 @@
  */
 
 import { Terminal, IDisposable, ITerminalAddon } from 'xterm';
+import { floor } from 'mathjs';
 
 export interface ISearchOptions {
   regex?: boolean;
@@ -38,7 +39,7 @@ export class SearchAddon implements ITerminalAddon {
     this._terminal = terminal;
   }
 
-  public dispose(): void {}
+  public dispose(): void { }
 
   /**
    * Find the next instance of the term, then scroll to and select it. If it
@@ -234,7 +235,7 @@ export class SearchAddon implements ITerminalAddon {
    */
   private _isWholeWord(searchIndex: number, line: string, term: string): boolean {
     return (((searchIndex === 0) || (NON_WORD_CHARACTERS.indexOf(line[searchIndex - 1]) !== -1)) &&
-        (((searchIndex + term.length) === line.length) || (NON_WORD_CHARACTERS.indexOf(line[searchIndex + term.length]) !== -1)));
+      (((searchIndex + term.length) === line.length) || (NON_WORD_CHARACTERS.indexOf(line[searchIndex + term.length]) !== -1)));
   }
 
   /**
@@ -373,7 +374,9 @@ export class SearchAddon implements ITerminalAddon {
       return false;
     }
     terminal.select(result.col, result.row, result.term.length);
-    terminal.scrollLines(result.row - terminal.buffer.viewportY);
+    let scroll = result.row - terminal.buffer.viewportY;
+    scroll = scroll - floor(terminal.rows / 2);
+    terminal.scrollLines(scroll);
     return true;
   }
 }


### PR DESCRIPTION
This causes search to be centered inside the viewport rather than defaulting to the top of the terminal. This is a fix for https://github.com/microsoft/vscode/issues/50623.