### PR TITLE
Fix web links addon support in Edge

### DIFF
--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -211,7 +211,7 @@ export class Linkifier implements ILinkifier {
    */
   private _doLinkifyRow(rowIndex: number, text: string, matcher: ILinkMatcher): void {
     // clone regex to do a global search on text
-    const rex = new RegExp(matcher.regex.source, matcher.regex.flags + 'g');
+    const rex = new RegExp(matcher.regex.source, (matcher.regex.flags || '') + 'g');
     let match;
     let stringIndex = -1;
     while ((match = rex.exec(text)) !== null) {


### PR DESCRIPTION
regex.flags isn't supported on Edge

Fixes #2417