### PR TITLE
Allows to run all integration tests inside devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,12 +8,19 @@ RUN apt-get update \
 # Verify git and process tools are installed
 RUN apt-get install -y git procps
 
-# Install yarn
+# Install yarn, puppeteer deps
 RUN apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get -y install --no-install-recommends yarn
+    && apt-get -y install --no-install-recommends \
+       yarn fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+       # https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322921352
+       gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+       libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+       libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+       libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+       ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
 # Clean up
 RUN apt-get autoremove -y \

--- a/addons/xterm-addon-attach/src/AttachAddon.api.ts
+++ b/addons/xterm-addon-attach/src/AttachAddon.api.ts
@@ -21,7 +21,7 @@ describe('AttachAddon', () => {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/addons/xterm-addon-search/src/SearchAddon.api.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.api.ts
@@ -21,7 +21,7 @@ describe('Search Tests', function (): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/addons/xterm-addon-web-links/src/WebLinksAddon.api.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.api.ts
@@ -20,7 +20,7 @@ describe('WebLinksAddon', () => {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/addons/xterm-addon-webgl/src/WebglRenderer.api.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.api.ts
@@ -22,7 +22,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/test/api/CharWidth.api.ts
+++ b/test/api/CharWidth.api.ts
@@ -21,7 +21,7 @@ describe('CharWidth Integration Tests', function(): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/test/api/InputHandler.api.ts
+++ b/test/api/InputHandler.api.ts
@@ -21,7 +21,7 @@ describe('InputHandler Integration Tests', function(): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/test/api/MouseTracking.api.ts
+++ b/test/api/MouseTracking.api.ts
@@ -11,8 +11,10 @@ const APP = 'http://127.0.0.1:3000/test';
 
 let browser: puppeteer.Browser;
 let page: puppeteer.Page;
-const width = 1024;
-const height = 768;
+// adjusted to work inside devcontainer
+// see https://github.com/xtermjs/xterm.js/issues/2379
+const width = 1280;
+const height = 960;
 
 // adjust terminal row/col size so we can test
 // >80 up to 223 and >255

--- a/test/api/MouseTracking.api.ts
+++ b/test/api/MouseTracking.api.ts
@@ -216,7 +216,7 @@ describe('Mouse Tracking Tests', function(): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/test/api/Parser.api.ts
+++ b/test/api/Parser.api.ts
@@ -21,7 +21,7 @@ describe('Parser Integration Tests', function(): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });

--- a/test/api/Terminal.api.ts
+++ b/test/api/Terminal.api.ts
@@ -21,7 +21,7 @@ describe('API Integration Tests', function(): void {
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
       slowMo: 80,
-      args: [`--window-size=${width},${height}`]
+      args: [`--window-size=${width},${height}`, `--no-sandbox`]
     });
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });


### PR DESCRIPTION
This fixes #2379. I ran the entire suite just fine after increasing the window size for MouseTracking api tests.