### PR TITLE
Don't scroll terminal search result if within viewport

### DIFF
--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -343,9 +343,13 @@ export class SearchAddon implements ITerminalAddon {
       return false;
     }
     terminal.select(result.col, result.row, result.term.length);
-    let scroll = result.row - terminal.buffer.viewportY;
-    scroll = scroll - Math.floor(terminal.rows / 2);
-    terminal.scrollLines(scroll);
+    // If it is not in the viewport then we scroll else it just gets selected
+    if (result.row > (terminal.buffer.viewportY + terminal.rows) || result.row < terminal.buffer.viewportY) {
+      let scroll = result.row - terminal.buffer.viewportY;
+      scroll = scroll - Math.floor(terminal.rows / 2);
+      terminal.scrollLines(scroll);
+      console.log('scrolling');
+    }
     return true;
   }
 }

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -348,7 +348,6 @@ export class SearchAddon implements ITerminalAddon {
       let scroll = result.row - terminal.buffer.viewportY;
       scroll = scroll - Math.floor(terminal.rows / 2);
       terminal.scrollLines(scroll);
-      console.log('scrolling');
     }
     return true;
   }


### PR DESCRIPTION
This allows search to further better match the behavior of other terminals. We were constantly attempting to center the search result even if it was within the viewport which would cause weird behaviors. This prevents the scrolling behavior if the current result is within the terminal viewport. Fixes https://github.com/xtermjs/xterm.js/issues/2352 and https://github.com/microsoft/vscode/issues/78281