### PR TITLE
Don't throw when rendering before atlas is set

### DIFF
--- a/addons/xterm-addon-webgl/src/GlyphRenderer.ts
+++ b/addons/xterm-addon-webgl/src/GlyphRenderer.ts
@@ -184,7 +184,7 @@ export class GlyphRenderer {
 
     let rasterizedGlyph: IRasterizedGlyph;
     if (!this._atlas) {
-      throw new Error('atlas must be set before updating cell');
+      return;
     }
     if (chars && chars.length > 1) {
       rasterizedGlyph = this._atlas.getRasterizedGlyphCombinedChar(chars, bg, fg);


### PR DESCRIPTION
This fixes a problem when loading the webgl addon before the terminal
is attached.

See microsoft/vscode#85048