### PR TITLE
Forbid only in mocha

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       yarn
     displayName: 'Install dependencies and build'
   - script: |
-      yarn test-unit
+      yarn test-unit --forbid-only
     displayName: 'Unit tests'
   - script: |
       yarn lint
@@ -38,7 +38,7 @@ jobs:
       yarn
     displayName: 'Install dependencies and build'
   - script: |
-      yarn test-unit
+      yarn test-unit --forbid-only
     displayName: 'Unit tests'
   - script: |
       yarn lint
@@ -56,7 +56,7 @@ jobs:
       yarn
     displayName: 'Install dependencies and build'
   - script: |
-      yarn test-unit
+      yarn test-unit --forbid-only
     displayName: 'Unit tests'
   - script: |
       yarn lint

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
   - script: |
       yarn start &
       sleep 10
-      yarn test-api --headless
+      yarn test-api --headless --forbid-only
     displayName: 'Linux Integration tests'
 
 - job: macOS_IntegrationTests
@@ -97,7 +97,7 @@ jobs:
   - script: |
       yarn start &
       sleep 10
-      yarn test-api --headless
+      yarn test-api --headless --forbid-only
     displayName: 'MacOS Integration tests'
 
 - job: Release

--- a/bin/test.js
+++ b/bin/test.js
@@ -23,7 +23,7 @@ if (process.argv.length > 2) {
   // ability to inject particular test files via
   // yarn test [testFileA testFileB ...]
   files = args.filter(e => !e.startsWith('--'));
-  if(files.length){
+  if (files.length) {
     testFiles = files;
   }
 }

--- a/bin/test.js
+++ b/bin/test.js
@@ -15,15 +15,22 @@ let testFiles = [
   './out/**/*test.js'
 ];
 
-// ability to inject particular test files via
-// yarn test [testFileA testFileB ...]
+let flagArgs = [];
+
 if (process.argv.length > 2) {
-  testFiles = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  flagArgs = args.filter(e => e.startsWith('--'));
+  // ability to inject particular test files via
+  // yarn test [testFileA testFileB ...]
+  files = args.filter(e => !e.startsWith('--'));
+  if(files.length){
+    testFiles = files;
+  }
 }
 
 const run = cp.spawnSync(
   path.resolve(__dirname, '../node_modules/.bin/mocha'),
-  testFiles,
+  [...testFiles, ...flagArgs],
   {
     cwd: path.resolve(__dirname, '..'),
     env,


### PR DESCRIPTION
I saw #2489 and was thinking, how about forbidding `.only` in Mocha for CI only? Should be way easier to catch if someone mistakenly commits it.

```
 mocha "**/*.api.js" --headless --forbid-only
C:\Users\leomo\Documents\projects\xterm.js\node_modules\yargs\yargs.js:1163
      else throw err
           ^

Error: `.only` forbidden
```

