### PR TITLE
Expose IViewportRange in the public API

### DIFF
--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -860,7 +860,7 @@ declare module 'xterm' {
   /**
    * An object representing a range within the viewport of the terminal.
    */
-  interface IViewportRange {
+  export interface IViewportRange {
     /**
      * The start cell of the range.
      */


### PR DESCRIPTION
Needed to get IViewportRange in the link hover tooltip. 