### PR TITLE
Double wide characters could have halves selected

### DIFF
--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -506,7 +506,7 @@ export class SelectionService implements ISelectionService {
     }
 
     // Return early if the click event is not in the buffer (eg. in scroll bar)
-    if (line.length >= this._model.selectionStart[0]) {
+    if (line.length === this._model.selectionStart[0]) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/xtermjs/xterm.js/issues/1732. The logic to prevent clicking the scrollbar causing a selection was capturing and returning before I could select a double width character. The logic for selecting double width characters already existed, but was never hit. This PR changes the scroll bar selection logic so that the double width character logic can be fired.