### PR TITLE
Setting fontFamily and fontSize priority as important to avoid css overriding issue

### DIFF
--- a/src/CharMeasure.ts
+++ b/src/CharMeasure.ts
@@ -40,8 +40,8 @@ export class CharMeasure implements ICharMeasure {
   }
 
   public measure(options: ITerminalOptions): void {
-    this._measureElement.style.fontFamily = options.fontFamily;
-    this._measureElement.style.fontSize = `${options.fontSize}px`;
+    this._measureElement.style.setProperty('font-family', options.fontFamily, 'important');
+    this._measureElement.style.setProperty('font-size', `${options.fontSize}px`, 'important');
     const geometry = this._measureElement.getBoundingClientRect();
     // The element is likely currently display:none, we should retain the
     // previous value.


### PR DESCRIPTION
I am having the issue in one of my project, where `xterm` inserts `'W'` character to measure the width and height of character after adding specified (specified in xtermOptions) `font-family`. But my application is overriding that css by adding `font-family` as `!important` in its parent selector.