### PR TITLE
Cancel keydown events when not in screenReaderMode

### DIFF
--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -556,16 +556,12 @@ describe('Terminal', () => {
       afterEach(() => term.browser.isMac = originalIsMac);
 
       it('should interfere with the alt key on keyDown', () => {
-        (<any>term)._keyDownHandled = false;
         evKeyDown.altKey = true;
         evKeyDown.keyCode = 81;
-        term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, true);
-        (<any>term)._keyDownHandled = false;
+        assert.equal(term.keyDown(evKeyDown), false);
         evKeyDown.altKey = true;
         evKeyDown.keyCode = 192;
-        term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, true);
+        assert.equal(term.keyDown(evKeyDown), false);
       });
     });
 
@@ -578,29 +574,22 @@ describe('Terminal', () => {
       afterEach(() => term.browser.isMac = originalIsMac);
 
       it('should not interfere with the alt key on keyDown', () => {
-        (<any>term)._keyDownHandled = false;
         evKeyDown.altKey = true;
         evKeyDown.keyCode = 81;
-        term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, false);
-        (<any>term)._keyDownHandled = false;
+        assert.equal(term.keyDown(evKeyDown), true);
         evKeyDown.altKey = true;
         evKeyDown.keyCode = 192;
         term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, false);
+        assert.equal(term.keyDown(evKeyDown), true);
       });
 
       it('should interfere with the alt + arrow keys', () => {
-        (<any>term)._keyDownHandled = false;
         evKeyDown.altKey = true;
         evKeyDown.keyCode = 37;
-        term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, true);
-        (<any>term)._keyDownHandled = false;
+        assert.equal(term.keyDown(evKeyDown), false);
         evKeyDown.altKey = true;
         evKeyDown.keyCode = 39;
-        term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, true);
+        assert.equal(term.keyDown(evKeyDown), false);
       });
 
       it('should emit key with alt + key on keyPress', (done) => {
@@ -652,32 +641,26 @@ describe('Terminal', () => {
       afterEach(() => term.browser.isWindows = originalIsWindows);
 
       it('should not interfere with the alt + ctrl key on keyDown', () => {
-        (<any>term)._keyDownHandled = false;
         evKeyPress.altKey = true;
         evKeyPress.ctrlKey = true;
         evKeyPress.keyCode = 81;
-        term.keyDown(evKeyPress);
-        assert.equal((<any>term)._keyDownHandled, false);
-        (<any>term)._keyDownHandled = false;
+        assert.equal(term.keyDown(evKeyPress), true);
         evKeyDown.altKey = true;
         evKeyDown.ctrlKey = true;
         evKeyDown.keyCode = 81;
         term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, false);
+        assert.equal(term.keyDown(evKeyPress), true);
       });
 
-      it('should interefere with the alt + ctrl + arrow keys', () => {
+      it('should interfere with the alt + ctrl + arrow keys', () => {
         evKeyDown.altKey = true;
         evKeyDown.ctrlKey = true;
 
-        (<any>term)._keyDownHandled = false;
         evKeyDown.keyCode = 37;
-        term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, true);
-        (<any>term)._keyDownHandled = false;
+        assert.equal(term.keyDown(evKeyDown), false);
         evKeyDown.keyCode = 39;
         term.keyDown(evKeyDown);
-        assert.equal((<any>term)._keyDownHandled, true);
+        assert.equal(term.keyDown(evKeyDown), false);
       });
 
       it('should emit key with alt + ctrl + key on keyPress', (done) => {

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1568,10 +1568,19 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
       this.textarea.value = '';
     }
 
-    this._keyDownHandled = true;
     this._onKey.fire({ key: result.key, domEvent: event });
     this.showCursor();
     this._coreService.triggerDataEvent(result.key, true);
+
+    // Cancel events when not in screen reader mode so events don't get bubbled up and handled by
+    // other listeners. When screen reader mode is enabled, this could cause issues if the event
+    // is handled at a higher level, this is a compromise in order to echo keys to the screen
+    // reader.
+    if (!this.optionsService.options.screenReaderMode) {
+      return this.cancel(event, true);
+    }
+
+    this._keyDownHandled = true;
   }
 
   private _isThirdLevelShift(browser: IBrowser, ev: IKeyboardEvent): boolean {


### PR DESCRIPTION
This caused issues with embedder keybinding systems firing when they
shouldn't be. The fix is to only allow it in screenReaderMode as a
compromise so keys are echoed.

See https://github.com/microsoft/vscode/issues/77945