### PR TITLE
Support for bubbling scroll events to parent(s)

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -1037,8 +1037,9 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     // the shell for example
     this.register(addDisposableDomListener(el, 'wheel', (ev: WheelEvent) => {
       if (this.mouseEvents) return;
-      this.viewport.onWheel(ev);
-      return this.cancel(ev);
+      if (!this.viewport.onWheel(ev)) {
+        return this.cancel(ev);
+      }
     }));
 
     this.register(addDisposableDomListener(el, 'touchstart', (ev: TouchEvent) => {
@@ -1049,8 +1050,9 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     this.register(addDisposableDomListener(el, 'touchmove', (ev: TouchEvent) => {
       if (this.mouseEvents) return;
-      this.viewport.onTouchMove(ev);
-      return this.cancel(ev);
+      if (!this.viewport.onTouchMove(ev)) {
+        return this.cancel(ev);
+      }
     }));
   }
 

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -401,13 +401,13 @@ export class MockViewport implements IViewport {
   onThemeChange(colors: IColorSet): void {
     throw new Error('Method not implemented.');
   }
-  onWheel(ev: WheelEvent): void {
+  onWheel(ev: WheelEvent): boolean {
     throw new Error('Method not implemented.');
   }
   onTouchStart(ev: TouchEvent): void {
     throw new Error('Method not implemented.');
   }
-  onTouchMove(ev: TouchEvent): void {
+  onTouchMove(ev: TouchEvent): boolean {
     throw new Error('Method not implemented.');
   }
   syncScrollArea(): void { }

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -37,9 +37,9 @@ export interface IViewport extends IDisposable {
   scrollBarWidth: number;
   syncScrollArea(): void;
   getLinesScrolled(ev: WheelEvent): number;
-  onWheel(ev: WheelEvent): void;
+  onWheel(ev: WheelEvent): boolean;
   onTouchStart(ev: TouchEvent): void;
-  onTouchMove(ev: TouchEvent): void;
+  onTouchMove(ev: TouchEvent): boolean;
   onThemeChange(colors: IColorSet): void;
 }
 

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -152,12 +152,19 @@ export class Viewport extends Disposable implements IViewport {
     this._scrollLines(diff, true);
   }
 
-
-  private _bubbleScroll(amount: number): boolean {
+  /**
+   * Handles bubbling of scroll event in case the viewport has reached top or bottom
+   * @param ev The scroll event.
+   * @param amount The amount scrolled
+   */
+  private _bubbleScroll(ev: Event, amount: number): boolean {
     const scrollPosFromTop = this._viewportElement.scrollTop + this._lastRecordedViewportHeight;
     if ((amount < 0 && this._viewportElement.scrollTop !== 0) ||
     (amount > 0 &&  scrollPosFromTop < this._lastRecordedBufferHeight)) {
-        return false;
+      if (ev.cancelable) {
+        ev.preventDefault();
+      }
+      return false;
     }
     return true;
   }
@@ -174,12 +181,7 @@ export class Viewport extends Disposable implements IViewport {
       return false;
     }
     this._viewportElement.scrollTop += amount;
-    // Prevent the page from scrolling when the terminal scrolls
-    const shouldBubbleEvent = this._bubbleScroll(amount);
-    if (!shouldBubbleEvent && ev.cancelable) {
-      ev.preventDefault();
-    }
-    return shouldBubbleEvent;
+    return this._bubbleScroll(ev, amount);
   }
 
   private _getPixelsScrolled(ev: WheelEvent): number {
@@ -241,10 +243,6 @@ export class Viewport extends Disposable implements IViewport {
       return false;
     }
     this._viewportElement.scrollTop += deltaY;
-    const shouldBubbleEvent = this._bubbleScroll(deltaY);
-    if (!shouldBubbleEvent && ev.cancelable) {
-      ev.preventDefault();
-    }
-    return shouldBubbleEvent;
+    return this._bubbleScroll(ev, deltaY);
   }
 }

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -160,7 +160,7 @@ export class Viewport extends Disposable implements IViewport {
   private _bubbleScroll(ev: Event, amount: number): boolean {
     const scrollPosFromTop = this._viewportElement.scrollTop + this._lastRecordedViewportHeight;
     if ((amount < 0 && this._viewportElement.scrollTop !== 0) ||
-    (amount > 0 &&  scrollPosFromTop < this._lastRecordedBufferHeight)) {
+        (amount > 0 &&  scrollPosFromTop < this._lastRecordedBufferHeight)) {
       if (ev.cancelable) {
         ev.preventDefault();
       }


### PR DESCRIPTION
Fixes #1343 

After this PR the scroll (touchmove/wheel) should bubble in case the scroll has reached the bottom or top of the viewport.
