### PR TITLE
Update unfocused cursor to match current cursor style

### DIFF
--- a/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
@@ -139,8 +139,8 @@ export class CursorRenderLayer extends BaseRenderLayer {
       this._clearCursor();
       this._ctx.save();
       this._ctx.fillStyle = this._colors.cursor.css;
-      const cursorStyle = terminal.getOption('cursorStyle')
-      if (cursorStyle && cursorStyle != 'block') {
+      const cursorStyle = terminal.getOption('cursorStyle');
+      if (cursorStyle && cursorStyle !== 'block') {
         this._cursorRenderers[cursorStyle](terminal, terminal.buffer.cursorX, viewportRelativeCursorY, this._cell);
       } else {
         this._renderBlurCursor(terminal, terminal.buffer.cursorX, viewportRelativeCursorY, this._cell);

--- a/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
@@ -139,12 +139,17 @@ export class CursorRenderLayer extends BaseRenderLayer {
       this._clearCursor();
       this._ctx.save();
       this._ctx.fillStyle = this._colors.cursor.css;
-      this._renderBlurCursor(terminal, terminal.buffer.cursorX, viewportRelativeCursorY, this._cell);
+      const cursorStyle = terminal.getOption('cursorStyle')
+      if (cursorStyle && cursorStyle != 'block') {
+        this._cursorRenderers[cursorStyle](terminal, terminal.buffer.cursorX, viewportRelativeCursorY, this._cell);
+      } else {
+        this._renderBlurCursor(terminal, terminal.buffer.cursorX, viewportRelativeCursorY, this._cell);
+      }
       this._ctx.restore();
       this._state.x = terminal.buffer.cursorX;
       this._state.y = viewportRelativeCursorY;
       this._state.isFocused = false;
-      this._state.style = terminal.getOption('cursorStyle');
+      this._state.style = cursorStyle;
       this._state.width = this._cell.getWidth();
       return;
     }

--- a/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
@@ -92,10 +92,10 @@ export class CursorRenderLayer extends BaseRenderLayer {
       if (this._cursorBlinkStateManager) {
         this._cursorBlinkStateManager.dispose();
       }
-      // Request a refresh from the terminal as management of rendering is being
-      // moved back to the terminal
-      terminal.refresh(terminal.buffer.cursorY, terminal.buffer.cursorY);
     }
+    // Request a refresh from the terminal as management of rendering is being
+    // moved back to the terminal
+    terminal.refresh(terminal.buffer.cursorY, terminal.buffer.cursorY);
   }
 
   public onCursorMove(terminal: Terminal): void {

--- a/src/renderer/CursorRenderLayer.ts
+++ b/src/renderer/CursorRenderLayer.ts
@@ -149,7 +149,7 @@ export class CursorRenderLayer extends BaseRenderLayer {
       this._ctx.save();
       this._ctx.fillStyle = this._colors.cursor.css;
       const cursorStyle = this._optionsService.options.cursorStyle;
-      if (cursorStyle && cursorStyle != 'block') {
+      if (cursorStyle && cursorStyle !== 'block') {
         this._cursorRenderers[cursorStyle](this._bufferService.buffer.x, viewportRelativeCursorY, this._cell);
       } else {
         this._renderBlurCursor(this._bufferService.buffer.x, viewportRelativeCursorY, this._cell);

--- a/src/renderer/CursorRenderLayer.ts
+++ b/src/renderer/CursorRenderLayer.ts
@@ -148,12 +148,17 @@ export class CursorRenderLayer extends BaseRenderLayer {
       this._clearCursor();
       this._ctx.save();
       this._ctx.fillStyle = this._colors.cursor.css;
-      this._renderBlurCursor(this._bufferService.buffer.x, viewportRelativeCursorY, this._cell);
+      const cursorStyle = this._optionsService.options.cursorStyle;
+      if (cursorStyle && cursorStyle != 'block') {
+        this._cursorRenderers[cursorStyle](this._bufferService.buffer.x, viewportRelativeCursorY, this._cell);
+      } else {
+        this._renderBlurCursor(this._bufferService.buffer.x, viewportRelativeCursorY, this._cell);
+      }
       this._ctx.restore();
       this._state.x = this._bufferService.buffer.x;
       this._state.y = viewportRelativeCursorY;
       this._state.isFocused = false;
-      this._state.style = this._optionsService.options.cursorStyle;
+      this._state.style = cursorStyle;
       this._state.width = this._cell.getWidth();
       return;
     }

--- a/src/renderer/CursorRenderLayer.ts
+++ b/src/renderer/CursorRenderLayer.ts
@@ -103,10 +103,10 @@ export class CursorRenderLayer extends BaseRenderLayer {
         this._cursorBlinkStateManager.dispose();
         this._cursorBlinkStateManager = null;
       }
-      // Request a refresh from the terminal as management of rendering is being
-      // moved back to the terminal
-      this._terminal.refresh(this._bufferService.buffer.y, this._bufferService.buffer.y);
     }
+    // Request a refresh from the terminal as management of rendering is being
+    // moved back to the terminal
+    this._terminal.refresh(this._bufferService.buffer.y, this._bufferService.buffer.y);
   }
 
   public onCursorMove(): void {

--- a/src/renderer/dom/DomRenderer.ts
+++ b/src/renderer/dom/DomRenderer.ts
@@ -183,7 +183,7 @@ export class DomRenderer extends Disposable implements IRenderer {
         `}`;
     // Cursor
     styles +=
-        `${this._terminalSelector} .${ROW_CONTAINER_CLASS}:not(.${FOCUS_CLASS}) .${CURSOR_CLASS} {` +
+        `${this._terminalSelector} .${ROW_CONTAINER_CLASS}:not(.${FOCUS_CLASS}) .${CURSOR_CLASS}.${CURSOR_STYLE_BLOCK_CLASS} {` +
         ` outline: 1px solid ${this._colors.cursor.css};` +
         ` outline-offset: -1px;` +
         `}` +
@@ -197,10 +197,10 @@ export class DomRenderer extends Disposable implements IRenderer {
         ` background-color: ${this._colors.cursor.css};` +
         ` color: ${this._colors.cursorAccent.css};` +
         `}` +
-        `${this._terminalSelector} .${ROW_CONTAINER_CLASS}.${FOCUS_CLASS} .${CURSOR_CLASS}.${CURSOR_STYLE_BAR_CLASS} {` +
+        `${this._terminalSelector} .${ROW_CONTAINER_CLASS} .${CURSOR_CLASS}.${CURSOR_STYLE_BAR_CLASS} {` +
         ` box-shadow: 1px 0 0 ${this._colors.cursor.css} inset;` +
         `}` +
-        `${this._terminalSelector} .${ROW_CONTAINER_CLASS}.${FOCUS_CLASS} .${CURSOR_CLASS}.${CURSOR_STYLE_UNDERLINE_CLASS} {` +
+        `${this._terminalSelector} .${ROW_CONTAINER_CLASS} .${CURSOR_CLASS}.${CURSOR_STYLE_UNDERLINE_CLASS} {` +
         ` box-shadow: 0 -1px 0 ${this._colors.cursor.css} inset;` +
         `}`;
     // Selection


### PR DESCRIPTION
Fixes #2356.

### Block cursor (unchanged)
When terminal is unfocused, it shows a outline of the block cursor.

### Underline and bar cursors
When terminal is unfocused, it shows the underline or bar cursor. It always showed the outlined block cursor prior to this change.

### Additional Change
This change revealed an unintended behaviour where if blinking is enabled and terminal is not focused, changing the cursor style did not update screen's cursor. A second change was made to force a refresh after options have changed regardless of whether blinking is enabled.

### Tests
I tested unfocusing the terminal with all three styles and all three renderers (DOM, Canvas, WebGL) and verified proper cursor behaviour.