### PR TITLE
Make dispose idempotent

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -265,6 +265,9 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   }
 
   public dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
     super.dispose();
     if (this._windowsMode) {
       this._windowsMode.dispose();


### PR DESCRIPTION
Fixes #2351

Issue was caused because vscode calls `Terminal.dispose` multiple times now due to strict null checks, xterm.js should be more resilient.