### PR TITLE
fix stacking of multiple intermediates

### DIFF
--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -281,7 +281,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
     this.setEscHandler({final: '\\'}, () => {});
   }
 
-  private _identifier(id: IFunctionIdentifier, finalRange: number[] = [0x40, 0x7e]): number {
+  protected _identifier(id: IFunctionIdentifier, finalRange: number[] = [0x40, 0x7e]): number {
     let res = 0;
     if (id.prefix) {
       if (id.prefix.length > 1) {
@@ -558,6 +558,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
           i--;
           break;
         case ParserAction.COLLECT:
+          collect <<= 8;
           collect |= code;
           break;
         case ParserAction.ESC_DISPATCH:


### PR DESCRIPTION
Fixes a minor bug in the parser not collecting / stacking up multiple intermediates correctly.

Repro: Registration of these two handlers:
```typescript
// CSI ! z
const handlerA = term.addCsiHandler({intermediates: '!', final 'z'}, ...);
// CSI SP ! z
const handlerB = term.addCsiHandler({intermediates: ' !', final 'z'}, ...);
```
`handlerB` should be triggered by `\x1b[ !z`, but `handlerA` gets called instead.

This is not yet a problem as there are no known sequences with multiple intermediates. Should still be fixed since we officially support up to two intermediates.

Additionally this PR comes with extensive tests for `IFunctionIdentifier` testing allowed byte ranges and number of bytes for `prefix`, `intermediates` and `final`.