### PR TITLE
Prevent search result from being deselected if it is the only result

### DIFF
--- a/addons/xterm-addon-search/src/SearchAddon.api.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.api.ts
@@ -15,7 +15,7 @@ const width = 800;
 const height = 600;
 
 describe('Search Tests', function (): void {
-  this.timeout(200000);
+  this.timeout(20000);
 
   before(async function (): Promise<any> {
     browser = await puppeteer.launch({
@@ -97,6 +97,14 @@ describe('Search Tests', function (): void {
     assert.deepEqual(await page.evaluate(`window.term.getSelection()`), 'abc');
     await page.evaluate(`window.search.findNext('[A-Z]+', {regex: true, caseSensitive: true})`);
     assert.deepEqual(await page.evaluate(`window.term.getSelection()`), 'ABCD');
+  });
+
+  it('Search for single result twice should not unselect it', async () => {
+    await writeSync('abc def');
+    assert.deepEqual(await page.evaluate(`window.search.findNext('abc')`), true);
+    assert.deepEqual(await page.evaluate(`window.term.getSelection()`), 'abc');
+    assert.deepEqual(await page.evaluate(`window.search.findNext('abc')`), true);
+    assert.deepEqual(await page.evaluate(`window.term.getSelection()`), 'abc');
   });
 });
 

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -59,12 +59,12 @@ export class SearchAddon implements ITerminalAddon {
 
     let startCol = 0;
     let startRow = 0;
-
+    let currentSelection = null;
     if (this._terminal.hasSelection()) {
       const incremental = searchOptions ? searchOptions.incremental : false;
       // Start from the selection end if there is a selection
       // For incremental search, use existing row
-      const currentSelection = this._terminal.getSelectionPosition()!;
+      currentSelection = this._terminal.getSelectionPosition()!;
       startRow = incremental ? currentSelection.startRow : currentSelection.endRow;
       startCol = incremental ? currentSelection.startColumn : currentSelection.endColumn;
     }
@@ -97,6 +97,9 @@ export class SearchAddon implements ITerminalAddon {
       }
     }
 
+    // If there is only one result, return false.
+    if (!result && currentSelection) return false;
+
     // Set selection and scroll if a result was found
     return this._selectResult(result);
   }
@@ -123,8 +126,9 @@ export class SearchAddon implements ITerminalAddon {
     let startCol = this._terminal.cols;
     let result: ISearchResult | undefined = undefined;
     const incremental = searchOptions ? searchOptions.incremental : false;
+    let currentSelection = null;
     if (this._terminal.hasSelection()) {
-      const currentSelection = this._terminal.getSelectionPosition()!;
+      currentSelection = this._terminal.getSelectionPosition()!;
       // Start from selection start if there is a selection
       startRow = currentSelection.startRow;
       startCol = currentSelection.startColumn;
@@ -160,6 +164,9 @@ export class SearchAddon implements ITerminalAddon {
         }
       }
     }
+
+    // If there is only one result, return false.
+    if (!result && currentSelection) return false;
 
     // Set selection and scroll if a result was found
     return this._selectResult(result);

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -59,7 +59,7 @@ export class SearchAddon implements ITerminalAddon {
 
     let startCol = 0;
     let startRow = 0;
-    let currentSelection: ISelectionPosition | undefined = undefined;
+    let currentSelection: ISelectionPosition | undefined;
     if (this._terminal.hasSelection()) {
       const incremental = searchOptions ? searchOptions.incremental : false;
       // Start from the selection end if there is a selection
@@ -124,9 +124,9 @@ export class SearchAddon implements ITerminalAddon {
     const isReverseSearch = true;
     let startRow = this._terminal.buffer.baseY + this._terminal.rows;
     let startCol = this._terminal.cols;
-    let result: ISearchResult | undefined = undefined;
+    let result: ISearchResult | undefined;
     const incremental = searchOptions ? searchOptions.incremental : false;
-    let currentSelection: ISelectionPosition | undefined = undefined;
+    let currentSelection: ISelectionPosition | undefined;
     if (this._terminal.hasSelection()) {
       currentSelection = this._terminal.getSelectionPosition()!;
       // Start from selection start if there is a selection

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { Terminal, IDisposable, ITerminalAddon } from 'xterm';
+import { Terminal, IDisposable, ITerminalAddon, ISelectionPosition } from 'xterm';
 
 export interface ISearchOptions {
   regex?: boolean;
@@ -59,7 +59,7 @@ export class SearchAddon implements ITerminalAddon {
 
     let startCol = 0;
     let startRow = 0;
-    let currentSelection = null;
+    let currentSelection: ISelectionPosition | undefined = undefined;
     if (this._terminal.hasSelection()) {
       const incremental = searchOptions ? searchOptions.incremental : false;
       // Start from the selection end if there is a selection
@@ -97,8 +97,8 @@ export class SearchAddon implements ITerminalAddon {
       }
     }
 
-    // If there is only one result, return false.
-    if (!result && currentSelection) return false;
+    // If there is only one result, return true.
+    if (!result && currentSelection) return true;
 
     // Set selection and scroll if a result was found
     return this._selectResult(result);
@@ -126,7 +126,7 @@ export class SearchAddon implements ITerminalAddon {
     let startCol = this._terminal.cols;
     let result: ISearchResult | undefined = undefined;
     const incremental = searchOptions ? searchOptions.incremental : false;
-    let currentSelection = null;
+    let currentSelection: ISelectionPosition | undefined = undefined;
     if (this._terminal.hasSelection()) {
       currentSelection = this._terminal.getSelectionPosition()!;
       // Start from selection start if there is a selection
@@ -165,8 +165,8 @@ export class SearchAddon implements ITerminalAddon {
       }
     }
 
-    // If there is only one result, return false.
-    if (!result && currentSelection) return false;
+    // If there is only one result, return true.
+    if (!result && currentSelection) return true;
 
     // Set selection and scroll if a result was found
     return this._selectResult(result);


### PR DESCRIPTION
fixes #2456 

Prevents single results from being deselected after pressing enter multiple times on a successful search. I couldn't find tests for addons so I wasn't sure if some needed to be made. I will be happy to include them if they are needed.

