### PR TITLE
#2463 Add comma as a default word separator

### DIFF
--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -49,7 +49,7 @@ export const DEFAULT_OPTIONS: ITerminalOptions = Object.freeze({
   screenKeys: false,
   cancelEvents: false,
   useFlowControl: false,
-  wordSeparator: ' ()[]{}\'"'
+  wordSeparator: ' ()[]{}\',"'
 });
 
 /**


### PR DESCRIPTION
This is a simple change just to make sure when we double click a word in xterm the selection stops when it finds a comma.