### PR TITLE
Removes Chai Assertion Library

### DIFF
--- a/addons/xterm-addon-attach/src/AttachAddon.api.ts
+++ b/addons/xterm-addon-attach/src/AttachAddon.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from 'xterm';
 import WebSocket = require('ws');
 

--- a/addons/xterm-addon-search/src/SearchAddon.api.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from 'xterm';
 
 const APP = 'http://127.0.0.1:3000/test';
@@ -14,7 +14,7 @@ let page: puppeteer.Page;
 const width = 800;
 const height = 600;
 
-describe.only('Search Tests', function (): void {
+describe('Search Tests', function (): void {
   this.timeout(200000);
 
   before(async function (): Promise<any> {

--- a/addons/xterm-addon-web-links/src/WebLinksAddon.api.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from 'xterm';
 
 const APP = 'http://127.0.0.1:3000/test';

--- a/addons/xterm-addon-webgl/src/TypedArray.test.ts
+++ b/addons/xterm-addon-webgl/src/TypedArray.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 The xterm.js authors. All rights reserved.
  * @license MIT
  */
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { sliceFallback } from './TypedArray';
 
 type TypedArray = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray

--- a/addons/xterm-addon-webgl/src/WebglRenderer.api.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from '../../../src/Types';
 import { ITheme } from 'xterm';
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf lib out addons/*/lib addons/*/out"
   },
   "devDependencies": {
-    "@types/chai": "^3.4.34",
+    "@types/assert": "^1.4.2",
     "@types/glob": "^5.0.35",
     "@types/jsdom": "11.0.1",
     "@types/mocha": "^2.2.33",
@@ -35,7 +35,6 @@
     "@types/utf8": "^2.1.6",
     "@types/webpack": "^4.4.11",
     "@types/ws": "^6.0.1",
-    "chai": "3.5.0",
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
     "glob": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "clean": "rm -rf lib out addons/*/lib addons/*/out"
   },
   "devDependencies": {
-    "@types/assert": "^1.4.2",
     "@types/glob": "^5.0.35",
     "@types/jsdom": "11.0.1",
     "@types/mocha": "^2.2.33",

--- a/src/InputHandler.test.ts
+++ b/src/InputHandler.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import * as assert from 'assert';
 import { InputHandler } from './InputHandler';
 import { MockInputHandlingTerminal, TestTerminal } from './TestUtils.test';
 import { Terminal } from './Terminal';
@@ -122,32 +122,32 @@ describe('InputHandler', () => {
       inputHandler.parse(Array(bufferService.cols - 9).join('a'));
       inputHandler.parse('1234567890');
       const line1: IBufferLine = bufferService.buffer.lines.get(0);
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '1234567890');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '1234567890');
 
       // insert one char from params = [0]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.insertChars(Params.fromArray([0]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + ' 123456789');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + ' 123456789');
 
       // insert one char from params = [1]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.insertChars(Params.fromArray([1]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '  12345678');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '  12345678');
 
       // insert two chars from params = [2]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.insertChars(Params.fromArray([2]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '    123456');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '    123456');
 
       // insert 10 chars from params = [10]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.insertChars(Params.fromArray([10]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '          ');
-      expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a'));
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '          ');
+      assert.strictEqual(line1.translateToString(true), Array(bufferService.cols - 9).join('a'));
     });
     it('deleteChars', function(): void {
       const term = new Terminal();
@@ -160,35 +160,35 @@ describe('InputHandler', () => {
       inputHandler.parse(Array(bufferService.cols - 9).join('a'));
       inputHandler.parse('1234567890');
       const line1: IBufferLine = bufferService.buffer.lines.get(0);
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '1234567890');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '1234567890');
 
       // delete one char from params = [0]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.deleteChars(Params.fromArray([0]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '234567890 ');
-      expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a') + '234567890');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '234567890 ');
+      assert.strictEqual(line1.translateToString(true), Array(bufferService.cols - 9).join('a') + '234567890');
 
       // insert one char from params = [1]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.deleteChars(Params.fromArray([1]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '34567890  ');
-      expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a') + '34567890');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '34567890  ');
+      assert.strictEqual(line1.translateToString(true), Array(bufferService.cols - 9).join('a') + '34567890');
 
       // insert two chars from params = [2]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.deleteChars(Params.fromArray([2]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '567890    ');
-      expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a') + '567890');
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '567890    ');
+      assert.strictEqual(line1.translateToString(true), Array(bufferService.cols - 9).join('a') + '567890');
 
       // insert 10 chars from params = [10]
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.deleteChars(Params.fromArray([10]));
-      expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '          ');
-      expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a'));
+      assert.strictEqual(line1.translateToString(false), Array(bufferService.cols - 9).join('a') + '          ');
+      assert.strictEqual(line1.translateToString(true), Array(bufferService.cols - 9).join('a'));
     });
     it('eraseInLine', function(): void {
       const term = new Terminal();
@@ -204,19 +204,19 @@ describe('InputHandler', () => {
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 70;
       inputHandler.eraseInLine(Params.fromArray([0]));
-      expect(bufferService.buffer.lines.get(0).translateToString(false)).equals(Array(71).join('a') + '          ');
+      assert.strictEqual(bufferService.buffer.lines.get(0).translateToString(false), Array(71).join('a') + '          ');
 
       // params[1] - left erase
       bufferService.buffer.y = 1;
       bufferService.buffer.x = 70;
       inputHandler.eraseInLine(Params.fromArray([1]));
-      expect(bufferService.buffer.lines.get(1).translateToString(false)).equals(Array(71).join(' ') + ' aaaaaaaaa');
+      assert.strictEqual(bufferService.buffer.lines.get(1).translateToString(false), Array(71).join(' ') + ' aaaaaaaaa');
 
       // params[1] - left erase
       bufferService.buffer.y = 2;
       bufferService.buffer.x = 70;
       inputHandler.eraseInLine(Params.fromArray([2]));
-      expect(bufferService.buffer.lines.get(2).translateToString(false)).equals(Array(bufferService.cols + 1).join(' '));
+      assert.strictEqual(bufferService.buffer.lines.get(2).translateToString(false), Array(bufferService.cols + 1).join(' '));
 
     });
     it('eraseInDisplay', function(): void {
@@ -231,7 +231,7 @@ describe('InputHandler', () => {
       bufferService.buffer.y = 5;
       bufferService.buffer.x = 40;
       inputHandler.eraseInDisplay(Params.fromArray([0]));
-      expect(termContent(bufferService, false)).eql([
+      assert.deepEqual(termContent(bufferService, false), [
         Array(bufferService.cols + 1).join('a'),
         Array(bufferService.cols + 1).join('a'),
         Array(bufferService.cols + 1).join('a'),
@@ -240,7 +240,7 @@ describe('InputHandler', () => {
         Array(40 + 1).join('a') + Array(bufferService.cols - 40 + 1).join(' '),
         Array(bufferService.cols + 1).join(' ')
       ]);
-      expect(termContent(bufferService, true)).eql([
+      assert.deepEqual(termContent(bufferService, true), [
         Array(bufferService.cols + 1).join('a'),
         Array(bufferService.cols + 1).join('a'),
         Array(bufferService.cols + 1).join('a'),
@@ -259,7 +259,7 @@ describe('InputHandler', () => {
       bufferService.buffer.y = 5;
       bufferService.buffer.x = 40;
       inputHandler.eraseInDisplay(Params.fromArray([1]));
-      expect(termContent(bufferService, false)).eql([
+      assert.deepEqual(termContent(bufferService, false), [
         Array(bufferService.cols + 1).join(' '),
         Array(bufferService.cols + 1).join(' '),
         Array(bufferService.cols + 1).join(' '),
@@ -268,7 +268,7 @@ describe('InputHandler', () => {
         Array(41 + 1).join(' ') + Array(bufferService.cols - 41 + 1).join('a'),
         Array(bufferService.cols + 1).join('a')
       ]);
-      expect(termContent(bufferService, true)).eql([
+      assert.deepEqual(termContent(bufferService, true), [
         '',
         '',
         '',
@@ -287,7 +287,7 @@ describe('InputHandler', () => {
       bufferService.buffer.y = 5;
       bufferService.buffer.x = 40;
       inputHandler.eraseInDisplay(Params.fromArray([2]));
-      expect(termContent(bufferService, false)).eql([
+      assert.deepEqual(termContent(bufferService, false), [
         Array(bufferService.cols + 1).join(' '),
         Array(bufferService.cols + 1).join(' '),
         Array(bufferService.cols + 1).join(' '),
@@ -296,7 +296,7 @@ describe('InputHandler', () => {
         Array(bufferService.cols + 1).join(' '),
         Array(bufferService.cols + 1).join(' ')
       ]);
-      expect(termContent(bufferService, true)).eql([
+      assert.deepEqual(termContent(bufferService, true), [
         '',
         '',
         '',
@@ -315,11 +315,11 @@ describe('InputHandler', () => {
 
       // params[1] left and above with wrap
       // confirm precondition that line 2 is wrapped
-      expect(bufferService.buffer.lines.get(2).isWrapped).true;
+      assert.strictEqual(bufferService.buffer.lines.get(2).isWrapped, true);
       bufferService.buffer.y = 2;
       bufferService.buffer.x = 40;
       inputHandler.eraseInDisplay(Params.fromArray([1]));
-      expect(bufferService.buffer.lines.get(2).isWrapped).false;
+      assert.strictEqual(bufferService.buffer.lines.get(2).isWrapped, false);
 
       // reset and add a wrapped line
       bufferService.buffer.y = 0;
@@ -330,29 +330,29 @@ describe('InputHandler', () => {
 
       // params[1] left and above with wrap
       // confirm precondition that line 2 is wrapped
-      expect(bufferService.buffer.lines.get(2).isWrapped).true;
+      assert.strictEqual(bufferService.buffer.lines.get(2).isWrapped, true);
       bufferService.buffer.y = 1;
       bufferService.buffer.x = 90; // Cursor is beyond last column
       inputHandler.eraseInDisplay(Params.fromArray([1]));
-      expect(bufferService.buffer.lines.get(2).isWrapped).false;
+      assert.strictEqual(bufferService.buffer.lines.get(2).isWrapped, false);
     });
   });
   it('convertEol setting', function(): void {
     // not converting
     const termNotConverting = new Terminal({cols: 15, rows: 10});
     (termNotConverting as any)._inputHandler.parse('Hello\nWorld');
-    expect(termNotConverting.buffer.lines.get(0).translateToString(false)).equals('Hello          ');
-    expect(termNotConverting.buffer.lines.get(1).translateToString(false)).equals('     World     ');
-    expect(termNotConverting.buffer.lines.get(0).translateToString(true)).equals('Hello');
-    expect(termNotConverting.buffer.lines.get(1).translateToString(true)).equals('     World');
+    assert.strictEqual(termNotConverting.buffer.lines.get(0).translateToString(false), 'Hello          ');
+    assert.strictEqual(termNotConverting.buffer.lines.get(1).translateToString(false), '     World     ');
+    assert.strictEqual(termNotConverting.buffer.lines.get(0).translateToString(true), 'Hello');
+    assert.strictEqual(termNotConverting.buffer.lines.get(1).translateToString(true), '     World');
 
     // converting
     const termConverting = new Terminal({cols: 15, rows: 10, convertEol: true});
     (termConverting as any)._inputHandler.parse('Hello\nWorld');
-    expect(termConverting.buffer.lines.get(0).translateToString(false)).equals('Hello          ');
-    expect(termConverting.buffer.lines.get(1).translateToString(false)).equals('World          ');
-    expect(termConverting.buffer.lines.get(0).translateToString(true)).equals('Hello');
-    expect(termConverting.buffer.lines.get(1).translateToString(true)).equals('World');
+    assert.strictEqual(termConverting.buffer.lines.get(0).translateToString(false), 'Hello          ');
+    assert.strictEqual(termConverting.buffer.lines.get(1).translateToString(false), 'World          ');
+    assert.strictEqual(termConverting.buffer.lines.get(0).translateToString(true), 'Hello');
+    assert.strictEqual(termConverting.buffer.lines.get(1).translateToString(true), 'World');
   });
   describe('print', () => {
     it('should not cause an infinite loop (regression test)', () => {
@@ -376,48 +376,48 @@ describe('InputHandler', () => {
     });
     it('should handle DECSET/DECRST 47 (alt screen buffer)', () => {
       handler.parse('\x1b[?47h\r\n\x1b[31mJUNK\x1b[?47lTEST');
-      expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('');
-      expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('    TEST');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(0, true), '');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(1, true), '    TEST');
       // Text color of 'TEST' should be red
-      expect((bufferService.buffer.lines.get(1).loadCell(4, new CellData()).getFgColor())).to.equal(1);
+      assert.strictEqual((bufferService.buffer.lines.get(1).loadCell(4, new CellData()).getFgColor()), 1);
     });
     it('should handle DECSET/DECRST 1047 (alt screen buffer)', () => {
       handler.parse('\x1b[?1047h\r\n\x1b[31mJUNK\x1b[?1047lTEST');
-      expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('');
-      expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('    TEST');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(0, true), '');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(1, true), '    TEST');
       // Text color of 'TEST' should be red
-      expect((bufferService.buffer.lines.get(1).loadCell(4, new CellData()).getFgColor())).to.equal(1);
+      assert.strictEqual((bufferService.buffer.lines.get(1).loadCell(4, new CellData()).getFgColor()), 1);
     });
     it('should handle DECSET/DECRST 1048 (alt screen cursor)', () => {
       handler.parse('\x1b[?1048h\r\n\x1b[31mJUNK\x1b[?1048lTEST');
-      expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('TEST');
-      expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('JUNK');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(0, true), 'TEST');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(1, true), 'JUNK');
       // Text color of 'TEST' should be default
-      expect(bufferService.buffer.lines.get(0).loadCell(0, new CellData()).fg).to.equal(DEFAULT_ATTR_DATA.fg);
+      assert.strictEqual(bufferService.buffer.lines.get(0).loadCell(0, new CellData()).fg, DEFAULT_ATTR_DATA.fg);
       // Text color of 'JUNK' should be red
-      expect((bufferService.buffer.lines.get(1).loadCell(0, new CellData()).getFgColor())).to.equal(1);
+      assert.strictEqual((bufferService.buffer.lines.get(1).loadCell(0, new CellData()).getFgColor()), 1);
     });
     it('should handle DECSET/DECRST 1049 (alt screen buffer+cursor)', () => {
       handler.parse('\x1b[?1049h\r\n\x1b[31mJUNK\x1b[?1049lTEST');
-      expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('TEST');
-      expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(0, true), 'TEST');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(1, true), '');
       // Text color of 'TEST' should be default
-      expect(bufferService.buffer.lines.get(0).loadCell(0, new CellData()).fg).to.equal(DEFAULT_ATTR_DATA.fg);
+      assert.strictEqual(bufferService.buffer.lines.get(0).loadCell(0, new CellData()).fg, DEFAULT_ATTR_DATA.fg);
     });
     it('should handle DECSET/DECRST 1049 - maintains saved cursor for alt buffer', () => {
       handler.parse('\x1b[?1049h\r\n\x1b[31m\x1b[s\x1b[?1049lTEST');
-      expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('TEST');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(0, true), 'TEST');
       // Text color of 'TEST' should be default
-      expect(bufferService.buffer.lines.get(0).loadCell(0, new CellData()).fg).to.equal(DEFAULT_ATTR_DATA.fg);
+      assert.strictEqual(bufferService.buffer.lines.get(0).loadCell(0, new CellData()).fg, DEFAULT_ATTR_DATA.fg);
       handler.parse('\x1b[?1049h\x1b[uTEST');
-      expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('TEST');
+      assert.strictEqual(bufferService.buffer.translateBufferLineToString(1, true), 'TEST');
       // Text color of 'TEST' should be red
-      expect((bufferService.buffer.lines.get(1).loadCell(0, new CellData()).getFgColor())).to.equal(1);
+      assert.strictEqual((bufferService.buffer.lines.get(1).loadCell(0, new CellData()).getFgColor()), 1);
     });
     it('should handle DECSET/DECRST 1049 - clears alt buffer with erase attributes', () => {
       handler.parse('\x1b[42m\x1b[?1049h');
       // Buffer should be filled with green background
-      expect(bufferService.buffer.lines.get(20).loadCell(10, new CellData()).getBgColor()).to.equal(2);
+      assert.strictEqual(bufferService.buffer.lines.get(20).loadCell(10, new CellData()).getBgColor(), 2);
     });
   });
 

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -809,7 +809,7 @@ describe('Terminal', () => {
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         assert.strictEqual(cell.getChars(), 'e\u0301');
-        assert.strictEqual(cell.getChars(), 2);
+        assert.strictEqual(cell.getChars().length, 2);
         assert.strictEqual(cell.getWidth(), 1);
       }
       term.buffer.lines.get(1).loadCell(0, cell);

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import * as assert from 'assert';
 import { MockViewport, MockCompositionHelper, MockRenderer, TestTerminal } from './TestUtils.test';
 import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
 import { CellData } from 'common/buffer/CellData';
@@ -77,7 +77,7 @@ describe('Terminal', () => {
     it('should fire a key event after a keypress DOM event', (done) => {
       term.onKey(e => {
         assert.equal(typeof e.key, 'string');
-        expect(e.domEvent).to.be.an.instanceof(Object);
+        assert.strictEqual(e.domEvent instanceof Object, true);
         done();
       });
       const evKeyPress = <KeyboardEvent>{
@@ -91,7 +91,7 @@ describe('Terminal', () => {
     it('should fire a key event after a keydown DOM event', (done) => {
       term.onKey(e => {
         assert.equal(typeof e.key, 'string');
-        expect(e.domEvent).to.be.an.instanceof(Object);
+        assert.strictEqual(e.domEvent instanceof Object, true);
         done();
       });
       (<any>term).textarea = { value: '' };
@@ -105,7 +105,8 @@ describe('Terminal', () => {
     });
     it('should fire the onResize event', (done) => {
       term.onResize(e => {
-        expect(e).to.have.keys(['cols', 'rows']);
+        assert.ok(e['cols']);
+        assert.ok(e['rows']);
         assert.equal(typeof e.cols, 'number');
         assert.equal(typeof e.rows, 'number');
         done();
@@ -714,10 +715,10 @@ describe('Terminal', () => {
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.write(high + String.fromCharCode(i));
         const tchar = term.buffer.lines.get(0).loadCell(0, cell);
-        expect(tchar.getChars()).eql(high + String.fromCharCode(i));
-        expect(tchar.getChars().length).eql(2);
-        expect(tchar.getWidth()).eql(1);
-        expect(term.buffer.lines.get(0).loadCell(1, cell).getChars()).eql('');
+        assert.strictEqual(tchar.getChars(), high + String.fromCharCode(i));
+        assert.strictEqual(tchar.getChars().length, 2);
+        assert.strictEqual(tchar.getWidth(), 1);
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(1, cell).getChars(), '');
         term.reset();
       }
     });
@@ -727,9 +728,9 @@ describe('Terminal', () => {
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.buffer.x = term.cols - 1;
         term.write(high + String.fromCharCode(i));
-        expect(term.buffer.lines.get(0).loadCell(term.buffer.x - 1, cell).getChars()).eql(high + String.fromCharCode(i));
-        expect(term.buffer.lines.get(0).loadCell(term.buffer.x - 1, cell).getChars().length).eql(2);
-        expect(term.buffer.lines.get(1).loadCell(0, cell).getChars()).eql('');
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(term.buffer.x - 1, cell).getChars(), high + String.fromCharCode(i));
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(term.buffer.x - 1, cell).getChars().length, 2);
+        assert.strictEqual(term.buffer.lines.get(1).loadCell(0, cell).getChars(), '');
         term.reset();
       }
     });
@@ -740,10 +741,10 @@ describe('Terminal', () => {
         term.buffer.x = term.cols - 1;
         term.wraparoundMode = true;
         term.write('a' + high + String.fromCharCode(i));
-        expect(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars()).eql('a');
-        expect(term.buffer.lines.get(1).loadCell(0, cell).getChars()).eql(high + String.fromCharCode(i));
-        expect(term.buffer.lines.get(1).loadCell(0, cell).getChars().length).eql(2);
-        expect(term.buffer.lines.get(1).loadCell(1, cell).getChars()).eql('');
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars(), 'a');
+        assert.strictEqual(term.buffer.lines.get(1).loadCell(0, cell).getChars(), high + String.fromCharCode(i));
+        assert.strictEqual(term.buffer.lines.get(1).loadCell(0, cell).getChars().length, 2);
+        assert.strictEqual(term.buffer.lines.get(1).loadCell(1, cell).getChars(), '');
         term.reset();
       }
     });
@@ -759,9 +760,9 @@ describe('Terminal', () => {
         }
         term.write('a' + high + String.fromCharCode(i));
         // auto wraparound mode should cut off the rest of the line
-        expect(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars()).eql(high + String.fromCharCode(i));
-        expect(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars().length).eql(2);
-        expect(term.buffer.lines.get(1).loadCell(1, cell).getChars()).eql('');
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars(), high + String.fromCharCode(i));
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars().length, 2);
+        assert.strictEqual(term.buffer.lines.get(1).loadCell(1, cell).getChars(), '');
         term.reset();
       }
     });
@@ -772,10 +773,10 @@ describe('Terminal', () => {
         term.write(high);
         term.write(String.fromCharCode(i));
         const tchar = term.buffer.lines.get(0).loadCell(0, cell);
-        expect(tchar.getChars()).eql(high + String.fromCharCode(i));
-        expect(tchar.getChars().length).eql(2);
-        expect(tchar.getWidth()).eql(1);
-        expect(term.buffer.lines.get(0).loadCell(1, cell).getChars()).eql('');
+        assert.strictEqual(tchar.getChars(), high + String.fromCharCode(i));
+        assert.strictEqual(tchar.getChars().length, 2);
+        assert.strictEqual(tchar.getWidth(), 1);
+        assert.strictEqual(term.buffer.lines.get(0).loadCell(1, cell).getChars(), '');
         term.reset();
       }
     });
@@ -786,64 +787,64 @@ describe('Terminal', () => {
     it('café', () => {
       term.write('cafe\u0301');
       term.buffer.lines.get(0).loadCell(3, cell);
-      expect(cell.getChars()).eql('e\u0301');
-      expect(cell.getChars().length).eql(2);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), 'e\u0301');
+      assert.strictEqual(cell.getChars().length, 2);
+      assert.strictEqual(cell.getWidth(), 1);
     });
     it('café - end of line', () => {
       term.buffer.x = term.cols - 1 - 3;
       term.write('cafe\u0301');
       term.buffer.lines.get(0).loadCell(term.cols - 1, cell);
-      expect(cell.getChars()).eql('e\u0301');
-      expect(cell.getChars().length).eql(2);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), 'e\u0301');
+      assert.strictEqual(cell.getChars().length, 2);
+      assert.strictEqual(cell.getWidth(), 1);
       term.buffer.lines.get(0).loadCell(1, cell);
-      expect(cell.getChars()).eql('');
-      expect(cell.getChars().length).eql(0);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), '');
+      assert.strictEqual(cell.getChars().length, 0);
+      assert.strictEqual(cell.getWidth(), 1);
     });
     it('multiple combined é', () => {
       term.wraparoundMode = true;
       term.write(Array(100).join('e\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
-        expect(cell.getChars()).eql('e\u0301');
-        expect(cell.getChars().length).eql(2);
-        expect(cell.getWidth()).eql(1);
+        assert.strictEqual(cell.getChars(), 'e\u0301');
+        assert.strictEqual(cell.getChars(), 2);
+        assert.strictEqual(cell.getWidth(), 1);
       }
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('e\u0301');
-      expect(cell.getChars().length).eql(2);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), 'e\u0301');
+      assert.strictEqual(cell.getChars().length, 2);
+      assert.strictEqual(cell.getWidth(), 1);
     });
     it('multiple surrogate with combined', () => {
       term.wraparoundMode = true;
       term.write(Array(100).join('\uD800\uDC00\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
-        expect(cell.getChars()).eql('\uD800\uDC00\u0301');
-        expect(cell.getChars().length).eql(3);
-        expect(cell.getWidth()).eql(1);
+        assert.strictEqual(cell.getChars(), '\uD800\uDC00\u0301');
+        assert.strictEqual(cell.getChars().length, 3);
+        assert.strictEqual(cell.getWidth(), 1);
       }
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('\uD800\uDC00\u0301');
-      expect(cell.getChars().length).eql(3);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), '\uD800\uDC00\u0301');
+      assert.strictEqual(cell.getChars().length, 3);
+      assert.strictEqual(cell.getWidth(), 1);
     });
   });
 
   describe('unicode - fullwidth characters', () => {
     const cell = new CellData();
     it('cursor movement even', () => {
-      expect(term.buffer.x).eql(0);
+      assert.strictEqual(term.buffer.x, 0);
       term.write('￥');
-      expect(term.buffer.x).eql(2);
+      assert.strictEqual(term.buffer.x, 2);
     });
     it('cursor movement odd', () => {
       term.buffer.x = 1;
-      expect(term.buffer.x).eql(1);
+      assert.strictEqual(term.buffer.x, 1);
       term.write('￥');
-      expect(term.buffer.x).eql(3);
+      assert.strictEqual(term.buffer.x, 3);
     });
     it('line of ￥ even', () => {
       term.wraparoundMode = true;
@@ -851,19 +852,19 @@ describe('Terminal', () => {
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         if (i % 2) {
-          expect(cell.getChars()).eql('');
-          expect(cell.getChars().length).eql(0);
-          expect(cell.getWidth()).eql(0);
+          assert.strictEqual(cell.getChars(), '');
+          assert.strictEqual(cell.getChars().length, 0);
+          assert.strictEqual(cell.getWidth(), 0);
         } else {
-          expect(cell.getChars()).eql('￥');
-          expect(cell.getChars().length).eql(1);
-          expect(cell.getWidth()).eql(2);
+          assert.strictEqual(cell.getChars(), '￥');
+          assert.strictEqual(cell.getChars().length, 1);
+          assert.strictEqual(cell.getWidth(), 2);
         }
       }
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('￥');
-      expect(cell.getChars().length).eql(1);
-      expect(cell.getWidth()).eql(2);
+      assert.strictEqual(cell.getChars(), '￥');
+      assert.strictEqual(cell.getChars().length, 1);
+      assert.strictEqual(cell.getWidth(), 2);
     });
     it('line of ￥ odd', () => {
       term.wraparoundMode = true;
@@ -872,23 +873,23 @@ describe('Terminal', () => {
       for (let i = 1; i < term.cols - 1; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         if (!(i % 2)) {
-          expect(cell.getChars()).eql('');
-          expect(cell.getChars().length).eql(0);
-          expect(cell.getWidth()).eql(0);
+          assert.strictEqual(cell.getChars(), '');
+          assert.strictEqual(cell.getChars().length, 0);
+          assert.strictEqual(cell.getWidth(), 0);
         } else {
-          expect(cell.getChars()).eql('￥');
-          expect(cell.getChars().length).eql(1);
-          expect(cell.getWidth()).eql(2);
+          assert.strictEqual(cell.getChars(), '￥');
+          assert.strictEqual(cell.getChars().length, 1);
+          assert.strictEqual(cell.getWidth(), 2);
         }
       }
       term.buffer.lines.get(0).loadCell(term.cols - 1, cell);
-      expect(cell.getChars()).eql('');
-      expect(cell.getChars().length).eql(0);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), '');
+      assert.strictEqual(cell.getChars().length, 0);
+      assert.strictEqual(cell.getWidth(), 1);
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('￥');
-      expect(cell.getChars().length).eql(1);
-      expect(cell.getWidth()).eql(2);
+      assert.strictEqual(cell.getChars(), '￥');
+      assert.strictEqual(cell.getChars().length, 1);
+      assert.strictEqual(cell.getWidth(), 2);
     });
     it('line of ￥ with combining odd', () => {
       term.wraparoundMode = true;
@@ -897,23 +898,23 @@ describe('Terminal', () => {
       for (let i = 1; i < term.cols - 1; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         if (!(i % 2)) {
-          expect(cell.getChars()).eql('');
-          expect(cell.getChars().length).eql(0);
-          expect(cell.getWidth()).eql(0);
+          assert.strictEqual(cell.getChars(), '');
+          assert.strictEqual(cell.getChars().length, 0);
+          assert.strictEqual(cell.getWidth(), 0);
         } else {
-          expect(cell.getChars()).eql('￥\u0301');
-          expect(cell.getChars().length).eql(2);
-          expect(cell.getWidth()).eql(2);
+          assert.strictEqual(cell.getChars(), '￥\u0301');
+          assert.strictEqual(cell.getChars().length, 2);
+          assert.strictEqual(cell.getWidth(), 2);
         }
       }
       term.buffer.lines.get(0).loadCell(term.cols - 1, cell);
-      expect(cell.getChars()).eql('');
-      expect(cell.getChars().length).eql(0);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), '');
+      assert.strictEqual(cell.getChars().length, 0);
+      assert.strictEqual(cell.getWidth(), 1);
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('￥\u0301');
-      expect(cell.getChars().length).eql(2);
-      expect(cell.getWidth()).eql(2);
+      assert.strictEqual(cell.getChars(), '￥\u0301');
+      assert.strictEqual(cell.getChars().length, 2);
+      assert.strictEqual(cell.getWidth(), 2);
     });
     it('line of ￥ with combining even', () => {
       term.wraparoundMode = true;
@@ -921,19 +922,19 @@ describe('Terminal', () => {
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         if (i % 2) {
-          expect(cell.getChars()).eql('');
-          expect(cell.getChars().length).eql(0);
-          expect(cell.getWidth()).eql(0);
+          assert.strictEqual(cell.getChars(), '');
+          assert.strictEqual(cell.getChars().length, 0);
+          assert.strictEqual(cell.getWidth(), 0);
         } else {
-          expect(cell.getChars()).eql('￥\u0301');
-          expect(cell.getChars().length).eql(2);
-          expect(cell.getWidth()).eql(2);
+          assert.strictEqual(cell.getChars(), '￥\u0301');
+          assert.strictEqual(cell.getChars().length, 2);
+          assert.strictEqual(cell.getWidth(), 2);
         }
       }
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('￥\u0301');
-      expect(cell.getChars().length).eql(2);
-      expect(cell.getWidth()).eql(2);
+      assert.strictEqual(cell.getChars(), '￥\u0301');
+      assert.strictEqual(cell.getChars().length, 2);
+      assert.strictEqual(cell.getWidth(), 2);
     });
     it('line of surrogate fullwidth with combining odd', () => {
       term.wraparoundMode = true;
@@ -942,23 +943,23 @@ describe('Terminal', () => {
       for (let i = 1; i < term.cols - 1; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         if (!(i % 2)) {
-          expect(cell.getChars()).eql('');
-          expect(cell.getChars().length).eql(0);
-          expect(cell.getWidth()).eql(0);
+          assert.strictEqual(cell.getChars(), '');
+          assert.strictEqual(cell.getChars().length, 0);
+          assert.strictEqual(cell.getWidth(), 0);
         } else {
-          expect(cell.getChars()).eql('\ud843\ude6d\u0301');
-          expect(cell.getChars().length).eql(3);
-          expect(cell.getWidth()).eql(2);
+          assert.strictEqual(cell.getChars(), '\ud843\ude6d\u0301');
+          assert.strictEqual(cell.getChars().length, 3);
+          assert.strictEqual(cell.getWidth(), 2);
         }
       }
       term.buffer.lines.get(0).loadCell(term.cols - 1, cell);
-      expect(cell.getChars()).eql('');
-      expect(cell.getChars().length).eql(0);
-      expect(cell.getWidth()).eql(1);
+      assert.strictEqual(cell.getChars(), '');
+      assert.strictEqual(cell.getChars().length, 0);
+      assert.strictEqual(cell.getWidth(), 1);
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('\ud843\ude6d\u0301');
-      expect(cell.getChars().length).eql(3);
-      expect(cell.getWidth()).eql(2);
+      assert.strictEqual(cell.getChars(), '\ud843\ude6d\u0301');
+      assert.strictEqual(cell.getChars().length, 3);
+      assert.strictEqual(cell.getWidth(), 2);
     });
     it('line of surrogate fullwidth with combining even', () => {
       term.wraparoundMode = true;
@@ -966,19 +967,19 @@ describe('Terminal', () => {
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
         if (i % 2) {
-          expect(cell.getChars()).eql('');
-          expect(cell.getChars().length).eql(0);
-          expect(cell.getWidth()).eql(0);
+          assert.strictEqual(cell.getChars(), '');
+          assert.strictEqual(cell.getChars().length, 0);
+          assert.strictEqual(cell.getWidth(), 0);
         } else {
-          expect(cell.getChars()).eql('\ud843\ude6d\u0301');
-          expect(cell.getChars().length).eql(3);
-          expect(cell.getWidth()).eql(2);
+          assert.strictEqual(cell.getChars(), '\ud843\ude6d\u0301');
+          assert.strictEqual(cell.getChars().length, 3);
+          assert.strictEqual(cell.getWidth(), 2);
         }
       }
       term.buffer.lines.get(1).loadCell(0, cell);
-      expect(cell.getChars()).eql('\ud843\ude6d\u0301');
-      expect(cell.getChars().length).eql(3);
-      expect(cell.getWidth()).eql(2);
+      assert.strictEqual(cell.getChars(), '\ud843\ude6d\u0301');
+      assert.strictEqual(cell.getChars().length, 3);
+      assert.strictEqual(cell.getWidth(), 2);
     });
   });
 
@@ -990,11 +991,11 @@ describe('Terminal', () => {
       term.buffer.y = 0;
       term.insertMode = true;
       term.write('abcde');
-      expect(term.buffer.lines.get(0).length).eql(term.cols);
-      expect(term.buffer.lines.get(0).loadCell(10, cell).getChars()).eql('a');
-      expect(term.buffer.lines.get(0).loadCell(14, cell).getChars()).eql('e');
-      expect(term.buffer.lines.get(0).loadCell(15, cell).getChars()).eql('0');
-      expect(term.buffer.lines.get(0).loadCell(79, cell).getChars()).eql('4');
+      assert.strictEqual(term.buffer.lines.get(0).length, term.cols);
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(10, cell).getChars(), 'a');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(14, cell).getChars(), 'e');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(15, cell).getChars(), '0');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(79, cell).getChars(), '4');
     });
     it('fullwidth - insert', () => {
       term.write(Array(9).join('0123456789').slice(-80));
@@ -1002,12 +1003,12 @@ describe('Terminal', () => {
       term.buffer.y = 0;
       term.insertMode = true;
       term.write('￥￥￥');
-      expect(term.buffer.lines.get(0).length).eql(term.cols);
-      expect(term.buffer.lines.get(0).loadCell(10, cell).getChars()).eql('￥');
-      expect(term.buffer.lines.get(0).loadCell(11, cell).getChars()).eql('');
-      expect(term.buffer.lines.get(0).loadCell(14, cell).getChars()).eql('￥');
-      expect(term.buffer.lines.get(0).loadCell(15, cell).getChars()).eql('');
-      expect(term.buffer.lines.get(0).loadCell(79, cell).getChars()).eql('3');
+      assert.strictEqual(term.buffer.lines.get(0).length, term.cols);
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(10, cell).getChars(), '￥');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(11, cell).getChars(), '');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(14, cell).getChars(), '￥');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(15, cell).getChars(), '');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(79, cell).getChars(), '3');
     });
     it('fullwidth - right border', () => {
       term.write(Array(41).join('￥'));
@@ -1015,15 +1016,15 @@ describe('Terminal', () => {
       term.buffer.y = 0;
       term.insertMode = true;
       term.write('a');
-      expect(term.buffer.lines.get(0).length).eql(term.cols);
-      expect(term.buffer.lines.get(0).loadCell(10, cell).getChars()).eql('a');
-      expect(term.buffer.lines.get(0).loadCell(11, cell).getChars()).eql('￥');
-      expect(term.buffer.lines.get(0).loadCell(79, cell).getChars()).eql('');  // fullwidth char got replaced
+      assert.strictEqual(term.buffer.lines.get(0).length, term.cols);
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(10, cell).getChars(), 'a');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(11, cell).getChars(), '￥');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(79, cell).getChars(), '');  // fullwidth char got replaced
       term.write('b');
-      expect(term.buffer.lines.get(0).length).eql(term.cols);
-      expect(term.buffer.lines.get(0).loadCell(11, cell).getChars()).eql('b');
-      expect(term.buffer.lines.get(0).loadCell(12, cell).getChars()).eql('￥');
-      expect(term.buffer.lines.get(0).loadCell(79, cell).getChars()).eql('');  // empty cell after fullwidth
+      assert.strictEqual(term.buffer.lines.get(0).length, term.cols);
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(11, cell).getChars(), 'b');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(12, cell).getChars(), '￥');
+      assert.strictEqual(term.buffer.lines.get(0).loadCell(79, cell).getChars(), '');  // empty cell after fullwidth
     });
   });
 

--- a/src/browser/Clipboard.test.ts
+++ b/src/browser/Clipboard.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import * as Clipboard from 'browser/Clipboard';
 
 describe('evaluatePastedTextProcessing', () => {

--- a/src/browser/ColorManager.test.ts
+++ b/src/browser/ColorManager.test.ts
@@ -4,7 +4,7 @@
  */
 
 import jsdom = require('jsdom');
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ColorManager } from 'browser/ColorManager';
 
 describe('ColorManager', () => {

--- a/src/browser/Linkifier.test.ts
+++ b/src/browser/Linkifier.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { IMouseZoneManager, IMouseZone, IRegisteredLinkMatcher } from 'browser/Types';
 import { IBufferLine } from 'common/Types';
 import { Linkifier } from 'browser/Linkifier';
@@ -96,7 +96,7 @@ describe('Linkifier', () => {
     it('should allow link matcher registration', done => {
       assert.doesNotThrow(() => {
         const linkMatcherId = linkifier.registerLinkMatcher(/foo/, () => {});
-        assert.isTrue(linkifier.deregisterLinkMatcher(linkMatcherId));
+        assert.strictEqual(linkifier.deregisterLinkMatcher(linkMatcherId), true);
         done();
       });
     });
@@ -192,7 +192,7 @@ describe('Linkifier', () => {
 
       it('should disable link if false', done => {
         addRow('test');
-        linkifier.registerLinkMatcher(/test/, () => assert.fail(), {
+        linkifier.registerLinkMatcher(/test/, () => assert.fail('Register Link Matcher Succeed', 'Register Link Matcher Failed'), {
           validationCallback: (url, cb) => {
             assert.equal(mouseZoneManager.zones.length, 0);
             cb(false);
@@ -207,7 +207,7 @@ describe('Linkifier', () => {
       it('should trigger for multiple link matches on one row', done => {
         addRow('test test');
         let count = 0;
-        linkifier.registerLinkMatcher(/test/, () => assert.fail(), {
+        linkifier.registerLinkMatcher(/test/, () => assert.fail('Register Link Matcher Succeed', 'Register Link Matcher Failed'), {
           validationCallback: (url, cb) => {
             count += 1;
             if (count === 2) {

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { CompositionHelper } from 'browser/input/CompositionHelper';
 import { MockCharSizeService } from 'browser/TestUtils.test';
 import { MockCoreService, MockBufferService, MockOptionsService } from 'common/TestUtils.test';

--- a/src/browser/input/Mouse.test.ts
+++ b/src/browser/input/Mouse.test.ts
@@ -4,7 +4,7 @@
  */
 
 import jsdom = require('jsdom');
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { getCoords } from 'browser/input/Mouse';
 
 const CHAR_WIDTH = 10;

--- a/src/browser/input/MoveToCell.test.ts
+++ b/src/browser/input/MoveToCell.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { IBufferService } from 'common/services/Services';
 import { MockBufferService } from 'common/TestUtils.test';
 import { moveToCellSequence } from './MoveToCell';

--- a/src/browser/renderer/CharacterJoinerRegistry.test.ts
+++ b/src/browser/renderer/CharacterJoinerRegistry.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ICharacterJoinerRegistry } from 'browser/renderer/Types';
 import { CharacterJoinerRegistry } from 'browser/renderer/CharacterJoinerRegistry';
 import { BufferLine } from 'common/buffer/BufferLine';

--- a/src/browser/renderer/GridCache.test.ts
+++ b/src/browser/renderer/GridCache.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { GridCache } from 'browser/renderer/GridCache';
 
 describe('GridCache', () => {

--- a/src/browser/renderer/atlas/LRUMap.test.ts
+++ b/src/browser/renderer/atlas/LRUMap.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { LRUMap } from 'browser/renderer/atlas/LRUMap';
 
 describe('LRUMap', () => {
@@ -33,11 +33,11 @@ describe('LRUMap', () => {
     map.set(3, 'value');
     map.set(4, 'value');
     map.set(5, 'value');
-    assert.isNull(map.get(1));
-    assert.isNotNull(map.get(2));
-    assert.isNotNull(map.get(3));
-    assert.isNotNull(map.get(4));
-    assert.isNotNull(map.get(5));
+    assert.ok(!map.get(1));
+    assert.ok(map.get(2));
+    assert.ok(map.get(3));
+    assert.ok(map.get(4));
+    assert.ok(map.get(5));
     assert.strictEqual(map.size, 4);
   });
 
@@ -48,10 +48,10 @@ describe('LRUMap', () => {
     map.get(1);
     // a would normally get deleted here, except that we called get()
     map.set(3, 'value');
-    assert.isNotNull(map.get(1));
+    assert.ok(map.get(1));
     // b got deleted instead of a
-    assert.isNull(map.get(2));
-    assert.isNotNull(map.get(3));
+    assert.ok(!map.get(2));
+    assert.ok(map.get(3));
   });
 
   it('supports mutation', () => {

--- a/src/browser/renderer/dom/DomRendererRowFactory.test.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.test.ts
@@ -4,7 +4,7 @@
  */
 
 import jsdom = require('jsdom');
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { DomRendererRowFactory } from 'browser/renderer/dom/DomRendererRowFactory';
 import { NULL_CELL_CODE, NULL_CELL_WIDTH, NULL_CELL_CHAR, DEFAULT_ATTR, FgFlags, BgFlags, Attributes } from 'common/buffer/Constants';
 import { BufferLine, DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';

--- a/src/browser/selection/SelectionModel.test.ts
+++ b/src/browser/selection/SelectionModel.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { SelectionModel } from './SelectionModel';
 import { MockBufferService } from 'common/TestUtils.test';
 

--- a/src/browser/services/SelectionService.test.ts
+++ b/src/browser/services/SelectionService.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { SelectionService, SelectionMode } from './SelectionService';
 import { SelectionModel } from 'browser/selection/SelectionModel';
 import { IBufferLine } from 'common/Types';
@@ -476,13 +476,13 @@ describe('SelectionService', () => {
 
   describe('_areCoordsInSelection', () => {
     it('should return whether coords are in the selection', () => {
-      assert.isFalse(selectionService.areCoordsInSelection([0, 0], [2, 0], [2, 1]));
-      assert.isFalse(selectionService.areCoordsInSelection([1, 0], [2, 0], [2, 1]));
-      assert.isTrue(selectionService.areCoordsInSelection([2, 0], [2, 0], [2, 1]));
-      assert.isTrue(selectionService.areCoordsInSelection([10, 0], [2, 0], [2, 1]));
-      assert.isTrue(selectionService.areCoordsInSelection([0, 1], [2, 0], [2, 1]));
-      assert.isTrue(selectionService.areCoordsInSelection([1, 1], [2, 0], [2, 1]));
-      assert.isFalse(selectionService.areCoordsInSelection([2, 1], [2, 0], [2, 1]));
+      assert.strictEqual(selectionService.areCoordsInSelection([0, 0], [2, 0], [2, 1]), false);
+      assert.strictEqual(selectionService.areCoordsInSelection([1, 0], [2, 0], [2, 1]), false);
+      assert.strictEqual(selectionService.areCoordsInSelection([2, 0], [2, 0], [2, 1]), true);
+      assert.strictEqual(selectionService.areCoordsInSelection([10, 0], [2, 0], [2, 1]), true);
+      assert.strictEqual(selectionService.areCoordsInSelection([0, 1], [2, 0], [2, 1]), true);
+      assert.strictEqual(selectionService.areCoordsInSelection([1, 1], [2, 0], [2, 1]), true);
+      assert.strictEqual(selectionService.areCoordsInSelection([2, 1], [2, 0], [2, 1]), false);
     });
   });
 });

--- a/src/common/CharWidth.test.ts
+++ b/src/common/CharWidth.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { wcwidth } from 'common/CharWidth';
 

--- a/src/common/CharWidth.test.ts
+++ b/src/common/CharWidth.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { wcwidth } from 'common/CharWidth';
 
 it('wcwidth should match all values from the old implementation', function(): void {

--- a/src/common/CircularList.test.ts
+++ b/src/common/CircularList.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { CircularList } from 'common/CircularList';
 

--- a/src/common/CircularList.test.ts
+++ b/src/common/CircularList.test.ts
@@ -176,9 +176,9 @@ describe('CircularList', () => {
     it('should throw for invalid args', () => {
       const list = new CircularList<number>(5);
       list.push(1);
-      assert.throws(() => list.shiftElements(-1, 1, 1), 'start argument out of range');
-      assert.throws(() => list.shiftElements(1, 1, 1), 'start argument out of range');
-      assert.throws(() => list.shiftElements(0, 1, -1), 'Cannot shift elements in list beyond index 0');
+      assert.throws(() => list.shiftElements(-1, 1, 1));
+      assert.throws(() => list.shiftElements(1, 1, 1));
+      assert.throws(() => list.shiftElements(0, 1, -1));
     });
 
     it('should shift an element forward', () => {

--- a/src/common/CircularList.test.ts
+++ b/src/common/CircularList.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { CircularList } from 'common/CircularList';
 
 describe('CircularList', () => {

--- a/src/common/Clone.test.ts
+++ b/src/common/Clone.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { clone } from 'common/Clone';
 

--- a/src/common/Clone.test.ts
+++ b/src/common/Clone.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert, expect } from 'chai';
+import * as assert from 'assert';
 import { clone } from 'common/Clone';
 
 describe('clone', () => {
@@ -124,6 +124,6 @@ describe('clone', () => {
 
     test.a.b.c = test;
 
-    expect(() => clone(test)).to.not.throw();
+    assert.doesNotThrow(() => clone(test));
   });
 });

--- a/src/common/EventEmitter.test.ts
+++ b/src/common/EventEmitter.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { EventEmitter } from 'common/EventEmitter';
 
 describe('EventEmitter', () => {

--- a/src/common/EventEmitter.test.ts
+++ b/src/common/EventEmitter.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { EventEmitter } from 'common/EventEmitter';
 

--- a/src/common/Lifecycle.test.ts
+++ b/src/common/Lifecycle.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { Disposable } from 'common/Lifecycle';
 

--- a/src/common/Lifecycle.test.ts
+++ b/src/common/Lifecycle.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { Disposable } from 'common/Lifecycle';
 
 class TestDisposable extends Disposable {
@@ -37,9 +37,9 @@ describe('Disposable', () => {
   describe('dispose', () => {
     it('should set is disposed flag', () => {
       const d = new TestDisposable();
-      assert.isFalse(d.isDisposed);
+      assert.strictEqual(d.isDisposed, false);
       d.dispose();
-      assert.isTrue(d.isDisposed);
+      assert.strictEqual(d.isDisposed, true);
     });
   });
 });

--- a/src/common/TypedArrayUtils.test.ts
+++ b/src/common/TypedArrayUtils.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 The xterm.js authors. All rights reserved.
  * @license MIT
  */
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { fillFallback, concat } from 'common/TypedArrayUtils';
 
 type TypedArray = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray

--- a/src/common/TypedArrayUtils.test.ts
+++ b/src/common/TypedArrayUtils.test.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 The xterm.js authors. All rights reserved.
  * @license MIT
  */
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { fillFallback, concat } from 'common/TypedArrayUtils';
 

--- a/src/common/buffer/Buffer.test.ts
+++ b/src/common/buffer/Buffer.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { Buffer } from 'common/buffer/Buffer';
 import { CircularList } from 'common/CircularList';

--- a/src/common/buffer/Buffer.test.ts
+++ b/src/common/buffer/Buffer.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { Buffer } from 'common/buffer/Buffer';
 import { CircularList } from 'common/CircularList';
 import { MockOptionsService, MockBufferService } from 'common/TestUtils.test';
@@ -27,7 +27,7 @@ describe('Buffer', () => {
 
   describe('constructor', () => {
     it('should create a CircularList with max length equal to rows + scrollback, for its lines', () => {
-      assert.instanceOf(buffer.lines, CircularList);
+      assert.strictEqual(buffer.lines instanceof CircularList, true);
       assert.equal(buffer.lines.maxLength, bufferService.rows + INIT_SCROLLBACK);
     });
     it('should set the Buffer\'s scrollBottom value equal to the terminal\'s rows -1', () => {

--- a/src/common/buffer/BufferLine.test.ts
+++ b/src/common/buffer/BufferLine.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 The xterm.js authors. All rights reserved.
  * @license MIT
  */
-import * as chai from 'chai';
+import * as assert from 'assert';
 import { NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE, DEFAULT_ATTR, Content } from 'common/buffer/Constants';
 import { BufferLine } from 'common/buffer//BufferLine';
 import { CellData } from 'common/buffer/CellData';
@@ -27,44 +27,44 @@ describe('CellData', () => {
     const cell = new CellData();
     // ASCII
     cell.setFromCharData([123, 'a', 1, 'a'.charCodeAt(0)]);
-    chai.assert.deepEqual(cell.getAsCharData(), [123, 'a', 1, 'a'.charCodeAt(0)]);
-    chai.assert.equal(cell.isCombined(), 0);
+    assert.deepEqual(cell.getAsCharData(), [123, 'a', 1, 'a'.charCodeAt(0)]);
+    assert.equal(cell.isCombined(), 0);
     // combining
     cell.setFromCharData([123, 'e\u0301', 1, '\u0301'.charCodeAt(0)]);
-    chai.assert.deepEqual(cell.getAsCharData(), [123, 'e\u0301', 1, '\u0301'.charCodeAt(0)]);
-    chai.assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
+    assert.deepEqual(cell.getAsCharData(), [123, 'e\u0301', 1, '\u0301'.charCodeAt(0)]);
+    assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
     // surrogate
     cell.setFromCharData([123, '𝄞', 1, 0x1D11E]);
-    chai.assert.deepEqual(cell.getAsCharData(), [123, '𝄞', 1, 0x1D11E]);
-    chai.assert.equal(cell.isCombined(), 0);
+    assert.deepEqual(cell.getAsCharData(), [123, '𝄞', 1, 0x1D11E]);
+    assert.equal(cell.isCombined(), 0);
     // surrogate + combining
     cell.setFromCharData([123, '𓂀\u0301', 1, '𓂀\u0301'.charCodeAt(2)]);
-    chai.assert.deepEqual(cell.getAsCharData(), [123, '𓂀\u0301', 1, '𓂀\u0301'.charCodeAt(2)]);
-    chai.assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
+    assert.deepEqual(cell.getAsCharData(), [123, '𓂀\u0301', 1, '𓂀\u0301'.charCodeAt(2)]);
+    assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
     // wide char
     cell.setFromCharData([123, '１', 2, '１'.charCodeAt(0)]);
-    chai.assert.deepEqual(cell.getAsCharData(), [123, '１', 2, '１'.charCodeAt(0)]);
-    chai.assert.equal(cell.isCombined(), 0);
+    assert.deepEqual(cell.getAsCharData(), [123, '１', 2, '１'.charCodeAt(0)]);
+    assert.equal(cell.isCombined(), 0);
   });
 });
 
 describe('BufferLine', function(): void {
   it('ctor', function(): void {
     let line: IBufferLine = new TestBufferLine(0);
-    chai.expect(line.length).equals(0);
-    chai.expect(line.isWrapped).equals(false);
+    assert.strictEqual(line.length, 0);
+    assert.strictEqual(line.isWrapped, false);
     line = new TestBufferLine(10);
-    chai.expect(line.length).equals(10);
-    chai.expect(line.loadCell(0, new CellData()).getAsCharData()).eql([0, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]);
-    chai.expect(line.isWrapped).equals(false);
+    assert.strictEqual(line.length, 10);
+    assert.deepEqual(line.loadCell(0, new CellData()).getAsCharData(), [0, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]);
+    assert.strictEqual(line.isWrapped, false);
     line = new TestBufferLine(10, undefined, true);
-    chai.expect(line.length).equals(10);
-    chai.expect(line.loadCell(0, new CellData()).getAsCharData()).eql([0, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]);
-    chai.expect(line.isWrapped).equals(true);
+    assert.strictEqual(line.length, 10);
+    assert.deepEqual(line.loadCell(0, new CellData()).getAsCharData(), [0, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]);
+    assert.strictEqual(line.isWrapped, true);
     line = new TestBufferLine(10, CellData.fromCharData([123, 'a', 456, 'a'.charCodeAt(0)]), true);
-    chai.expect(line.length).equals(10);
-    chai.expect(line.loadCell(0, new CellData()).getAsCharData()).eql([123, 'a', 456, 'a'.charCodeAt(0)]);
-    chai.expect(line.isWrapped).equals(true);
+    assert.strictEqual(line.length, 10);
+    assert.deepEqual(line.loadCell(0, new CellData()).getAsCharData(), [123, 'a', 456, 'a'.charCodeAt(0)]);
+    assert.deepEqual(line.isWrapped, true);
   });
   it('insertCells', function(): void {
     const line = new TestBufferLine(3);
@@ -72,7 +72,7 @@ describe('BufferLine', function(): void {
     line.setCell(1, CellData.fromCharData([2, 'b', 0, 'b'.charCodeAt(0)]));
     line.setCell(2, CellData.fromCharData([3, 'c', 0, 'c'.charCodeAt(0)]));
     line.insertCells(1, 3, CellData.fromCharData([4, 'd', 0, 'd'.charCodeAt(0)]));
-    chai.expect(line.toArray()).eql([
+    assert.deepEqual(line.toArray(), [
       [1, 'a', 0, 'a'.charCodeAt(0)],
       [4, 'd', 0, 'd'.charCodeAt(0)],
       [4, 'd', 0, 'd'.charCodeAt(0)]
@@ -86,7 +86,7 @@ describe('BufferLine', function(): void {
     line.setCell(3, CellData.fromCharData([4, 'd', 0, 'd'.charCodeAt(0)]));
     line.setCell(4, CellData.fromCharData([5, 'e', 0, 'e'.charCodeAt(0)]));
     line.deleteCells(1, 2, CellData.fromCharData([6, 'f', 0, 'f'.charCodeAt(0)]));
-    chai.expect(line.toArray()).eql([
+    assert.deepEqual(line.toArray(), [
       [1, 'a', 0, 'a'.charCodeAt(0)],
       [4, 'd', 0, 'd'.charCodeAt(0)],
       [5, 'e', 0, 'e'.charCodeAt(0)],
@@ -102,7 +102,7 @@ describe('BufferLine', function(): void {
     line.setCell(3, CellData.fromCharData([4, 'd', 0, 'd'.charCodeAt(0)]));
     line.setCell(4, CellData.fromCharData([5, 'e', 0, 'e'.charCodeAt(0)]));
     line.replaceCells(2, 4, CellData.fromCharData([6, 'f', 0, 'f'.charCodeAt(0)]));
-    chai.expect(line.toArray()).eql([
+    assert.deepEqual(line.toArray(), [
       [1, 'a', 0, 'a'.charCodeAt(0)],
       [2, 'b', 0, 'b'.charCodeAt(0)],
       [6, 'f', 0, 'f'.charCodeAt(0)],
@@ -118,7 +118,7 @@ describe('BufferLine', function(): void {
     line.setCell(3, CellData.fromCharData([4, 'd', 0, 'd'.charCodeAt(0)]));
     line.setCell(4, CellData.fromCharData([5, 'e', 0, 'e'.charCodeAt(0)]));
     line.fill(CellData.fromCharData([123, 'z', 0, 'z'.charCodeAt(0)]));
-    chai.expect(line.toArray()).eql([
+    assert.deepEqual(line.toArray(), [
       [123, 'z', 0, 'z'.charCodeAt(0)],
       [123, 'z', 0, 'z'.charCodeAt(0)],
       [123, 'z', 0, 'z'.charCodeAt(0)],
@@ -134,9 +134,9 @@ describe('BufferLine', function(): void {
     line.setCell(3, CellData.fromCharData([4, 'd', 0, 'd'.charCodeAt(0)]));
     line.setCell(4, CellData.fromCharData([5, 'e', 0, 'e'.charCodeAt(0)]));
     const line2 = line.clone();
-    chai.expect(TestBufferLine.prototype.toArray.apply(line2)).eql(line.toArray());
-    chai.expect(line2.length).equals(line.length);
-    chai.expect(line2.isWrapped).equals(line.isWrapped);
+    assert.deepEqual(TestBufferLine.prototype.toArray.apply(line2), line.toArray());
+    assert.strictEqual(line2.length, line.length);
+    assert.strictEqual(line2.isWrapped, line.isWrapped);
   });
   it('copyFrom', function(): void {
     const line = new TestBufferLine(5);
@@ -147,92 +147,92 @@ describe('BufferLine', function(): void {
     line.setCell(4, CellData.fromCharData([5, 'e', 0, 'e'.charCodeAt(0)]));
     const line2 = new TestBufferLine(5, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]), true);
     line2.copyFrom(line);
-    chai.expect(line2.toArray()).eql(line.toArray());
-    chai.expect(line2.length).equals(line.length);
-    chai.expect(line2.isWrapped).equals(line.isWrapped);
+    assert.deepEqual(line2.toArray(), line.toArray());
+    assert.strictEqual(line2.length, line.length);
+    assert.strictEqual(line2.isWrapped, line.isWrapped);
   });
   it('should support combining chars', function(): void {
     // CHAR_DATA_CODE_INDEX resembles current behavior in InputHandler.print
     // --> set code to the last charCodeAt value of the string
     // Note: needs to be fixed once the string pointer is in place
     const line = new TestBufferLine(2, CellData.fromCharData([1, 'e\u0301', 0, '\u0301'.charCodeAt(0)]));
-    chai.expect(line.toArray()).eql([[1, 'e\u0301', 0, '\u0301'.charCodeAt(0)], [1, 'e\u0301', 0, '\u0301'.charCodeAt(0)]]);
+    assert.deepEqual(line.toArray(), [[1, 'e\u0301', 0, '\u0301'.charCodeAt(0)], [1, 'e\u0301', 0, '\u0301'.charCodeAt(0)]]);
     const line2 = new TestBufferLine(5, CellData.fromCharData([1, 'a', 0, '\u0301'.charCodeAt(0)]), true);
     line2.copyFrom(line);
-    chai.expect(line2.toArray()).eql(line.toArray());
+    assert.deepEqual(line2.toArray(), line.toArray());
     const line3 = line.clone();
-    chai.expect(TestBufferLine.prototype.toArray.apply(line3)).eql(line.toArray());
+    assert.deepEqual(TestBufferLine.prototype.toArray.apply(line3), line.toArray());
   });
   describe('resize', function(): void {
     it('enlarge(false)', function(): void {
       const line = new TestBufferLine(5, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]), false);
       line.resize(10, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]));
-      chai.expect(line.toArray()).eql((Array(10) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      assert.deepEqual(line.toArray(), (Array(10) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
     });
     it('enlarge(true)', function(): void {
       const line = new TestBufferLine(5, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]), false);
       line.resize(10, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]));
-      chai.expect(line.toArray()).eql((Array(10) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      assert.deepEqual(line.toArray(), (Array(10) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
     });
     it('shrink(true) - should apply new size', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]), false);
       line.resize(5, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]));
-      chai.expect(line.toArray()).eql((Array(5) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      assert.deepEqual(line.toArray(), (Array(5) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
     });
     it('shrink to 0 length', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]), false);
       line.resize(0, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]));
-      chai.expect(line.toArray()).eql((Array(0) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
+      assert.deepEqual(line.toArray(), (Array(0) as any).fill([1, 'a', 0, 'a'.charCodeAt(0)]));
     });
     it('should remove combining data on replaced cells after shrinking then enlarging', () => {
       const line = new TestBufferLine(10, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]), false);
       line.set(2, [ 0, '😁', 1, '😁'.charCodeAt(0) ]);
       line.set(9, [ 0, '😁', 1, '😁'.charCodeAt(0) ]);
-      chai.expect(line.translateToString()).eql('aa😁aaaaaa😁');
-      chai.expect(Object.keys(line.combined).length).eql(2);
+      assert.strictEqual(line.translateToString(), 'aa😁aaaaaa😁');
+      assert.strictEqual(Object.keys(line.combined).length, 2);
       line.resize(5, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]));
-      chai.expect(line.translateToString()).eql('aa😁aa');
+      assert.strictEqual(line.translateToString(), 'aa😁aa');
       line.resize(10, CellData.fromCharData([1, 'a', 0, 'a'.charCodeAt(0)]));
-      chai.expect(line.translateToString()).eql('aa😁aaaaaaa');
-      chai.expect(Object.keys(line.combined).length).eql(1);
+      assert.strictEqual(line.translateToString(), 'aa😁aaaaaaa');
+      assert.strictEqual(Object.keys(line.combined).length, 1);
     });
   });
   describe('getTrimLength', function(): void {
     it('empty line', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
-      chai.expect(line.getTrimmedLength()).equal(0);
+      assert.strictEqual(line.getTrimmedLength(), 0);
     });
     it('ASCII', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
       line.setCell(0, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(2, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
-      chai.expect(line.getTrimmedLength()).equal(3);
+      assert.strictEqual(line.getTrimmedLength(), 3);
     });
     it('surrogate', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
       line.setCell(0, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(2, CellData.fromCharData([1, '𝄞', 1, '𝄞'.charCodeAt(0)]));
-      chai.expect(line.getTrimmedLength()).equal(3);
+      assert.strictEqual(line.getTrimmedLength(), 3);
     });
     it('combining', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
       line.setCell(0, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(2, CellData.fromCharData([1, 'e\u0301', 1, '\u0301'.charCodeAt(0)]));
-      chai.expect(line.getTrimmedLength()).equal(3);
+      assert.strictEqual(line.getTrimmedLength(), 3);
     });
     it('fullwidth', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
       line.setCell(0, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(2, CellData.fromCharData([1, '１', 2, '１'.charCodeAt(0)]));
       line.setCell(3, CellData.fromCharData([0, '', 0, 0]));
-      chai.expect(line.getTrimmedLength()).equal(4); // also counts null cell after fullwidth
+      assert.strictEqual(line.getTrimmedLength(), 4); // also counts null cell after fullwidth
     });
   });
   describe('translateToString with and w\'o trimming', function(): void {
     it('empty line', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
-      chai.expect(line.translateToString(false)).equal('          ');
-      chai.expect(line.translateToString(true)).equal('');
+      assert.strictEqual(line.translateToString(false), '          ');
+      assert.strictEqual(line.translateToString(true), '');
     });
     it('ASCII', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
@@ -240,14 +240,14 @@ describe('BufferLine', function(): void {
       line.setCell(2, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(4, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(5, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
-      chai.expect(line.translateToString(false)).equal('a a aa    ');
-      chai.expect(line.translateToString(true)).equal('a a aa');
-      chai.expect(line.translateToString(false, 0, 5)).equal('a a a');
-      chai.expect(line.translateToString(false, 0, 4)).equal('a a ');
-      chai.expect(line.translateToString(false, 0, 3)).equal('a a');
-      chai.expect(line.translateToString(true, 0, 5)).equal('a a a');
-      chai.expect(line.translateToString(true, 0, 4)).equal('a a ');
-      chai.expect(line.translateToString(true, 0, 3)).equal('a a');
+      assert.strictEqual(line.translateToString(false), 'a a aa    ');
+      assert.strictEqual(line.translateToString(true), 'a a aa');
+      assert.strictEqual(line.translateToString(false, 0, 5), 'a a a');
+      assert.strictEqual(line.translateToString(false, 0, 4), 'a a ');
+      assert.strictEqual(line.translateToString(false, 0, 3), 'a a');
+      assert.strictEqual(line.translateToString(true, 0, 5), 'a a a');
+      assert.strictEqual(line.translateToString(true, 0, 4), 'a a ');
+      assert.strictEqual(line.translateToString(true, 0, 3), 'a a');
 
     });
     it('surrogate', function(): void {
@@ -256,14 +256,14 @@ describe('BufferLine', function(): void {
       line.setCell(2, CellData.fromCharData([1, '𝄞', 1, '𝄞'.charCodeAt(0)]));
       line.setCell(4, CellData.fromCharData([1, '𝄞', 1, '𝄞'.charCodeAt(0)]));
       line.setCell(5, CellData.fromCharData([1, '𝄞', 1, '𝄞'.charCodeAt(0)]));
-      chai.expect(line.translateToString(false)).equal('a 𝄞 𝄞𝄞    ');
-      chai.expect(line.translateToString(true)).equal('a 𝄞 𝄞𝄞');
-      chai.expect(line.translateToString(false, 0, 5)).equal('a 𝄞 𝄞');
-      chai.expect(line.translateToString(false, 0, 4)).equal('a 𝄞 ');
-      chai.expect(line.translateToString(false, 0, 3)).equal('a 𝄞');
-      chai.expect(line.translateToString(true, 0, 5)).equal('a 𝄞 𝄞');
-      chai.expect(line.translateToString(true, 0, 4)).equal('a 𝄞 ');
-      chai.expect(line.translateToString(true, 0, 3)).equal('a 𝄞');
+      assert.strictEqual(line.translateToString(false), 'a 𝄞 𝄞𝄞    ');
+      assert.strictEqual(line.translateToString(true), 'a 𝄞 𝄞𝄞');
+      assert.strictEqual(line.translateToString(false, 0, 5), 'a 𝄞 𝄞');
+      assert.strictEqual(line.translateToString(false, 0, 4), 'a 𝄞 ');
+      assert.strictEqual(line.translateToString(false, 0, 3), 'a 𝄞');
+      assert.strictEqual(line.translateToString(true, 0, 5), 'a 𝄞 𝄞');
+      assert.strictEqual(line.translateToString(true, 0, 4), 'a 𝄞 ');
+      assert.strictEqual(line.translateToString(true, 0, 3), 'a 𝄞');
     });
     it('combining', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
@@ -271,14 +271,14 @@ describe('BufferLine', function(): void {
       line.setCell(2, CellData.fromCharData([1, 'e\u0301', 1, '\u0301'.charCodeAt(0)]));
       line.setCell(4, CellData.fromCharData([1, 'e\u0301', 1, '\u0301'.charCodeAt(0)]));
       line.setCell(5, CellData.fromCharData([1, 'e\u0301', 1, '\u0301'.charCodeAt(0)]));
-      chai.expect(line.translateToString(false)).equal('a e\u0301 e\u0301e\u0301    ');
-      chai.expect(line.translateToString(true)).equal('a e\u0301 e\u0301e\u0301');
-      chai.expect(line.translateToString(false, 0, 5)).equal('a e\u0301 e\u0301');
-      chai.expect(line.translateToString(false, 0, 4)).equal('a e\u0301 ');
-      chai.expect(line.translateToString(false, 0, 3)).equal('a e\u0301');
-      chai.expect(line.translateToString(true, 0, 5)).equal('a e\u0301 e\u0301');
-      chai.expect(line.translateToString(true, 0, 4)).equal('a e\u0301 ');
-      chai.expect(line.translateToString(true, 0, 3)).equal('a e\u0301');
+      assert.strictEqual(line.translateToString(false), 'a e\u0301 e\u0301e\u0301    ');
+      assert.strictEqual(line.translateToString(true), 'a e\u0301 e\u0301e\u0301');
+      assert.strictEqual(line.translateToString(false, 0, 5), 'a e\u0301 e\u0301');
+      assert.strictEqual(line.translateToString(false, 0, 4), 'a e\u0301 ');
+      assert.strictEqual(line.translateToString(false, 0, 3), 'a e\u0301');
+      assert.strictEqual(line.translateToString(true, 0, 5), 'a e\u0301 e\u0301');
+      assert.strictEqual(line.translateToString(true, 0, 4), 'a e\u0301 ');
+      assert.strictEqual(line.translateToString(true, 0, 3), 'a e\u0301');
     });
     it('fullwidth', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
@@ -289,20 +289,20 @@ describe('BufferLine', function(): void {
       line.setCell(6, CellData.fromCharData([0, '', 0, 0]));
       line.setCell(7, CellData.fromCharData([1, '１', 2, '１'.charCodeAt(0)]));
       line.setCell(8, CellData.fromCharData([0, '', 0, 0]));
-      chai.expect(line.translateToString(false)).equal('a １ １１ ');
-      chai.expect(line.translateToString(true)).equal('a １ １１');
-      chai.expect(line.translateToString(false, 0, 7)).equal('a １ １');
-      chai.expect(line.translateToString(false, 0, 6)).equal('a １ １');
-      chai.expect(line.translateToString(false, 0, 5)).equal('a １ ');
-      chai.expect(line.translateToString(false, 0, 4)).equal('a １');
-      chai.expect(line.translateToString(false, 0, 3)).equal('a １');
-      chai.expect(line.translateToString(false, 0, 2)).equal('a ');
-      chai.expect(line.translateToString(true, 0, 7)).equal('a １ １');
-      chai.expect(line.translateToString(true, 0, 6)).equal('a １ １');
-      chai.expect(line.translateToString(true, 0, 5)).equal('a １ ');
-      chai.expect(line.translateToString(true, 0, 4)).equal('a １');
-      chai.expect(line.translateToString(true, 0, 3)).equal('a １');
-      chai.expect(line.translateToString(true, 0, 2)).equal('a ');
+      assert.strictEqual(line.translateToString(false), 'a １ １１ ');
+      assert.strictEqual(line.translateToString(true), 'a １ １１');
+      assert.strictEqual(line.translateToString(false, 0, 7), 'a １ １');
+      assert.strictEqual(line.translateToString(false, 0, 6), 'a １ １');
+      assert.strictEqual(line.translateToString(false, 0, 5), 'a １ ');
+      assert.strictEqual(line.translateToString(false, 0, 4), 'a １');
+      assert.strictEqual(line.translateToString(false, 0, 3), 'a １');
+      assert.strictEqual(line.translateToString(false, 0, 2), 'a ');
+      assert.strictEqual(line.translateToString(true, 0, 7), 'a １ １');
+      assert.strictEqual(line.translateToString(true, 0, 6), 'a １ １');
+      assert.strictEqual(line.translateToString(true, 0, 5), 'a １ ');
+      assert.strictEqual(line.translateToString(true, 0, 4), 'a １');
+      assert.strictEqual(line.translateToString(true, 0, 3), 'a １');
+      assert.strictEqual(line.translateToString(true, 0, 2), 'a ');
     });
     it('space at end', function(): void {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
@@ -311,21 +311,21 @@ describe('BufferLine', function(): void {
       line.setCell(4, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(5, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
       line.setCell(6, CellData.fromCharData([1, ' ', 1, ' '.charCodeAt(0)]));
-      chai.expect(line.translateToString(false)).equal('a a aa    ');
-      chai.expect(line.translateToString(true)).equal('a a aa ');
+      assert.strictEqual(line.translateToString(false), 'a a aa    ');
+      assert.strictEqual(line.translateToString(true), 'a a aa ');
     });
     it('should always return some sane value', function(): void {
       // sanity check - broken line with invalid out of bound null width cells
       // this can atm happen with deleting/inserting chars in inputhandler by "breaking"
       // fullwidth pairs --> needs to be fixed after settling BufferLine impl
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, 0, NULL_CELL_CODE]), false);
-      chai.expect(line.translateToString(false)).equal('          ');
-      chai.expect(line.translateToString(true)).equal('');
+      assert.strictEqual(line.translateToString(false), '          ');
+      assert.strictEqual(line.translateToString(true), '');
     });
     it('should work with endCol=0', () => {
       const line = new TestBufferLine(10, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, 0, NULL_CELL_CODE]), false);
       line.setCell(0, CellData.fromCharData([1, 'a', 1, 'a'.charCodeAt(0)]));
-      chai.expect(line.translateToString(true, 0, 0)).equal('');
+      assert.strictEqual(line.translateToString(true, 0, 0), '');
     });
   });
   describe('addCharToCell', () => {
@@ -335,9 +335,9 @@ describe('BufferLine', function(): void {
       const cell = line.loadCell(0, new CellData());
       // chars contains single combining char
       // width is set to 1
-      chai.assert.deepEqual(cell.getAsCharData(), [DEFAULT_ATTR, '\u0301', 1, 0x0301]);
+      assert.deepEqual(cell.getAsCharData(), [DEFAULT_ATTR, '\u0301', 1, 0x0301]);
       // do not account a single combining char as combined
-      chai.assert.equal(cell.isCombined(), 0);
+      assert.equal(cell.isCombined(), 0);
     });
     it('should add char to combining string in cell', () => {
       const line = new TestBufferLine(3, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
@@ -348,9 +348,9 @@ describe('BufferLine', function(): void {
       line.loadCell(0, cell);
       // chars contains 3 chars
       // width is set to 1
-      chai.assert.deepEqual(cell.getAsCharData(), [123, 'e\u0301\u0301', 1, 0x0301]);
+      assert.deepEqual(cell.getAsCharData(), [123, 'e\u0301\u0301', 1, 0x0301]);
       // do not account a single combining char as combined
-      chai.assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
+      assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
     });
     it('should create combining string on taken cell', () => {
       const line = new TestBufferLine(3, CellData.fromCharData([DEFAULT_ATTR, NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE]), false);
@@ -361,9 +361,9 @@ describe('BufferLine', function(): void {
       line.loadCell(0, cell);
       // chars contains 2 chars
       // width is set to 1
-      chai.assert.deepEqual(cell.getAsCharData(), [123, 'e\u0301', 1, 0x0301]);
+      assert.deepEqual(cell.getAsCharData(), [123, 'e\u0301', 1, 0x0301]);
       // do not account a single combining char as combined
-      chai.assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
+      assert.equal(cell.isCombined(), Content.IS_COMBINED_MASK);
     });
   });
 });

--- a/src/common/buffer/BufferLine.test.ts
+++ b/src/common/buffer/BufferLine.test.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 The xterm.js authors. All rights reserved.
  * @license MIT
  */
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE, DEFAULT_ATTR, Content } from 'common/buffer/Constants';
 import { BufferLine } from 'common/buffer//BufferLine';

--- a/src/common/buffer/BufferReflow.test.ts
+++ b/src/common/buffer/BufferReflow.test.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 The xterm.js authors. All rights reserved.
  * @license MIT
  */
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { BufferLine } from 'common/buffer/BufferLine';
 import { NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE } from 'common/buffer/Constants';

--- a/src/common/buffer/BufferReflow.test.ts
+++ b/src/common/buffer/BufferReflow.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 The xterm.js authors. All rights reserved.
  * @license MIT
  */
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { BufferLine } from 'common/buffer/BufferLine';
 import { NULL_CELL_CHAR, NULL_CELL_WIDTH, NULL_CELL_CODE } from 'common/buffer/Constants';
 import { reflowSmallerGetNewLineLengths } from 'common/buffer/BufferReflow';

--- a/src/common/buffer/BufferSet.test.ts
+++ b/src/common/buffer/BufferSet.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { BufferSet } from 'common/buffer/BufferSet';
 import { Buffer } from 'common/buffer/Buffer';

--- a/src/common/buffer/BufferSet.test.ts
+++ b/src/common/buffer/BufferSet.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { BufferSet } from 'common/buffer/BufferSet';
 import { Buffer } from 'common/buffer/Buffer';
 import { MockOptionsService, MockBufferService } from 'common/TestUtils.test';
@@ -20,8 +20,8 @@ describe('BufferSet', () => {
 
   describe('constructor', () => {
     it('should create two different buffers: alt and normal', () => {
-      assert.instanceOf(bufferSet.normal, Buffer);
-      assert.instanceOf(bufferSet.alt, Buffer);
+      assert.strictEqual(bufferSet.normal instanceof Buffer, true);
+      assert.strictEqual(bufferSet.alt instanceof Buffer, true);
       assert.notEqual(bufferSet.normal, bufferSet.alt);
     });
   });

--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -1,4 +1,9 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
 
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { evaluateKeyboardEvent } from 'common/input/Keyboard';
 import { IKeyboardResult, IKeyboardEvent } from 'common/Types';

--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -1,5 +1,5 @@
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { evaluateKeyboardEvent } from 'common/input/Keyboard';
 import { IKeyboardResult, IKeyboardEvent } from 'common/Types';
 

--- a/src/common/input/TextDecoder.test.ts
+++ b/src/common/input/TextDecoder.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { StringToUtf32, stringFromCodePoint, Utf8ToUtf32, utf32ToString } from 'common/input/TextDecoder';
 import { encode } from 'utf8';
 

--- a/src/common/input/TextDecoder.test.ts
+++ b/src/common/input/TextDecoder.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { StringToUtf32, stringFromCodePoint, Utf8ToUtf32, utf32ToString } from 'common/input/TextDecoder';
 import { encode } from 'utf8';

--- a/src/common/parser/EscapeSequenceParser.test.ts
+++ b/src/common/parser/EscapeSequenceParser.test.ts
@@ -5,7 +5,7 @@
 
 import { IDcsHandler, IParsingState, IParams, ParamsArray } from 'common/parser/Types';
 import { EscapeSequenceParser, TransitionTable, VT500_TRANSITION_TABLE } from 'common/parser/EscapeSequenceParser';
-import * as chai from 'chai';
+import * as assert from 'assert';
 import { StringToUtf32, stringFromCodePoint } from 'common/input/TextDecoder';
 import { ParserState } from 'common/parser/Constants';
 import { Params } from 'common/parser/Params';
@@ -55,7 +55,7 @@ const testTerminal: any = {
     this.calls = [];
   },
   compare: function (value: any): void {
-    chai.expect(this.calls.slice()).eql(value); // weird bug w'o slicing here
+    assert.deepEqual(this.calls.slice(), value); // weird bug w'o slicing here
   },
   print: function (data: Uint32Array, start: number, end: number): void {
     let s = '';
@@ -153,19 +153,19 @@ describe('EscapeSequenceParser', function (): void {
   describe('Parser init and methods', function (): void {
     it('constructor', function (): void {
       let p: EscapeSequenceParser = new EscapeSequenceParser();
-      chai.expect(p.TRANSITIONS).equal(VT500_TRANSITION_TABLE);
+      assert.strictEqual(p.TRANSITIONS, VT500_TRANSITION_TABLE);
       p = new EscapeSequenceParser(VT500_TRANSITION_TABLE);
-      chai.expect(p.TRANSITIONS).equal(VT500_TRANSITION_TABLE);
+      assert.strictEqual(p.TRANSITIONS, VT500_TRANSITION_TABLE);
       const tansitions: TransitionTable = new TransitionTable(10);
       p = new EscapeSequenceParser(tansitions);
-      chai.expect(p.TRANSITIONS).equal(tansitions);
+      assert.strictEqual(p.TRANSITIONS, tansitions);
     });
     it('inital states', function (): void {
-      chai.expect(parser.initialState).equal(ParserState.GROUND);
-      chai.expect(parser.currentState).equal(ParserState.GROUND);
-      chai.expect(parser.osc).equal('');
-      chai.expect(parser.params).eql([0]);
-      chai.expect(parser.collect).equal('');
+      assert.strictEqual(parser.initialState, ParserState.GROUND);
+      assert.strictEqual(parser.currentState, ParserState.GROUND);
+      assert.strictEqual(parser.osc, '');
+      assert.deepEqual(parser.params, [0]);
+      assert.strictEqual(parser.collect, '');
     });
     it('reset states', function (): void {
       parser.currentState = 124;
@@ -174,10 +174,10 @@ describe('EscapeSequenceParser', function (): void {
       parser.collect = '#';
 
       parser.reset();
-      chai.expect(parser.currentState).equal(ParserState.GROUND);
-      chai.expect(parser.osc).equal('');
-      chai.expect(parser.params).eql([0]);
-      chai.expect(parser.collect).equal('');
+      assert.strictEqual(parser.currentState, ParserState.GROUND);
+      assert.strictEqual(parser.osc, '');
+      assert.deepEqual(parser.params, [0]);
+      assert.strictEqual(parser.collect, '');
     });
   });
   describe('state transitions and actions', function (): void {
@@ -190,7 +190,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.GROUND;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -203,7 +203,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < printables.length; ++i) {
         parser.currentState = ParserState.GROUND;
         parse(parser, printables[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([['print', printables[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -225,13 +225,13 @@ describe('EscapeSequenceParser', function (): void {
         for (let i = 0; i < exes.length; ++i) {
           parser.currentState = state;
           parse(parser, exes[i]);
-          chai.expect(parser.currentState).equal(ParserState.GROUND);
+          assert.strictEqual(parser.currentState, ParserState.GROUND);
           testTerminal.compare((state in exceptions ? exceptions[state][exes[i]] : 0) || [['exe', exes[i]]]);
           parser.reset();
           testTerminal.clear();
         }
         parse(parser, '\x9c');
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([]);
         parser.reset();
         testTerminal.clear();
@@ -245,10 +245,10 @@ describe('EscapeSequenceParser', function (): void {
         parser.params = [23];
         parser.collect = '#';
         parse(parser, '\x1b');
-        chai.expect(parser.currentState).equal(ParserState.ESCAPE);
-        chai.expect(parser.osc).equal('');
-        chai.expect(parser.params).eql([0]);
-        chai.expect(parser.collect).equal('');
+        assert.strictEqual(parser.currentState, ParserState.ESCAPE);
+        assert.strictEqual(parser.osc, '');
+        assert.deepEqual(parser.params, [0]);
+        assert.strictEqual(parser.collect, '');
         parser.reset();
       }
     });
@@ -261,7 +261,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.ESCAPE;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.ESCAPE);
+        assert.strictEqual(parser.currentState, ParserState.ESCAPE);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -272,7 +272,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.ESCAPE;
       parse(parser, '\x7f');
-      chai.expect(parser.currentState).equal(ParserState.ESCAPE);
+      assert.strictEqual(parser.currentState, ParserState.ESCAPE);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -287,7 +287,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < dispatches.length; ++i) {
         parser.currentState = ParserState.ESCAPE;
         parse(parser, dispatches[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([['esc', '', dispatches[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -299,8 +299,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.ESCAPE;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.ESCAPE_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.ESCAPE_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -313,7 +313,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.ESCAPE_INTERMEDIATE;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.ESCAPE_INTERMEDIATE);
+        assert.strictEqual(parser.currentState, ParserState.ESCAPE_INTERMEDIATE);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -324,7 +324,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.ESCAPE_INTERMEDIATE;
       parse(parser, '\x7f');
-      chai.expect(parser.currentState).equal(ParserState.ESCAPE_INTERMEDIATE);
+      assert.strictEqual(parser.currentState, ParserState.ESCAPE_INTERMEDIATE);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -335,8 +335,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.ESCAPE_INTERMEDIATE;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.ESCAPE_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.ESCAPE_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -347,7 +347,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.ESCAPE_INTERMEDIATE;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         // '\x5c' --> ESC + \ (7bit ST) parser does not expose this as it already got handled
         testTerminal.compare((collect[i] === '\x5c') ? [] : [['esc', '', collect[i]]]);
         parser.reset();
@@ -362,10 +362,10 @@ describe('EscapeSequenceParser', function (): void {
       parser.params = [123];
       parser.collect = '#';
       parse(parser, '[');
-      chai.expect(parser.currentState).equal(ParserState.CSI_ENTRY);
-      chai.expect(parser.osc).equal('');
-      chai.expect(parser.params).eql([0]);
-      chai.expect(parser.collect).equal('');
+      assert.strictEqual(parser.currentState, ParserState.CSI_ENTRY);
+      assert.strictEqual(parser.osc, '');
+      assert.deepEqual(parser.params, [0]);
+      assert.strictEqual(parser.collect, '');
       parser.reset();
       // C1
       for (state in states) {
@@ -374,10 +374,10 @@ describe('EscapeSequenceParser', function (): void {
         parser.params = [123];
         parser.collect = '#';
         parse(parser, '\x9b');
-        chai.expect(parser.currentState).equal(ParserState.CSI_ENTRY);
-        chai.expect(parser.osc).equal('');
-        chai.expect(parser.params).eql([0]);
-        chai.expect(parser.collect).equal('');
+        assert.strictEqual(parser.currentState, ParserState.CSI_ENTRY);
+        assert.strictEqual(parser.osc, '');
+        assert.deepEqual(parser.params, [0]);
+        assert.strictEqual(parser.collect, '');
         parser.reset();
       }
     });
@@ -390,7 +390,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.CSI_ENTRY;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_ENTRY);
+        assert.strictEqual(parser.currentState, ParserState.CSI_ENTRY);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -401,7 +401,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.CSI_ENTRY;
       parse(parser, '\x7f');
-      chai.expect(parser.currentState).equal(ParserState.CSI_ENTRY);
+      assert.strictEqual(parser.currentState, ParserState.CSI_ENTRY);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -412,7 +412,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < dispatches.length; ++i) {
         parser.currentState = ParserState.CSI_ENTRY;
         parse(parser, dispatches[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([['csi', '', [0], dispatches[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -425,20 +425,20 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < params.length; ++i) {
         parser.currentState = ParserState.CSI_ENTRY;
         parse(parser, params[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
-        chai.expect(parser.params).eql([params[i].charCodeAt(0) - 48]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
+        assert.deepEqual(parser.params, [params[i].charCodeAt(0) - 48]);
         parser.reset();
       }
       parser.currentState = ParserState.CSI_ENTRY;
       parse(parser, '\x3b');
-      chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
-      chai.expect(parser.params).eql([0, 0]);
+      assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
+      assert.deepEqual(parser.params, [0, 0]);
       parser.reset();
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.CSI_ENTRY;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -451,7 +451,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.CSI_PARAM;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
+        assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -463,14 +463,14 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < params.length; ++i) {
         parser.currentState = ParserState.CSI_PARAM;
         parse(parser, params[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
-        chai.expect(parser.params).eql([params[i].charCodeAt(0) - 48]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
+        assert.deepEqual(parser.params, [params[i].charCodeAt(0) - 48]);
         parser.reset();
       }
       parser.currentState = ParserState.CSI_PARAM;
       parse(parser, '\x3b');
-      chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
-      chai.expect(parser.params).eql([0, 0]);
+      assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
+      assert.deepEqual(parser.params, [0, 0]);
       parser.reset();
     });
     it('state CSI_PARAM ignore', function (): void {
@@ -478,7 +478,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.CSI_PARAM;
       parse(parser, '\x7f');
-      chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
+      assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -490,7 +490,7 @@ describe('EscapeSequenceParser', function (): void {
         parser.currentState = ParserState.CSI_PARAM;
         parser.params = [0, 1];
         parse(parser, dispatches[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([['csi', '', [0, 1], dispatches[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -502,8 +502,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.CSI_ENTRY;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -513,8 +513,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.CSI_PARAM;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -527,7 +527,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.CSI_INTERMEDIATE;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_INTERMEDIATE);
+        assert.strictEqual(parser.currentState, ParserState.CSI_INTERMEDIATE);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -539,8 +539,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.CSI_INTERMEDIATE;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -549,7 +549,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.CSI_INTERMEDIATE;
       parse(parser, '\x7f');
-      chai.expect(parser.currentState).equal(ParserState.CSI_INTERMEDIATE);
+      assert.strictEqual(parser.currentState, ParserState.CSI_INTERMEDIATE);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -561,7 +561,7 @@ describe('EscapeSequenceParser', function (): void {
         parser.currentState = ParserState.CSI_INTERMEDIATE;
         parser.params = [0, 1];
         parse(parser, dispatches[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([['csi', '', [0, 1], dispatches[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -571,7 +571,7 @@ describe('EscapeSequenceParser', function (): void {
       parser.reset();
       parser.currentState = ParserState.CSI_ENTRY;
       parse(parser, '\x3a');
-      chai.expect(parser.currentState).equal(ParserState.CSI_PARAM);
+      assert.strictEqual(parser.currentState, ParserState.CSI_PARAM);
       parser.reset();
     });
     it('trans CSI_PARAM --> CSI_IGNORE', function (): void {
@@ -580,8 +580,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < chars.length; ++i) {
         parser.currentState = ParserState.CSI_PARAM;
         parse(parser, '\x3b' + chars[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_IGNORE);
-        chai.expect(parser.params).eql([0, 0]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_IGNORE);
+        assert.deepEqual(parser.params, [0, 0]);
         parser.reset();
       }
     });
@@ -589,11 +589,11 @@ describe('EscapeSequenceParser', function (): void {
       parser.reset();
       const chars = ['\x3c', '\x3d', '\x3e', '\x3f'];
       for (let i = 0; i < chars.length; ++i) {
-        chai.expect(parser.params).eql([0]);
+        assert.deepEqual(parser.params, [0]);
         parser.currentState = ParserState.CSI_PARAM;
         parse(parser, '\x3b' + chars[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_IGNORE);
-        chai.expect(parser.params).eql([0, 0]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_IGNORE);
+        assert.deepEqual(parser.params, [0, 0]);
         parser.reset();
       }
     });
@@ -603,8 +603,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < chars.length; ++i) {
         parser.currentState = ParserState.CSI_INTERMEDIATE;
         parse(parser, chars[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_IGNORE);
-        chai.expect(parser.params).eql([0]);
+        assert.strictEqual(parser.currentState, ParserState.CSI_IGNORE);
+        assert.deepEqual(parser.params, [0]);
         parser.reset();
       }
     });
@@ -617,7 +617,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < exes.length; ++i) {
         parser.currentState = ParserState.CSI_IGNORE;
         parse(parser, exes[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_IGNORE);
+        assert.strictEqual(parser.currentState, ParserState.CSI_IGNORE);
         testTerminal.compare([['exe', exes[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -631,7 +631,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.CSI_IGNORE;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.CSI_IGNORE);
+        assert.strictEqual(parser.currentState, ParserState.CSI_IGNORE);
         testTerminal.compare([]);
         parser.reset();
         testTerminal.clear();
@@ -644,7 +644,7 @@ describe('EscapeSequenceParser', function (): void {
         parser.currentState = ParserState.CSI_IGNORE;
         parser.params = [0, 1];
         parse(parser, dispatches[i]);
-        chai.expect(parser.currentState).equal(ParserState.GROUND);
+        assert.strictEqual(parser.currentState, ParserState.GROUND);
         testTerminal.compare([]);
         parser.reset();
         testTerminal.clear();
@@ -656,7 +656,7 @@ describe('EscapeSequenceParser', function (): void {
       let initializers = ['\x58', '\x5e', '\x5f'];
       for (let i = 0; i < initializers.length; ++i) {
         parse(parser, '\x1b' + initializers[i]);
-        chai.expect(parser.currentState).equal(ParserState.SOS_PM_APC_STRING);
+        assert.strictEqual(parser.currentState, ParserState.SOS_PM_APC_STRING);
         parser.reset();
       }
       // C1
@@ -665,7 +665,7 @@ describe('EscapeSequenceParser', function (): void {
         initializers = ['\x98', '\x9e', '\x9f'];
         for (let i = 0; i < initializers.length; ++i) {
           parse(parser, initializers[i]);
-          chai.expect(parser.currentState).equal(ParserState.SOS_PM_APC_STRING);
+          assert.strictEqual(parser.currentState, ParserState.SOS_PM_APC_STRING);
           parser.reset();
         }
       }
@@ -679,7 +679,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.SOS_PM_APC_STRING;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.SOS_PM_APC_STRING);
+        assert.strictEqual(parser.currentState, ParserState.SOS_PM_APC_STRING);
         parser.reset();
       }
     });
@@ -687,13 +687,13 @@ describe('EscapeSequenceParser', function (): void {
       parser.reset();
       // C0
       parse(parser, '\x1b]');
-      chai.expect(parser.currentState).equal(ParserState.OSC_STRING);
+      assert.strictEqual(parser.currentState, ParserState.OSC_STRING);
       parser.reset();
       // C1
       for (state in states) {
         parser.currentState = state;
         parse(parser, '\x9d');
-        chai.expect(parser.currentState).equal(ParserState.OSC_STRING);
+        assert.strictEqual(parser.currentState, ParserState.OSC_STRING);
         parser.reset();
       }
     });
@@ -706,8 +706,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.OSC_STRING;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.OSC_STRING);
-        chai.expect(parser.osc).equal('');
+        assert.strictEqual(parser.currentState, ParserState.OSC_STRING);
+        assert.strictEqual(parser.osc, '');
         parser.reset();
       }
     });
@@ -717,8 +717,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < puts.length; ++i) {
         parser.currentState = ParserState.OSC_STRING;
         parse(parser, puts[i]);
-        chai.expect(parser.currentState).equal(ParserState.OSC_STRING);
-        chai.expect(parser.osc).equal(puts[i]);
+        assert.strictEqual(parser.currentState, ParserState.OSC_STRING);
+        assert.strictEqual(parser.osc, puts[i]);
         parser.reset();
       }
     });
@@ -726,13 +726,13 @@ describe('EscapeSequenceParser', function (): void {
       parser.reset();
       // C0
       parse(parser, '\x1bP');
-      chai.expect(parser.currentState).equal(ParserState.DCS_ENTRY);
+      assert.strictEqual(parser.currentState, ParserState.DCS_ENTRY);
       parser.reset();
       // C1
       for (state in states) {
         parser.currentState = state;
         parse(parser, '\x90');
-        chai.expect(parser.currentState).equal(ParserState.DCS_ENTRY);
+        assert.strictEqual(parser.currentState, ParserState.DCS_ENTRY);
         parser.reset();
       }
     });
@@ -745,7 +745,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.DCS_ENTRY;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_ENTRY);
+        assert.strictEqual(parser.currentState, ParserState.DCS_ENTRY);
         parser.reset();
       }
     });
@@ -756,20 +756,20 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < params.length; ++i) {
         parser.currentState = ParserState.DCS_ENTRY;
         parse(parser, params[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
-        chai.expect(parser.params).eql([params[i].charCodeAt(0) - 48]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
+        assert.deepEqual(parser.params, [params[i].charCodeAt(0) - 48]);
         parser.reset();
       }
       parser.currentState = ParserState.DCS_ENTRY;
       parse(parser, '\x3b');
-      chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
-      chai.expect(parser.params).eql([0, 0]);
+      assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
+      assert.deepEqual(parser.params, [0, 0]);
       parser.reset();
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_ENTRY;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -782,7 +782,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.DCS_PARAM;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
         parser.reset();
       }
     });
@@ -792,21 +792,21 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < params.length; ++i) {
         parser.currentState = ParserState.DCS_PARAM;
         parse(parser, params[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
-        chai.expect(parser.params).eql([params[i].charCodeAt(0) - 48]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
+        assert.deepEqual(parser.params, [params[i].charCodeAt(0) - 48]);
         parser.reset();
       }
       parser.currentState = ParserState.DCS_PARAM;
       parse(parser, '\x3b');
-      chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
-      chai.expect(parser.params).eql([0, 0]);
+      assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
+      assert.deepEqual(parser.params, [0, 0]);
       parser.reset();
     });
     it('trans DCS_ENTRY --> DCS_PARAM for ":" (0x3a)', function (): void {
       parser.reset();
       parser.currentState = ParserState.DCS_ENTRY;
       parse(parser, '\x3a');
-      chai.expect(parser.currentState).equal(ParserState.DCS_PARAM);
+      assert.strictEqual(parser.currentState, ParserState.DCS_PARAM);
       parser.reset();
     });
     it('trans DCS_PARAM --> DCS_IGNORE', function (): void {
@@ -815,8 +815,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < chars.length; ++i) {
         parser.currentState = ParserState.DCS_PARAM;
         parse(parser, '\x3b' + chars[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_IGNORE);
-        chai.expect(parser.params).eql([0, 0]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_IGNORE);
+        assert.deepEqual(parser.params, [0, 0]);
         parser.reset();
       }
     });
@@ -826,7 +826,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < chars.length; ++i) {
         parser.currentState = ParserState.DCS_INTERMEDIATE;
         parse(parser, chars[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_IGNORE);
+        assert.strictEqual(parser.currentState, ParserState.DCS_IGNORE);
         parser.reset();
       }
     });
@@ -840,7 +840,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.DCS_IGNORE;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_IGNORE);
+        assert.strictEqual(parser.currentState, ParserState.DCS_IGNORE);
         parser.reset();
       }
     });
@@ -850,8 +850,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_ENTRY;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -861,8 +861,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_PARAM;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -875,7 +875,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < ignored.length; ++i) {
         parser.currentState = ParserState.DCS_INTERMEDIATE;
         parse(parser, ignored[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_INTERMEDIATE);
+        assert.strictEqual(parser.currentState, ParserState.DCS_INTERMEDIATE);
         parser.reset();
       }
     });
@@ -885,8 +885,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_INTERMEDIATE;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_INTERMEDIATE);
-        chai.expect(parser.collect).equal(collect[i]);
+        assert.strictEqual(parser.currentState, ParserState.DCS_INTERMEDIATE);
+        assert.strictEqual(parser.collect, collect[i]);
         parser.reset();
       }
     });
@@ -896,8 +896,8 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < chars.length; ++i) {
         parser.currentState = ParserState.DCS_INTERMEDIATE;
         parse(parser, '\x20' + chars[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_IGNORE);
-        chai.expect(parser.collect).equal('\x20');
+        assert.strictEqual(parser.currentState, ParserState.DCS_IGNORE);
+        assert.strictEqual(parser.collect, '\x20');
         parser.reset();
       }
     });
@@ -908,7 +908,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_ENTRY;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PASSTHROUGH);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PASSTHROUGH);
         testTerminal.compare([['dcs hook', '', [0], collect[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -921,7 +921,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_PARAM;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PASSTHROUGH);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PASSTHROUGH);
         testTerminal.compare([['dcs hook', '', [0], collect[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -934,7 +934,7 @@ describe('EscapeSequenceParser', function (): void {
       for (let i = 0; i < collect.length; ++i) {
         parser.currentState = ParserState.DCS_INTERMEDIATE;
         parse(parser, collect[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PASSTHROUGH);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PASSTHROUGH);
         testTerminal.compare([['dcs hook', '', [0], collect[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -951,7 +951,7 @@ describe('EscapeSequenceParser', function (): void {
         parser.currentState = ParserState.DCS_PASSTHROUGH;
         parser.mockActiveDcsHandler();
         parse(parser, puts[i]);
-        chai.expect(parser.currentState).equal(ParserState.DCS_PASSTHROUGH);
+        assert.strictEqual(parser.currentState, ParserState.DCS_PASSTHROUGH);
         testTerminal.compare([['dcs put', puts[i]]]);
         parser.reset();
         testTerminal.clear();
@@ -962,7 +962,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.DCS_PASSTHROUGH;
       parse(parser, '\x7f');
-      chai.expect(parser.currentState).equal(ParserState.DCS_PASSTHROUGH);
+      assert.strictEqual(parser.currentState, ParserState.DCS_PASSTHROUGH);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -1070,7 +1070,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.CSI_IGNORE;
       parse(parser, '€öäü');
-      chai.expect(parser.currentState).equal(ParserState.CSI_IGNORE);
+      assert.strictEqual(parser.currentState, ParserState.CSI_IGNORE);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -1080,7 +1080,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.DCS_IGNORE;
       parse(parser, '€öäü');
-      chai.expect(parser.currentState).equal(ParserState.DCS_IGNORE);
+      assert.strictEqual(parser.currentState, ParserState.DCS_IGNORE);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -1090,7 +1090,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.DCS_PASSTHROUGH;
       parse(parser, '\x901;2;3+$a€öäü');
-      chai.expect(parser.currentState).equal(ParserState.DCS_PASSTHROUGH);
+      assert.strictEqual(parser.currentState, ParserState.DCS_PASSTHROUGH);
       testTerminal.compare([['dcs hook', '+$', [1, 2, 3], 'a'], ['dcs put', '€öäü']]);
       parser.reset();
       testTerminal.clear();
@@ -1100,7 +1100,7 @@ describe('EscapeSequenceParser', function (): void {
       testTerminal.clear();
       parser.currentState = ParserState.GROUND;
       parse(parser, '\x9c');
-      chai.expect(parser.currentState).equal(ParserState.GROUND);
+      assert.strictEqual(parser.currentState, ParserState.GROUND);
       testTerminal.compare([]);
       parser.reset();
       testTerminal.clear();
@@ -1135,12 +1135,12 @@ describe('EscapeSequenceParser', function (): void {
         }
       });
       parse(parser2, INPUT);
-      chai.expect(print).equal('hello world!$>');
+      assert.strictEqual(print, 'hello world!$>');
       parser2.clearPrintHandler();
       parser2.clearPrintHandler(); // should not throw
       clearAccu();
       parse(parser2, INPUT);
-      chai.expect(print).equal('');
+      assert.strictEqual(print, '');
     });
     it('ESC handler', function (): void {
       parser2.setEscHandler('%G', function (): void {
@@ -1150,28 +1150,28 @@ describe('EscapeSequenceParser', function (): void {
         esc.push('E');
       });
       parse(parser2, INPUT);
-      chai.expect(esc).eql(['%G', 'E']);
+      assert.deepEqual(esc, ['%G', 'E']);
       parser2.clearEscHandler('%G');
       parser2.clearEscHandler('%G'); // should not throw
       clearAccu();
       parse(parser2, INPUT);
-      chai.expect(esc).eql(['E']);
+      assert.deepEqual(esc, ['E']);
       parser2.clearEscHandler('E');
       clearAccu();
       parse(parser2, INPUT);
-      chai.expect(esc).eql([]);
+      assert.deepEqual(esc, []);
     });
     it('CSI handler', function (): void {
       parser2.setCsiHandler('m', function (params: IParams, collect: string): void {
         csi.push(['m', params.toArray(), collect]);
       });
       parse(parser2, INPUT);
-      chai.expect(csi).eql([['m', [1, 31], ''], ['m', [0], '']]);
+      assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']]);
       parser2.clearCsiHandler('m');
       parser2.clearCsiHandler('m'); // should not throw
       clearAccu();
       parse(parser2, INPUT);
-      chai.expect(csi).eql([]);
+      assert.deepEqual(csi, []);
     });
     describe('CSI custom handlers', () => {
       it('Prevent fallback', () => {
@@ -1179,16 +1179,16 @@ describe('EscapeSequenceParser', function (): void {
         parser2.setCsiHandler('m', (params, collect) => csi.push(['m', params.toArray(), collect]));
         parser2.addCsiHandler('m', (params, collect) => { csiCustom.push(['m', params.toArray(), collect]); return true; });
         parse(parser2, INPUT);
-        chai.expect(csi).eql([], 'Should not fallback to original handler');
-        chai.expect(csiCustom).eql([['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csi, [], 'Should not fallback to original handler');
+        assert.deepEqual(csiCustom, [['m', [1, 31], ''], ['m', [0], '']]);
       });
       it('Allow fallback', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
         parser2.setCsiHandler('m', (params, collect) => csi.push(['m', params.toArray(), collect]));
         parser2.addCsiHandler('m', (params, collect) => { csiCustom.push(['m', params.toArray(), collect]); return false; });
         parse(parser2, INPUT);
-        chai.expect(csi).eql([['m', [1, 31], ''], ['m', [0], '']], 'Should fallback to original handler');
-        chai.expect(csiCustom).eql([['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']], 'Should fallback to original handler');
+        assert.deepEqual(csiCustom, [['m', [1, 31], ''], ['m', [0], '']]);
       });
       it('Multiple custom handlers fallback once', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
@@ -1197,9 +1197,9 @@ describe('EscapeSequenceParser', function (): void {
         parser2.addCsiHandler('m', (params, collect) => { csiCustom.push(['m', params.toArray(), collect]); return true; });
         parser2.addCsiHandler('m', (params, collect) => { csiCustom2.push(['m', params.toArray(), collect]); return false; });
         parse(parser2, INPUT);
-        chai.expect(csi).eql([], 'Should not fallback to original handler');
-        chai.expect(csiCustom).eql([['m', [1, 31], ''], ['m', [0], '']]);
-        chai.expect(csiCustom2).eql([['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csi, [], 'Should not fallback to original handler');
+        assert.deepEqual(csiCustom, [['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csiCustom2, [['m', [1, 31], ''], ['m', [0], '']]);
       });
       it('Multiple custom handlers no fallback', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
@@ -1208,9 +1208,9 @@ describe('EscapeSequenceParser', function (): void {
         parser2.addCsiHandler('m', (params, collect) => { csiCustom.push(['m', params.toArray(), collect]); return true; });
         parser2.addCsiHandler('m', (params, collect) => { csiCustom2.push(['m', params.toArray(), collect]); return true; });
         parse(parser2, INPUT);
-        chai.expect(csi).eql([], 'Should not fallback to original handler');
-        chai.expect(csiCustom).eql([], 'Should not fallback once');
-        chai.expect(csiCustom2).eql([['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csi, [], 'Should not fallback to original handler');
+        assert.deepEqual(csiCustom, [], 'Should not fallback once');
+        assert.deepEqual(csiCustom2, [['m', [1, 31], ''], ['m', [0], '']]);
       });
       it('Execution order should go from latest handler down to the original', () => {
         const order: number[] = [];
@@ -1218,7 +1218,7 @@ describe('EscapeSequenceParser', function (): void {
         parser2.addCsiHandler('m', () => { order.push(2); return false; });
         parser2.addCsiHandler('m', () => { order.push(3); return false; });
         parse(parser2, '\x1b[0m');
-        chai.expect(order).eql([3, 2, 1]);
+        assert.deepEqual(order, [3, 2, 1]);
       });
       it('Dispose should work', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
@@ -1226,8 +1226,8 @@ describe('EscapeSequenceParser', function (): void {
         const customHandler = parser2.addCsiHandler('m', (params, collect) => { csiCustom.push(['m', params.toArray(), collect]); return true; });
         customHandler.dispose();
         parse(parser2, INPUT);
-        chai.expect(csi).eql([['m', [1, 31], ''], ['m', [0], '']]);
-        chai.expect(csiCustom).eql([], 'Should not use custom handler as it was disposed');
+        assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csiCustom, [], 'Should not use custom handler as it was disposed');
       });
       it('Should not corrupt the parser when dispose is called twice', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
@@ -1236,8 +1236,8 @@ describe('EscapeSequenceParser', function (): void {
         customHandler.dispose();
         customHandler.dispose();
         parse(parser2, INPUT);
-        chai.expect(csi).eql([['m', [1, 31], ''], ['m', [0], '']]);
-        chai.expect(csiCustom).eql([], 'Should not use custom handler as it was disposed');
+        assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']]);
+        assert.deepEqual(csiCustom, [], 'Should not use custom handler as it was disposed');
       });
     });
     it('EXECUTE handler', function (): void {
@@ -1248,24 +1248,24 @@ describe('EscapeSequenceParser', function (): void {
         exe.push('\r');
       });
       parse(parser2, INPUT);
-      chai.expect(exe).eql(['\r', '\n']);
+      assert.deepEqual(exe, ['\r', '\n']);
       parser2.clearExecuteHandler('\r');
       parser2.clearExecuteHandler('\r'); // should not throw
       clearAccu();
       parse(parser2, INPUT);
-      chai.expect(exe).eql(['\n']);
+      assert.deepEqual(exe, ['\n']);
     });
     it('OSC handler', function (): void {
       parser2.setOscHandler(1, function (data: string): void {
         osc.push([1, data]);
       });
       parse(parser2, INPUT);
-      chai.expect(osc).eql([[1, 'foo=bar']]);
+      assert.deepEqual(osc, [[1, 'foo=bar']]);
       parser2.clearOscHandler(1);
       parser2.clearOscHandler(1); // should not throw
       clearAccu();
       parse(parser2, INPUT);
-      chai.expect(osc).eql([]);
+      assert.deepEqual(osc, []);
     });
     describe('OSC custom handlers', () => {
       it('Prevent fallback', () => {
@@ -1273,16 +1273,16 @@ describe('EscapeSequenceParser', function (): void {
         parser2.setOscHandler(1, data => osc.push([1, data]));
         parser2.addOscHandler(1, data => { oscCustom.push([1, data]); return true; });
         parse(parser2, INPUT);
-        chai.expect(osc).eql([], 'Should not fallback to original handler');
-        chai.expect(oscCustom).eql([[1, 'foo=bar']]);
+        assert.deepEqual(osc, [], 'Should not fallback to original handler');
+        assert.deepEqual(oscCustom, [[1, 'foo=bar']]);
       });
       it('Allow fallback', () => {
         const oscCustom: [number, string][] = [];
         parser2.setOscHandler(1, data => osc.push([1, data]));
         parser2.addOscHandler(1, data => { oscCustom.push([1, data]); return false; });
         parse(parser2, INPUT);
-        chai.expect(osc).eql([[1, 'foo=bar']], 'Should fallback to original handler');
-        chai.expect(oscCustom).eql([[1, 'foo=bar']]);
+        assert.deepEqual(osc, [[1, 'foo=bar']], 'Should fallback to original handler');
+        assert.deepEqual(oscCustom, [[1, 'foo=bar']]);
       });
       it('Multiple custom handlers fallback once', () => {
         const oscCustom: [number, string][] = [];
@@ -1291,9 +1291,9 @@ describe('EscapeSequenceParser', function (): void {
         parser2.addOscHandler(1, data => { oscCustom.push([1, data]); return true; });
         parser2.addOscHandler(1, data => { oscCustom2.push([1, data]); return false; });
         parse(parser2, INPUT);
-        chai.expect(osc).eql([], 'Should not fallback to original handler');
-        chai.expect(oscCustom).eql([[1, 'foo=bar']]);
-        chai.expect(oscCustom2).eql([[1, 'foo=bar']]);
+        assert.deepEqual(osc, [], 'Should not fallback to original handler');
+        assert.deepEqual(oscCustom, [[1, 'foo=bar']]);
+        assert.deepEqual(oscCustom2, [[1, 'foo=bar']]);
       });
       it('Multiple custom handlers no fallback', () => {
         const oscCustom: [number, string][] = [];
@@ -1302,9 +1302,9 @@ describe('EscapeSequenceParser', function (): void {
         parser2.addOscHandler(1, data => { oscCustom.push([1, data]); return true; });
         parser2.addOscHandler(1, data => { oscCustom2.push([1, data]); return true; });
         parse(parser2, INPUT);
-        chai.expect(osc).eql([], 'Should not fallback to original handler');
-        chai.expect(oscCustom).eql([], 'Should not fallback once');
-        chai.expect(oscCustom2).eql([[1, 'foo=bar']]);
+        assert.deepEqual(osc, [], 'Should not fallback to original handler');
+        assert.deepEqual(oscCustom, [], 'Should not fallback once');
+        assert.deepEqual(oscCustom2, [[1, 'foo=bar']]);
       });
       it('Execution order should go from latest handler down to the original', () => {
         const order: number[] = [];
@@ -1312,7 +1312,7 @@ describe('EscapeSequenceParser', function (): void {
         parser2.addOscHandler(1, () => { order.push(2); return false; });
         parser2.addOscHandler(1, () => { order.push(3); return false; });
         parse(parser2, '\x1b]1;foo=bar\x1b\\');
-        chai.expect(order).eql([3, 2, 1]);
+        assert.deepEqual(order, [3, 2, 1]);
       });
       it('Dispose should work', () => {
         const oscCustom: [number, string][] = [];
@@ -1320,8 +1320,8 @@ describe('EscapeSequenceParser', function (): void {
         const customHandler = parser2.addOscHandler(1, data => { oscCustom.push([1, data]); return true; });
         customHandler.dispose();
         parse(parser2, INPUT);
-        chai.expect(osc).eql([[1, 'foo=bar']]);
-        chai.expect(oscCustom).eql([], 'Should not use custom handler as it was disposed');
+        assert.deepEqual(osc, [[1, 'foo=bar']]);
+        assert.deepEqual(oscCustom, [], 'Should not use custom handler as it was disposed');
       });
       it('Should not corrupt the parser when dispose is called twice', () => {
         const oscCustom: [number, string][] = [];
@@ -1330,8 +1330,8 @@ describe('EscapeSequenceParser', function (): void {
         customHandler.dispose();
         customHandler.dispose();
         parse(parser2, INPUT);
-        chai.expect(osc).eql([[1, 'foo=bar']]);
-        chai.expect(oscCustom).eql([], 'Should not use custom handler as it was disposed');
+        assert.deepEqual(osc, [[1, 'foo=bar']]);
+        assert.deepEqual(oscCustom, [], 'Should not use custom handler as it was disposed');
       });
     });
     it('DCS handler', function (): void {
@@ -1352,7 +1352,7 @@ describe('EscapeSequenceParser', function (): void {
       });
       parse(parser2, '\x1bP1;2;3+pabc');
       parse(parser2, ';de\x9c');
-      chai.expect(dcs).eql([
+      assert.deepEqual(dcs, [
         ['hook', '+', [1, 2, 3], 'p'.charCodeAt(0)],
         ['put', 'abc'], ['put', ';de'],
         ['unhook']
@@ -1362,7 +1362,7 @@ describe('EscapeSequenceParser', function (): void {
       clearAccu();
       parse(parser2, '\x1bP1;2;3+pabc');
       parse(parser2, ';de\x9c');
-      chai.expect(dcs).eql([]);
+      assert.deepEqual(dcs, []);
     });
     it('ERROR handler', function (): void {
       let errorState: IParsingState | null = null;
@@ -1371,7 +1371,7 @@ describe('EscapeSequenceParser', function (): void {
         return state;
       });
       parse(parser2, '\x1b[1;2;€;3m'); // faulty escape sequence
-      chai.expect(errorState).eql({
+      assert.deepEqual(errorState, {
         position: 6,
         code: '€'.charCodeAt(0),
         currentState: ParserState.CSI_PARAM,
@@ -1384,7 +1384,7 @@ describe('EscapeSequenceParser', function (): void {
       parser2.clearErrorHandler(); // should not throw
       errorState = null;
       parse(parser2, '\x1b[1;2;a;3m');
-      chai.expect(errorState).eql(null);
+      assert.deepEqual(errorState, null);
     });
   });
   // TODO: error conditions and error recovery (not implemented yet in parser)

--- a/src/common/parser/EscapeSequenceParser.test.ts
+++ b/src/common/parser/EscapeSequenceParser.test.ts
@@ -3,6 +3,7 @@
  * @license MIT
  */
 
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import { IDcsHandler, IParsingState, IParams, ParamsArray } from 'common/parser/Types';
 import { EscapeSequenceParser, TransitionTable, VT500_TRANSITION_TABLE } from 'common/parser/EscapeSequenceParser';
 import * as assert from 'assert';

--- a/src/common/parser/Params.test.ts
+++ b/src/common/parser/Params.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 The xterm.js authors. All rights reserved.
  * @license MIT
  */
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { Params } from 'common/parser/Params';
 import { ParamsArray } from 'common/parser/Types';
 

--- a/src/common/parser/Params.test.ts
+++ b/src/common/parser/Params.test.ts
@@ -197,13 +197,13 @@ describe('Params', () => {
     it('reject params lesser -1', () => {
       const params = new Params();
       params.addParam(-1);
-      assert.throws(() => params.addParam(-2), 'values lesser than -1 are not allowed');
+      assert.throws(() => params.addParam(-2));
     });
     it('reject subparams lesser -1', () => {
       const params = new Params();
       params.addParam(-1);
       params.addSubParam(-1);
-      assert.throws(() => params.addSubParam(-2), 'values lesser than -1 are not allowed');
+      assert.throws(() => params.addSubParam(-2));
       assert.deepEqual(params.toArray(), [-1, [-1]]);
     });
     it('clamp parsed params', () => {

--- a/src/common/parser/Params.test.ts
+++ b/src/common/parser/Params.test.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 The xterm.js authors. All rights reserved.
  * @license MIT
  */
+/// <reference path="../../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
 import { Params } from 'common/parser/Params';
 import { ParamsArray } from 'common/parser/Types';

--- a/src/public/AddonManager.test.ts
+++ b/src/public/AddonManager.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { AddonManager, ILoadedAddon } from './AddonManager';
 import { ITerminalAddon } from 'xterm';
 

--- a/test/api/CharWidth.api.ts
+++ b/test/api/CharWidth.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from 'xterm';
 
 const APP = 'http://127.0.0.1:3000/test';

--- a/test/api/InputHandler.api.ts
+++ b/test/api/InputHandler.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from 'xterm';
 
 const APP = 'http://127.0.0.1:3000/test';

--- a/test/api/Terminal.api.ts
+++ b/test/api/Terminal.api.ts
@@ -4,7 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ITerminalOptions } from 'xterm';
 
 const APP = 'http://127.0.0.1:3000/test';

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,11 +42,6 @@
   resolved "https://registry.yarnpkg.com/@types/app-root-path/-/app-root-path-1.2.4.tgz#a78b703282b32ac54de768f5512ecc3569919dc7"
   integrity sha1-p4twMoKzKsVN52j1US7MNWmRncc=
 
-"@types/assert@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.2.tgz#e9116f5abf9cbd0c86ed22e38185b71e7f44071c"
-  integrity sha512-N5I8kX4ybqvqi4A+Y8b3coatbuRKWaa+sEPm3aCFdm9oCxsDvwY/ELNV4c/56W5MdRKJ6b8AOWRFyxhi437t7A==
-
 "@types/cli-table@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/cli-table/-/cli-table-0.3.0.tgz#f1857156bf5fd115c6a2db260ba0be1f8fc5671c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   resolved "https://registry.yarnpkg.com/@types/app-root-path/-/app-root-path-1.2.4.tgz#a78b703282b32ac54de768f5512ecc3569919dc7"
   integrity sha1-p4twMoKzKsVN52j1US7MNWmRncc=
 
-"@types/chai@^3.4.34":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.5.2.tgz#c11cd2817d3a401b7ba0f5a420f35c56139b1c1e"
-  integrity sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=
+"@types/assert@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.2.tgz#e9116f5abf9cbd0c86ed22e38185b71e7f44071c"
+  integrity sha512-N5I8kX4ybqvqi4A+Y8b3coatbuRKWaa+sEPm3aCFdm9oCxsDvwY/ELNV4c/56W5MdRKJ6b8AOWRFyxhi437t7A==
 
 "@types/cli-table@^0.3.0":
   version "0.3.0"
@@ -515,11 +515,6 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
-assertion-error@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -828,15 +823,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-chai@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
-  integrity sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=
-  dependencies:
-    assertion-error "^1.0.1"
-    deep-eql "^0.1.3"
-    type-detect "^1.0.0"
 
 chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
@@ -1325,13 +1311,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
-deep-eql@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
-  integrity sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
-  dependencies:
-    type-detect "0.1.1"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -4700,16 +4679,6 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
-  integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
-
-type-detect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
-  integrity sha1-diIXzAbbJY7EiQihKY6LlRIejqI=
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Lowers test expectations by removing all expects (programmers can be punny too). Removes chai assertion library in favor of Node.JS one. Closes https://github.com/xtermjs/xterm.js/issues/2324