### PR TITLE
Support link position in hover tooltip callback

### DIFF
--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -306,7 +306,7 @@ export class Linkifier implements ILinkifier {
       e => {
         this._onLinkTooltip.fire(this._createLinkHoverEvent(x1, y1, x2, y2, fg));
         if (matcher.hoverTooltipCallback) {
-          matcher.hoverTooltipCallback(e, uri);
+          matcher.hoverTooltipCallback(e, uri, { startRow: y1, startColumn: x1, endRow: y2, endColumn: x2 });
         }
       },
       () => {

--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -306,7 +306,7 @@ export class Linkifier implements ILinkifier {
       e => {
         this._onLinkTooltip.fire(this._createLinkHoverEvent(x1, y1, x2, y2, fg));
         if (matcher.hoverTooltipCallback) {
-          matcher.hoverTooltipCallback(e, uri, { startRow: y1, startColumn: x1, endRow: y2, endColumn: x2 });
+          matcher.hoverTooltipCallback(e, uri, { start: { row: y1, col: x1 }, end: { row: y2, col: x2 } });
         }
       },
       () => {

--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -306,7 +306,9 @@ export class Linkifier implements ILinkifier {
       e => {
         this._onLinkTooltip.fire(this._createLinkHoverEvent(x1, y1, x2, y2, fg));
         if (matcher.hoverTooltipCallback) {
-          matcher.hoverTooltipCallback(e, uri, { start: { row: y1, col: x1 }, end: { row: y2, col: x2 } });
+          // Note that IViewportRange use 1-based coordinates to align with escape sequences such
+          // as CUP which use 1,1 as the default for row/col
+          matcher.hoverTooltipCallback(e, uri, { start: { row: y1 + 1, col: x1 + 1 }, end: { row: y2 + 1, col: x2 } });
         }
       },
       () => {

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -43,14 +43,22 @@ export interface IViewport extends IDisposable {
   onThemeChange(colors: IColorSet): void;
 }
 
+export interface ILinkLocation {
+  startColumn: number;
+  startRow: number;
+  endColumn: number;
+  endRow: number;
+}
+
 export type LinkMatcherHandler = (event: MouseEvent, uri: string) => void;
+export type LinkMatcherHoverTooltipCallback = (event: MouseEvent, uri: string, position: ILinkLocation) => void;
 export type LinkMatcherValidationCallback = (uri: string, callback: (isValid: boolean) => void) => void;
 
 export interface ILinkMatcher {
   id: number;
   regex: RegExp;
   handler: LinkMatcherHandler;
-  hoverTooltipCallback?: LinkMatcherHandler;
+  hoverTooltipCallback?: LinkMatcherHoverTooltipCallback;
   hoverLeaveCallback?: () => void;
   matchIndex?: number;
   validationCallback?: LinkMatcherValidationCallback;
@@ -96,7 +104,7 @@ export interface ILinkMatcherOptions {
   /**
    * A callback that fires when the mouse hovers over a link.
    */
-  tooltipCallback?: LinkMatcherHandler;
+  tooltipCallback?: LinkMatcherHoverTooltipCallback;
   /**
    * A callback that fires when the mouse leaves a link that was hovered.
    */

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -43,15 +43,18 @@ export interface IViewport extends IDisposable {
   onThemeChange(colors: IColorSet): void;
 }
 
-export interface ILinkLocation {
-  startColumn: number;
-  startRow: number;
-  endColumn: number;
-  endRow: number;
+export interface IViewportRange {
+  start: IViewportCellPosition;
+  end: IViewportCellPosition;
+}
+
+export interface IViewportCellPosition {
+  col: number;
+  row: number;
 }
 
 export type LinkMatcherHandler = (event: MouseEvent, uri: string) => void;
-export type LinkMatcherHoverTooltipCallback = (event: MouseEvent, uri: string, position: ILinkLocation) => void;
+export type LinkMatcherHoverTooltipCallback = (event: MouseEvent, uri: string, position: IViewportRange) => void;
 export type LinkMatcherValidationCallback = (uri: string, callback: (isValid: boolean) => void) => void;
 
 export interface ILinkMatcher {

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -862,12 +862,12 @@ declare module 'xterm' {
    */
   interface IViewportCellPosition {
     /**
-     * The column of the cell.
+     * The column of the cell. Note that this is 1-based; the first column is column 1.
      */
     col: number;
 
     /**
-     * The row of the cell.
+     * The row of the cell. Note that this is 1-based; the first row is row 1.
      */
     row: number;
   }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -269,7 +269,7 @@ declare module 'xterm' {
     /**
      * A callback that fires when the mouse hovers over a link for a moment.
      */
-    tooltipCallback?: (event: MouseEvent, uri: string, location: ILinkLocation) => boolean | void;
+    tooltipCallback?: (event: MouseEvent, uri: string, location: IViewportRange) => boolean | void;
 
     /**
      * A callback that fires when the mouse leaves a link. Note that this can
@@ -843,28 +843,33 @@ declare module 'xterm' {
   }
 
   /**
-   * An object representing a link location within the terminal.
+   * An object representing a range within the viewport of the terminal.
    */
-  interface ILinkLocation {
+  interface IViewportRange {
     /**
-     * The start column of the link.
+     * The start cell of the range.
      */
-    startColumn: number;
+    start: IViewportCellPosition;
 
     /**
-     * The start row of the link.
+     * The end cell of the range.
      */
-    startRow: number;
+    end: IViewportCellPosition;
+  }
+
+  /**
+   * An object representing a cell within the viewport of the terminal.
+   */
+  interface IViewportCellPosition {
+    /**
+     * The column of the cell.
+     */
+    col: number;
 
     /**
-     * The end column of the link.
+     * The row of the cell.
      */
-    endColumn: number;
-
-    /**
-     * The end row of the link.
-     */
-    endRow: number;
+    row: number;
   }
 
   /**

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -858,7 +858,7 @@ declare module 'xterm' {
   }
 
   /**
-   * An object representing a cell within the viewport of the terminal.
+   * An object representing a cell position within the viewport of the terminal.
    */
   interface IViewportCellPosition {
     /**

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -269,7 +269,7 @@ declare module 'xterm' {
     /**
      * A callback that fires when the mouse hovers over a link for a moment.
      */
-    tooltipCallback?: (event: MouseEvent, uri: string) => boolean | void;
+    tooltipCallback?: (event: MouseEvent, uri: string, location: ILinkLocation) => boolean | void;
 
     /**
      * A callback that fires when the mouse leaves a link. Note that this can
@@ -838,6 +838,31 @@ declare module 'xterm' {
 
     /**
      * The end row of the selection.
+     */
+    endRow: number;
+  }
+
+  /**
+   * An object representing a link location within the terminal.
+   */
+  interface ILinkLocation {
+    /**
+     * The start column of the link.
+     */
+    startColumn: number;
+
+    /**
+     * The start row of the link.
+     */
+    startRow: number;
+
+    /**
+     * The end column of the link.
+     */
+    endColumn: number;
+
+    /**
+     * The end row of the link.
      */
     endRow: number;
   }


### PR DESCRIPTION
Added support for link position in the hover tooltip callback and tested that it works in the demo. 
I defined `ILinkLocation` in both the public API and the browser types. I know that this probably isn't correct, but I wasn't sure how to get around it. Closes #2468.