### PR TITLE
fix bugs in Params

### DIFF
--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -543,20 +543,16 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
           break;
         case ParserAction.PARAM:
           // inner loop: digits (0x30 - 0x39) and ; (0x3b) and : (0x3a)
-          let isSub = false;
           do {
             switch (code) {
               case 0x3b:
                 params.addParam(0);  // ZDM
-                isSub = false;
                 break;
               case 0x3a:
                 params.addSubParam(-1);
-                isSub = true;
                 break;
               default:  // 0x30 - 0x39
-                if (isSub) params.addSubParamDigit(code - 48);
-                else params.addParamDigit(code - 48);
+                params.addDigit(code - 48);
             }
           } while (++i < length && (code = data[i]) > 0x2f && code < 0x3c);
           i--;

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -212,7 +212,6 @@ export class Params implements IParams {
   /**
    * Add a single digit value to current parameter.
    * This is used by the parser to account digits on a char by char basis.
-   * Do not use this method directly, consider using `addParam` or `addSubParam` instead.
    */
   public addDigit(value: number): void {
     let length;

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -41,6 +41,7 @@ export class Params implements IParams {
   private _subParamsIdx: Uint16Array;
   private _rejectDigits: boolean;
   private _rejectSubDigits: boolean;
+  private _digitIsSub: boolean;
 
   /**
    * Create a `Params` type from JS array representation.
@@ -79,6 +80,7 @@ export class Params implements IParams {
     this._subParamsIdx = new Uint16Array(maxLength);
     this._rejectDigits = false;
     this._rejectSubDigits = false;
+    this._digitIsSub = false;
   }
 
   /**
@@ -91,6 +93,9 @@ export class Params implements IParams {
     newParams._subParams.set(this._subParams);
     newParams._subParamsLength = this._subParamsLength;
     newParams._subParamsIdx.set(this._subParamsIdx);
+    newParams._rejectDigits = this._rejectDigits;
+    newParams._rejectSubDigits = this._rejectSubDigits;
+    newParams._digitIsSub = this._digitIsSub;
     return newParams;
   }
 
@@ -121,6 +126,7 @@ export class Params implements IParams {
     this._subParamsLength = 0;
     this._rejectDigits = false;
     this._rejectSubDigits = false;
+    this._digitIsSub = false;
   }
 
   /**
@@ -131,6 +137,7 @@ export class Params implements IParams {
    * store up to 30.
    */
   public addParam(value: number): void {
+    this._digitIsSub = false;
     if (this.length >= this.maxLength) {
       this._rejectDigits = true;
       return;
@@ -150,10 +157,11 @@ export class Params implements IParams {
    * sub parameter will be ignored.
    */
   public addSubParam(value: number): void {
+    this._digitIsSub = true;
     if (!this.length) {
       return;
     }
-    if (this._subParamsLength >= this.maxSubParamsLength) {
+    if (this._rejectDigits || this._subParamsLength >= this.maxSubParamsLength) {
       this._rejectSubDigits = true;
       return;
     }
@@ -204,30 +212,19 @@ export class Params implements IParams {
   /**
    * Add a single digit value to current parameter.
    * This is used by the parser to account digits on a char by char basis.
-   * Do not use this method directly, consider using `addParam` instead.
+   * Do not use this method directly, consider using `addParam` or `addSubParam` instead.
    */
-  public addParamDigit(value: number): void {
-    if (this._rejectDigits) {
+  public addDigit(value: number): void {
+    let length;
+    if (this._rejectDigits
+      || !(length = this._digitIsSub ? this._subParamsLength : this.length)
+      || (this._digitIsSub && this._rejectSubDigits)
+    ) {
       return;
     }
-    const v = this.params[this.length - 1] * 10 + value;
-    this.params[this.length - 1] = v > MAX_VALUE ? MAX_VALUE : v;
-  }
 
-  /**
-   * Add a single digit value to current sub parameter.
-   * This is used by the parser to account digits on a char by char basis.
-   * Do not use this method directly, consider using `addSubParam` instead.
-   */
-  public addSubParamDigit(value: number): void {
-    if (!this._subParamsLength || this._rejectDigits || this._rejectSubDigits) {
-      return;
-    }
-    if (this._subParams[this._subParamsLength - 1] === -1) {
-      this._subParams[this._subParamsLength - 1] = value;
-    } else {
-      const v = this._subParams[this._subParamsLength - 1] * 10 + value;
-      this._subParams[this._subParamsLength - 1] = v > MAX_VALUE ? MAX_VALUE : v;
-    }
+    const store = this._digitIsSub ? this._subParams : this.params;
+    const cur = store[length - 1];
+    store[length - 1] = ~cur ? Math.min(cur * 10 + value, MAX_VALUE) : value;
   }
 }


### PR DESCRIPTION
Fixes #2389.

Behavior affected:
- cancel digits for params and subparams if space is exhausted (part 1 of #2389)
- save isSub state so split input goes in to the right slot (part 2 of #2389)
- correctly handle -1 as initial value in digit input (was only respected for subparams before)
- do not try to add digit if no slot was taken before (was only respected for subparams before)