### PR TITLE
Mark element and textarea APIs as | undefined

### DIFF
--- a/addons/xterm-addon-fit/src/FitAddon.ts
+++ b/addons/xterm-addon-fit/src/FitAddon.ts
@@ -49,7 +49,7 @@ export class FitAddon implements ITerminalAddon {
       return undefined;
     }
 
-    if (!this._terminal.element.parentElement) {
+    if (!this._terminal.element || !this._terminal.element.parentElement) {
       return undefined;
     }
 

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -76,7 +76,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   /**
    * The HTMLElement that the terminal is created in, set by Terminal.open.
    */
-  private _parent: HTMLElement;
+  private _parent: HTMLElement | null;
   private _document: Document;
   private _viewportScrollArea: HTMLElement;
   private _viewportElement: HTMLElement;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -173,7 +173,7 @@ export interface ITerminal extends IPublicTerminal, IElementAccessor, IBufferAcc
 
 // Portions of the public API that are required by the internal Terminal
 export interface IPublicTerminal extends IDisposable {
-  textarea: HTMLTextAreaElement;
+  textarea: HTMLTextAreaElement | undefined;
   rows: number;
   cols: number;
   buffer: IBuffer;
@@ -226,7 +226,7 @@ export interface IBufferAccessor {
 }
 
 export interface IElementAccessor {
-  readonly element: HTMLElement;
+  readonly element: HTMLElement | undefined;
 }
 
 export interface ILinkifierAccessor {

--- a/src/public/Terminal.ts
+++ b/src/public/Terminal.ts
@@ -33,14 +33,14 @@ export class Terminal implements ITerminalApi {
   public get onRender(): IEvent<{ start: number, end: number }> { return this._core.onRender; }
   public get onResize(): IEvent<{ cols: number, rows: number }> { return this._core.onResize; }
 
-  public get element(): HTMLElement { return this._core.element; }
+  public get element(): HTMLElement | undefined { return this._core.element; }
   public get parser(): IParser {
     if (!this._parser) {
       this._parser = new ParserApi(this._core);
     }
     return this._parser;
   }
-  public get textarea(): HTMLTextAreaElement { return this._core.textarea; }
+  public get textarea(): HTMLTextAreaElement | undefined { return this._core.textarea; }
   public get rows(): number { return this._core.rows; }
   public get cols(): number { return this._core.cols; }
   public get buffer(): IBufferApi { return new BufferApiView(this._core.buffer); }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -352,12 +352,12 @@ declare module 'xterm' {
     /**
      * The element containing the terminal.
      */
-    readonly element: HTMLElement;
+    readonly element: HTMLElement | undefined;
 
     /**
      * The textarea that accepts input for the terminal.
      */
-    readonly textarea: HTMLTextAreaElement;
+    readonly textarea: HTMLTextAreaElement | undefined;
 
     /**
      * The number of rows in the terminal's viewport. Use


### PR DESCRIPTION
Didn't fix all the issues in Terminal.ts as they will be covered in layering
refactor

Fixes #2471

---

Marked breaking as updates could cause compiler errors, no functional change happened though, it's just more correct.