### PR TITLE
Remove blankLine localized string

### DIFF
--- a/src/AccessibilityManager.ts
+++ b/src/AccessibilityManager.ts
@@ -258,7 +258,11 @@ export class AccessibilityManager extends Disposable {
       const posInSet = (buffer.ydisp + i + 1).toString();
       const element = this._rowElements[i];
       if (element) {
-        element.textContent = lineData.length === 0 ? Strings.blankLine : lineData;
+        if (lineData.length === 0) {
+          element.innerHTML = '&nbsp;';
+        } else {
+          element.textContent = lineData;
+        }
         element.setAttribute('aria-posinset', posInSet);
         element.setAttribute('aria-setsize', setSize);
       }

--- a/src/browser/LocalizableStrings.ts
+++ b/src/browser/LocalizableStrings.ts
@@ -3,6 +3,5 @@
  * @license MIT
  */
 
-export let blankLine = 'Blank line';
 export let promptLabel = 'Terminal input';
 export let tooMuchOutput = 'Too much output to announce, navigate to rows manually to read';

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -317,11 +317,6 @@ declare module 'xterm' {
    */
   export interface ILocalizableStrings {
     /**
-     * Announcement for a blank line when `screenReaderMode` is enabled.
-     */
-    blankLine: string;
-
-    /**
      * The aria label for the underlying input textarea for the terminal.
      */
     promptLabel: string;


### PR DESCRIPTION
Using a nbsp is more correct and lets the screen reader handle how it wants

Fixes #2260