### PR TITLE
Remove a large portion of InputHandler's dependency on Terminal

### DIFF
--- a/src/InputHandler.test.ts
+++ b/src/InputHandler.test.ts
@@ -7,7 +7,7 @@ import { assert, expect } from 'chai';
 import { InputHandler } from './InputHandler';
 import { MockInputHandlingTerminal, TestTerminal } from './TestUtils.test';
 import { Terminal } from './Terminal';
-import { IBufferLine } from 'common/Types';
+import { IBufferLine, IAttributeData } from 'common/Types';
 import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
 import { CellData } from 'common/buffer/CellData';
 import { Attributes } from 'common/buffer/Constants';
@@ -33,6 +33,10 @@ function getLines(term: TestTerminal, limit: number = term.rows): string[] {
   return res;
 }
 
+class TestInputHandler extends InputHandler {
+  get curAttrData(): IAttributeData { return (this as any)._curAttrData; }
+}
+
 describe('InputHandler', () => {
   describe('save and restore cursor', () => {
     const terminal = new MockInputHandlingTerminal();
@@ -40,22 +44,22 @@ describe('InputHandler', () => {
     bufferService.buffer.x = 1;
     bufferService.buffer.y = 2;
     bufferService.buffer.ybase = 0;
-    const inputHandler = new InputHandler(terminal, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
-    (inputHandler as any)._curAttrData.fg = 3;
+    const inputHandler = new TestInputHandler(terminal, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+    inputHandler.curAttrData.fg = 3;
     // Save cursor position
     inputHandler.saveCursor();
     assert.equal(bufferService.buffer.x, 1);
     assert.equal(bufferService.buffer.y, 2);
-    assert.equal((inputHandler as any)._curAttrData.fg, 3);
+    assert.equal(inputHandler.curAttrData.fg, 3);
     // Change cursor position
     bufferService.buffer.x = 10;
     bufferService.buffer.y = 20;
-    (inputHandler as any)._curAttrData.fg = 30;
+    inputHandler.curAttrData.fg = 30;
     // Restore cursor position
     inputHandler.restoreCursor();
     assert.equal(bufferService.buffer.x, 1);
     assert.equal(bufferService.buffer.y, 2);
-    assert.equal((inputHandler as any)._curAttrData.fg, 3);
+    assert.equal(inputHandler.curAttrData.fg, 3);
   });
   describe('setCursorStyle', () => {
     it('should call Terminal.setOption with correct params', () => {

--- a/src/InputHandler.test.ts
+++ b/src/InputHandler.test.ts
@@ -13,7 +13,7 @@ import { CellData } from 'common/buffer/CellData';
 import { Attributes } from 'common/buffer/Constants';
 import { AttributeData } from 'common/buffer/AttributeData';
 import { Params } from 'common/parser/Params';
-import { MockCoreService, MockBufferService, MockDirtyRowService, MockOptionsService, MockLogService, MockCoreMouseService } from 'common/TestUtils.test';
+import { MockCoreService, MockBufferService, MockDirtyRowService, MockOptionsService, MockLogService, MockCoreMouseService, MockCharsetService } from 'common/TestUtils.test';
 import { IBufferService } from 'common/services/Services';
 import { DEFAULT_OPTIONS } from 'common/services/OptionsService';
 import { clone } from 'common/Clone';
@@ -41,7 +41,7 @@ describe('InputHandler', () => {
     bufferService.buffer.x = 1;
     bufferService.buffer.y = 2;
     bufferService.buffer.ybase = 0;
-    const inputHandler = new InputHandler(terminal, bufferService, new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+    const inputHandler = new InputHandler(terminal, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
     // Save cursor position
     inputHandler.saveCursor();
     assert.equal(bufferService.buffer.x, 1);
@@ -60,7 +60,7 @@ describe('InputHandler', () => {
   describe('setCursorStyle', () => {
     it('should call Terminal.setOption with correct params', () => {
       const optionsService = new MockOptionsService();
-      const inputHandler = new InputHandler(new MockInputHandlingTerminal(), new MockBufferService(80, 30), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), optionsService, new MockCoreMouseService());
+      const inputHandler = new InputHandler(new MockInputHandlingTerminal(), new MockBufferService(80, 30), new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), optionsService, new MockCoreMouseService());
 
       inputHandler.setCursorStyle(Params.fromArray([0]));
       assert.equal(optionsService.options['cursorStyle'], 'block');
@@ -101,7 +101,7 @@ describe('InputHandler', () => {
     it('should toggle Terminal.bracketedPasteMode', () => {
       const terminal = new MockInputHandlingTerminal();
       terminal.bracketedPasteMode = false;
-      const inputHandler = new InputHandler(terminal, new MockBufferService(80, 30), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      const inputHandler = new InputHandler(terminal, new MockBufferService(80, 30), new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
       // Set bracketed paste mode
       inputHandler.setModePrivate(Params.fromArray([2004]));
       assert.equal(terminal.bracketedPasteMode, true);
@@ -120,7 +120,7 @@ describe('InputHandler', () => {
     it('insertChars', function(): void {
       const term = new Terminal();
       const bufferService = new MockBufferService(80, 30);
-      const inputHandler = new InputHandler(term, bufferService, new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      const inputHandler = new InputHandler(term, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
 
       // insert some data in first and second line
       inputHandler.parse(Array(bufferService.cols - 9).join('a'));
@@ -158,7 +158,7 @@ describe('InputHandler', () => {
     it('deleteChars', function(): void {
       const term = new Terminal();
       const bufferService = new MockBufferService(80, 30);
-      const inputHandler = new InputHandler(term, bufferService, new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      const inputHandler = new InputHandler(term, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
 
       // insert some data in first and second line
       inputHandler.parse(Array(bufferService.cols - 9).join('a'));
@@ -199,7 +199,7 @@ describe('InputHandler', () => {
     it('eraseInLine', function(): void {
       const term = new Terminal();
       const bufferService = new MockBufferService(80, 30);
-      const inputHandler = new InputHandler(term, bufferService, new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      const inputHandler = new InputHandler(term, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
 
       // fill 6 lines to test 3 different states
       inputHandler.parse(Array(bufferService.cols + 1).join('a'));
@@ -228,7 +228,7 @@ describe('InputHandler', () => {
     it('eraseInDisplay', function(): void {
       const term = new Terminal({cols: 80, rows: 7});
       const bufferService = new MockBufferService(80, 7);
-      const inputHandler = new InputHandler(term, bufferService, new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      const inputHandler = new InputHandler(term, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
 
       // fill display with a's
       for (let i = 0; i < bufferService.rows; ++i) inputHandler.parse(Array(bufferService.cols + 1).join('a'));
@@ -363,7 +363,7 @@ describe('InputHandler', () => {
   describe('print', () => {
     it('should not cause an infinite loop (regression test)', () => {
       const term = new Terminal();
-      const inputHandler = new InputHandler(term, new MockBufferService(80, 30), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      const inputHandler = new InputHandler(term, new MockBufferService(80, 30), new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
       const container = new Uint32Array(10);
       container[0] = 0x200B;
       inputHandler.print(container, 0, 1);
@@ -378,7 +378,7 @@ describe('InputHandler', () => {
     beforeEach(() => {
       term = new Terminal();
       bufferService = new MockBufferService(80, 30);
-      handler = new InputHandler(term, bufferService, new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+      handler = new InputHandler(term, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
     });
     it('should handle DECSET/DECRST 47 (alt screen buffer)', () => {
       handler.parse('\x1b[?47h\r\n\x1b[31mJUNK\x1b[?47lTEST');

--- a/src/InputHandler.test.ts
+++ b/src/InputHandler.test.ts
@@ -36,26 +36,26 @@ function getLines(term: TestTerminal, limit: number = term.rows): string[] {
 describe('InputHandler', () => {
   describe('save and restore cursor', () => {
     const terminal = new MockInputHandlingTerminal();
-    terminal.curAttrData.fg = 3;
     const bufferService = new MockBufferService(80, 30);
     bufferService.buffer.x = 1;
     bufferService.buffer.y = 2;
     bufferService.buffer.ybase = 0;
     const inputHandler = new InputHandler(terminal, bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService());
+    (inputHandler as any)._curAttrData.fg = 3;
     // Save cursor position
     inputHandler.saveCursor();
     assert.equal(bufferService.buffer.x, 1);
     assert.equal(bufferService.buffer.y, 2);
-    assert.equal(terminal.curAttrData.fg, 3);
+    assert.equal((inputHandler as any)._curAttrData.fg, 3);
     // Change cursor position
     bufferService.buffer.x = 10;
     bufferService.buffer.y = 20;
-    terminal.curAttrData.fg = 30;
+    (inputHandler as any)._curAttrData.fg = 30;
     // Restore cursor position
     inputHandler.restoreCursor();
     assert.equal(bufferService.buffer.x, 1);
     assert.equal(bufferService.buffer.y, 2);
-    assert.equal(terminal.curAttrData.fg, 3);
+    assert.equal((inputHandler as any)._curAttrData.fg, 3);
   });
   describe('setCursorStyle', () => {
     it('should call Terminal.setOption with correct params', () => {

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -135,6 +135,8 @@ export class InputHandler extends Disposable implements IInputHandler {
   public get onRequestRefreshRows(): IEvent<number, number> { return this._onRequestRefreshRows.event; }
   private _onRequestReset = new EventEmitter<void>();
   public get onRequestReset(): IEvent<void> { return this._onRequestReset.event; }
+  private _onRequestBell = new EventEmitter<void>();
+  public get onRequestBell(): IEvent<void> { return this._onRequestBell.event; }
   private _onCursorMove = new EventEmitter<void>();
   public get onCursorMove(): IEvent<void> { return this._onCursorMove.event; }
   private _onLineFeed = new EventEmitter<void>();
@@ -143,7 +145,7 @@ export class InputHandler extends Disposable implements IInputHandler {
   public get onScroll(): IEvent<number> { return this._onScroll.event; }
 
   constructor(
-    protected _terminal: IInputHandlingTerminal,
+    private _terminal: IInputHandlingTerminal,
     private readonly _bufferService: IBufferService,
     private readonly _charsetService: ICharsetService,
     private readonly _coreService: ICoreService,
@@ -543,7 +545,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * Bell (Ctrl-G).
    */
   public bell(): void {
-    this._terminal.bell();
+    this._onRequestBell.fire();
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1422,9 +1422,7 @@ export class InputHandler extends Disposable implements IInputHandler {
         case 66:
           this._logService.debug('Serial port requested application keypad.');
           this._coreService.decPrivateModes.applicationKeypad = true;
-          if (this._terminal.viewport) {
-            this._terminal.viewport.syncScrollArea();
-          }
+          this._terminal.viewport?.syncScrollArea();
           break;
         case 9: // X10 Mouse
           // no release, no motion, no wheel, no modifiers.
@@ -1469,9 +1467,7 @@ export class InputHandler extends Disposable implements IInputHandler {
         case 1047: // alt screen buffer
           this._bufferService.buffers.activateAltBuffer(this._terminal.eraseAttrData());
           this._onRequestRefreshRows.fire(0, this._bufferService.rows - 1);
-          if (this._terminal.viewport) {
-            this._terminal.viewport.syncScrollArea();
-          }
+          this._terminal.viewport?.syncScrollArea();
           this._terminal.showCursor();
           break;
         case 2004: // bracketed paste mode (https://cirw.in/blog/bracketed-paste)
@@ -1605,9 +1601,7 @@ export class InputHandler extends Disposable implements IInputHandler {
         case 66:
           this._logService.debug('Switching back to normal keypad.');
           this._coreService.decPrivateModes.applicationKeypad = false;
-          if (this._terminal.viewport) {
-            this._terminal.viewport.syncScrollArea();
-          }
+          this._terminal.viewport?.syncScrollArea();
           break;
         case 9: // X10 Mouse
         case 1000: // vt200 mouse
@@ -1643,9 +1637,7 @@ export class InputHandler extends Disposable implements IInputHandler {
             this.restoreCursor();
           }
           this._onRequestRefreshRows.fire(0, this._bufferService.rows - 1);
-          if (this._terminal.viewport) {
-            this._terminal.viewport.syncScrollArea();
-          }
+          this._terminal.viewport?.syncScrollArea();
           this._terminal.showCursor();
           break;
         case 2004: // bracketed paste mode (https://cirw.in/blog/bracketed-paste)
@@ -1965,9 +1957,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._coreService.isCursorHidden = false;
     this._terminal.insertMode = false;
     this._coreService.decPrivateModes.applicationKeypad = false; // ?
-    if (this._terminal.viewport) {
-      this._terminal.viewport.syncScrollArea();
-    }
+    this._terminal.viewport?.syncScrollArea();
     this._bufferService.buffer.scrollTop = 0;
     this._bufferService.buffer.scrollBottom = this._bufferService.rows - 1;
     this._terminal.curAttrData = DEFAULT_ATTR_DATA.clone();
@@ -2087,9 +2077,7 @@ export class InputHandler extends Disposable implements IInputHandler {
   public keypadApplicationMode(): void {
     this._logService.debug('Serial port requested application keypad.');
     this._coreService.decPrivateModes.applicationKeypad = true;
-    if (this._terminal.viewport) {
-      this._terminal.viewport.syncScrollArea();
-    }
+    this._terminal.viewport?.syncScrollArea();
   }
 
   /**
@@ -2100,9 +2088,7 @@ export class InputHandler extends Disposable implements IInputHandler {
   public keypadNumericMode(): void {
     this._logService.debug('Switching back to normal keypad.');
     this._coreService.decPrivateModes.applicationKeypad = false;
-    if (this._terminal.viewport) {
-      this._terminal.viewport.syncScrollArea();
-    }
+    this._terminal.viewport?.syncScrollArea();
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -385,7 +385,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     const charset = this._charsetService.charset;
     const screenReaderMode = this._optionsService.options.screenReaderMode;
     const cols = this._bufferService.cols;
-    const wraparoundMode = this._terminal.wraparoundMode;
+    const wraparoundMode = this._coreService.decPrivateModes.wraparound;
     const insertMode = this._terminal.insertMode;
     const curAttr = this._terminal.curAttrData;
     let bufferRow = buffer.lines.get(buffer.y + buffer.ybase);
@@ -1414,7 +1414,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._setCursor(0, 0);
           break;
         case 7:
-          this._terminal.wraparoundMode = true;
+          this._coreService.decPrivateModes.wraparound = true;
           break;
         case 12:
           // this.cursorBlink = true;
@@ -1597,7 +1597,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._setCursor(0, 0);
           break;
         case 7:
-          this._terminal.wraparoundMode = false;
+          this._coreService.decPrivateModes.wraparound = false;
           break;
         case 12:
           // this.cursorBlink = false;
@@ -1965,16 +1965,15 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._coreService.isCursorHidden = false;
     this._terminal.insertMode = false;
     this._terminal.originMode = false;
-    this._terminal.wraparoundMode = true;  // defaults: xterm - true, vt100 - false
     this._terminal.applicationKeypad = false; // ?
     if (this._terminal.viewport) {
       this._terminal.viewport.syncScrollArea();
     }
-    this._coreService.decPrivateModes.applicationCursorKeys = false;
     this._bufferService.buffer.scrollTop = 0;
     this._bufferService.buffer.scrollBottom = this._bufferService.rows - 1;
     this._terminal.curAttrData = DEFAULT_ATTR_DATA.clone();
     this._bufferService.buffer.x = this._bufferService.buffer.y = 0; // ?
+    this._coreService.reset();
     this._charsetService.reset();
   }
 

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -133,6 +133,8 @@ export class InputHandler extends Disposable implements IInputHandler {
 
   private _onRequestRefreshRows = new EventEmitter<number, number>();
   public get onRequestRefreshRows(): IEvent<number, number> { return this._onRequestRefreshRows.event; }
+  private _onRequestReset = new EventEmitter<void>();
+  public get onRequestReset(): IEvent<void> { return this._onRequestReset.event; }
   private _onCursorMove = new EventEmitter<void>();
   public get onCursorMove(): IEvent<void> { return this._onCursorMove.event; }
   private _onLineFeed = new EventEmitter<void>();
@@ -1410,7 +1412,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           // TODO: move DECCOLM into compat addon
           this._terminal.savedCols = this._bufferService.cols;
           this._terminal.resize(132, this._bufferService.rows);
-          this._terminal.reset();
+          this._onRequestReset.fire();
           break;
         case 6:
           this._coreService.decPrivateModes.origin = true;
@@ -1589,7 +1591,7 @@ export class InputHandler extends Disposable implements IInputHandler {
             this._terminal.resize(this._terminal.savedCols, this._bufferService.rows);
           }
           delete this._terminal.savedCols;
-          this._terminal.reset();
+          this._onRequestReset.fire();
           break;
         case 6:
           this._coreService.decPrivateModes.origin = false;
@@ -2193,7 +2195,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   public reset(): void {
     this._parser.reset();
-    this._terminal.reset();  // TODO: save to move from terminal?
+    this._onRequestReset.fire();
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1956,7 +1956,6 @@ export class InputHandler extends Disposable implements IInputHandler {
   public softReset(params: IParams): void {
     this._coreService.isCursorHidden = false;
     this._terminal.insertMode = false;
-    this._coreService.decPrivateModes.applicationKeypad = false; // ?
     this._terminal.viewport?.syncScrollArea();
     this._bufferService.buffer.scrollTop = 0;
     this._bufferService.buffer.scrollBottom = this._bufferService.rows - 1;

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -381,7 +381,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     let code: number;
     let chWidth: number;
     const buffer = this._bufferService.buffer;
-    const charset = this._terminal.charset;
+    const charset = this._coreService.charsetModes.charset;
     const screenReaderMode = this._optionsService.options.screenReaderMode;
     const cols = this._bufferService.cols;
     const wraparoundMode = this._terminal.wraparoundMode;
@@ -608,7 +608,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * G1 character set.
    */
   public shiftOut(): void {
-    this._terminal.setgLevel(1);
+    this._coreService.setgLevel(1);
   }
 
   /**
@@ -617,7 +617,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * character set (the default).
    */
   public shiftIn(): void {
-    this._terminal.setgLevel(0);
+    this._coreService.setgLevel(0);
   }
 
   /**
@@ -1396,10 +1396,10 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._coreService.decPrivateModes.applicationCursorKeys = true;
           break;
         case 2:
-          this._terminal.setgCharset(0, DEFAULT_CHARSET);
-          this._terminal.setgCharset(1, DEFAULT_CHARSET);
-          this._terminal.setgCharset(2, DEFAULT_CHARSET);
-          this._terminal.setgCharset(3, DEFAULT_CHARSET);
+          this._coreService.setgCharset(0, DEFAULT_CHARSET);
+          this._coreService.setgCharset(1, DEFAULT_CHARSET);
+          this._coreService.setgCharset(2, DEFAULT_CHARSET);
+          this._coreService.setgCharset(3, DEFAULT_CHARSET);
           // set VT100 mode here
           break;
         case 3: // 132 col mode
@@ -1974,9 +1974,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._bufferService.buffer.scrollBottom = this._bufferService.rows - 1;
     this._terminal.curAttrData = DEFAULT_ATTR_DATA.clone();
     this._bufferService.buffer.x = this._bufferService.buffer.y = 0; // ?
-    this._terminal.charset = null;
-    this._terminal.glevel = 0; // ??
-    this._terminal.charsets = [null]; // ??
+    this._coreService.softReset();
   }
 
   /**
@@ -2040,7 +2038,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._bufferService.buffer.savedY = this._bufferService.buffer.ybase + this._bufferService.buffer.y;
     this._bufferService.buffer.savedCurAttrData.fg = this._terminal.curAttrData.fg;
     this._bufferService.buffer.savedCurAttrData.bg = this._terminal.curAttrData.bg;
-    this._bufferService.buffer.savedCharset = this._terminal.charset;
+    this._bufferService.buffer.savedCharset = this._coreService.charsetModes.charset;
   }
 
 
@@ -2054,9 +2052,9 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._bufferService.buffer.y = Math.max(this._bufferService.buffer.savedY - this._bufferService.buffer.ybase, 0);
     this._terminal.curAttrData.fg = this._bufferService.buffer.savedCurAttrData.fg;
     this._terminal.curAttrData.bg = this._bufferService.buffer.savedCurAttrData.bg;
-    this._terminal.charset = (this as any)._savedCharset;
+    this._coreService.charsetModes.charset = (this as any)._savedCharset;
     if (this._bufferService.buffer.savedCharset) {
-      this._terminal.charset = this._bufferService.buffer.savedCharset;
+      this._coreService.charsetModes.charset = this._bufferService.buffer.savedCharset;
     }
     this._restrictCursor();
   }
@@ -2115,8 +2113,8 @@ export class InputHandler extends Disposable implements IInputHandler {
    *   therefore ESC % G does the same.
    */
   public selectDefaultCharset(): void {
-    this._terminal.setgLevel(0);
-    this._terminal.setgCharset(0, DEFAULT_CHARSET); // US (default)
+    this._coreService.setgLevel(0);
+    this._coreService.setgCharset(0, DEFAULT_CHARSET); // US (default)
   }
 
   /**
@@ -2143,7 +2141,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     if (collectAndFlag[0] === '/') {
       return;  // TODO: Is this supported?
     }
-    this._terminal.setgCharset(GLEVEL[collectAndFlag[0]], CHARSETS[collectAndFlag[1]] || DEFAULT_CHARSET);
+    this._coreService.setgCharset(GLEVEL[collectAndFlag[0]], CHARSETS[collectAndFlag[1]] || DEFAULT_CHARSET);
     return;
   }
 
@@ -2222,7 +2220,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    *   you use another locking shift. (partly supported)
    */
   public setgLevel(level: number): void {
-    this._terminal.setgLevel(level);  // TODO: save to move from terminal?
+    this._coreService.setgLevel(level);
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -128,6 +128,8 @@ export class InputHandler extends Disposable implements IInputHandler {
   private _utf8Decoder: Utf8ToUtf32 = new Utf8ToUtf32();
   private _workCell: CellData = new CellData();
 
+  private _onRequestRefreshRows = new EventEmitter<number, number>();
+  public get onRequestRefreshRows(): IEvent<number, number> { return this._onRequestRefreshRows.event; }
   private _onCursorMove = new EventEmitter<void>();
   public get onCursorMove(): IEvent<void> { return this._onCursorMove.event; }
   private _onLineFeed = new EventEmitter<void>();
@@ -372,7 +374,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     }
 
     // Refresh any dirty rows accumulated as part of parsing
-    this._terminal.refresh(this._dirtyRowService.start, this._dirtyRowService.end);
+    this._onRequestRefreshRows.fire(this._dirtyRowService.start, this._dirtyRowService.end);
   }
 
   public print(data: Uint32Array, start: number, end: number): void {
@@ -1465,7 +1467,7 @@ export class InputHandler extends Disposable implements IInputHandler {
         case 47: // alt screen buffer
         case 1047: // alt screen buffer
           this._bufferService.buffers.activateAltBuffer(this._terminal.eraseAttrData());
-          this._terminal.refresh(0, this._bufferService.rows - 1);
+          this._onRequestRefreshRows.fire(0, this._bufferService.rows - 1);
           if (this._terminal.viewport) {
             this._terminal.viewport.syncScrollArea();
           }
@@ -1639,7 +1641,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           if (params.params[i] === 1049) {
             this.restoreCursor();
           }
-          this._terminal.refresh(0, this._bufferService.rows - 1);
+          this._onRequestRefreshRows.fire(0, this._bufferService.rows - 1);
           if (this._terminal.viewport) {
             this._terminal.viewport.syncScrollArea();
           }

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -1421,7 +1421,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           break;
         case 66:
           this._logService.debug('Serial port requested application keypad.');
-          this._terminal.applicationKeypad = true;
+          this._coreService.decPrivateModes.applicationKeypad = true;
           if (this._terminal.viewport) {
             this._terminal.viewport.syncScrollArea();
           }
@@ -1604,7 +1604,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           break;
         case 66:
           this._logService.debug('Switching back to normal keypad.');
-          this._terminal.applicationKeypad = false;
+          this._coreService.decPrivateModes.applicationKeypad = false;
           if (this._terminal.viewport) {
             this._terminal.viewport.syncScrollArea();
           }
@@ -1964,7 +1964,7 @@ export class InputHandler extends Disposable implements IInputHandler {
   public softReset(params: IParams): void {
     this._coreService.isCursorHidden = false;
     this._terminal.insertMode = false;
-    this._terminal.applicationKeypad = false; // ?
+    this._coreService.decPrivateModes.applicationKeypad = false; // ?
     if (this._terminal.viewport) {
       this._terminal.viewport.syncScrollArea();
     }
@@ -2086,7 +2086,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   public keypadApplicationMode(): void {
     this._logService.debug('Serial port requested application keypad.');
-    this._terminal.applicationKeypad = true;
+    this._coreService.decPrivateModes.applicationKeypad = true;
     if (this._terminal.viewport) {
       this._terminal.viewport.syncScrollArea();
     }
@@ -2099,7 +2099,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   public keypadNumericMode(): void {
     this._logService.debug('Switching back to normal keypad.');
-    this._terminal.applicationKeypad = false;
+    this._coreService.decPrivateModes.applicationKeypad = false;
     if (this._terminal.viewport) {
       this._terminal.viewport.syncScrollArea();
     }

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -306,7 +306,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._parser.setEscHandler({final: 'M'}, () => this.reverseIndex());
     this._parser.setEscHandler({final: '='}, () => this.keypadApplicationMode());
     this._parser.setEscHandler({final: '>'}, () => this.keypadNumericMode());
-    this._parser.setEscHandler({final: 'c'}, () => this.reset());
+    this._parser.setEscHandler({final: 'c'}, () => this.fullReset());
     this._parser.setEscHandler({final: 'n'}, () => this.setgLevel(2));
     this._parser.setEscHandler({final: 'o'}, () => this.setgLevel(3));
     this._parser.setEscHandler({final: '|'}, () => this.setgLevel(3));
@@ -2195,9 +2195,14 @@ export class InputHandler extends Disposable implements IInputHandler {
    *   DEC mnemonic: RIS (https://vt100.net/docs/vt510-rm/RIS.html)
    *   Reset to initial state.
    */
+  public fullReset(): void {
+    this._onRequestReset.fire();
+  }
+
   public reset(): void {
     this._parser.reset();
-    this._onRequestReset.fire();
+    this._curAttrData = DEFAULT_ATTR_DATA.clone();
+    this._eraseAttrDataInternal = DEFAULT_ATTR_DATA.clone();
   }
 
   /**

--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -626,7 +626,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   private _restrictCursor(): void {
     this._bufferService.buffer.x = Math.min(this._bufferService.cols - 1, Math.max(0, this._bufferService.buffer.x));
-    this._bufferService.buffer.y = this._terminal.originMode
+    this._bufferService.buffer.y = this._coreService.decPrivateModes.origin
       ? Math.min(this._bufferService.buffer.scrollBottom, Math.max(this._bufferService.buffer.scrollTop, this._bufferService.buffer.y))
       : Math.min(this._bufferService.rows - 1, Math.max(0, this._bufferService.buffer.y));
     this._dirtyRowService.markDirty(this._bufferService.buffer.y);
@@ -637,7 +637,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   private _setCursor(x: number, y: number): void {
     this._dirtyRowService.markDirty(this._bufferService.buffer.y);
-    if (this._terminal.originMode) {
+    if (this._coreService.decPrivateModes.origin) {
       this._bufferService.buffer.x = x;
       this._bufferService.buffer.y = this._bufferService.buffer.scrollTop + y;
     } else {
@@ -1410,7 +1410,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._terminal.reset();
           break;
         case 6:
-          this._terminal.originMode = true;
+          this._coreService.decPrivateModes.origin = true;
           this._setCursor(0, 0);
           break;
         case 7:
@@ -1593,7 +1593,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           this._terminal.reset();
           break;
         case 6:
-          this._terminal.originMode = false;
+          this._coreService.decPrivateModes.origin = false;
           this._setCursor(0, 0);
           break;
         case 7:
@@ -1964,7 +1964,6 @@ export class InputHandler extends Disposable implements IInputHandler {
   public softReset(params: IParams): void {
     this._coreService.isCursorHidden = false;
     this._terminal.insertMode = false;
-    this._terminal.originMode = false;
     this._terminal.applicationKeypad = false; // ?
     if (this._terminal.viewport) {
       this._terminal.viewport.syncScrollArea();

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -112,7 +112,7 @@ describe('Terminal', () => {
         assert.equal(typeof e, 'number');
         done();
       });
-      term.scroll();
+      term.scroll(DEFAULT_ATTR_DATA.clone());
     });
     it('should fire the onTitleChange event', (done) => {
       term.onTitleChange(e => {
@@ -397,7 +397,7 @@ describe('Terminal', () => {
           term.buffer.lines.get(0).setCell(0, CellData.fromCharData([0, 'a', 0, 'a'.charCodeAt(0)]));
           term.buffer.lines.get(INIT_ROWS - 1).setCell(0, CellData.fromCharData([0, 'b', 0, 'b'.charCodeAt(0)]));
           term.buffer.y = INIT_ROWS - 1; // Move cursor to last line
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS + 1);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'a');
           assert.equal(term.buffer.lines.get(INIT_ROWS - 1).loadCell(0, new CellData()).getChars(), 'b');
@@ -410,7 +410,7 @@ describe('Terminal', () => {
           term.buffer.lines.get(2).setCell(0, CellData.fromCharData([0, 'c', 0, 'c'.charCodeAt(0)]));
           term.buffer.y = INIT_ROWS - 1; // Move cursor to last line
           term.buffer.scrollTop = 1;
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'a');
           assert.equal(term.buffer.lines.get(1).loadCell(0, new CellData()).getChars(), 'c');
@@ -424,7 +424,7 @@ describe('Terminal', () => {
           term.buffer.lines.get(4).setCell(0, CellData.fromCharData([0, 'e', 0, 'e'.charCodeAt(0)]));
           term.buffer.y = 3;
           term.buffer.scrollBottom = 3;
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS + 1);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'a', '\'a\' should be pushed to the scrollback');
           assert.equal(term.buffer.lines.get(1).loadCell(0, new CellData()).getChars(), 'b');
@@ -443,7 +443,7 @@ describe('Terminal', () => {
           term.buffer.y = INIT_ROWS - 1; // Move cursor to last line
           term.buffer.scrollTop = 1;
           term.buffer.scrollBottom = 3;
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'a');
           assert.equal(term.buffer.lines.get(1).loadCell(0, new CellData()).getChars(), 'c', '\'b\' should be removed from the buffer');
@@ -465,7 +465,7 @@ describe('Terminal', () => {
           term.buffer.lines.get(INIT_ROWS - 1).setCell(0, CellData.fromCharData([0, 'c', 0, 'c'.charCodeAt(0)]));
           term.buffer.y = INIT_ROWS - 1; // Move cursor to last line
           assert.equal(term.buffer.lines.length, INIT_ROWS);
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS);
           // 'a' gets pushed out of buffer
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'b');
@@ -480,7 +480,7 @@ describe('Terminal', () => {
           term.buffer.lines.get(2).setCell(0, CellData.fromCharData([0, 'c', 0, 'c'.charCodeAt(0)]));
           term.buffer.y = INIT_ROWS - 1; // Move cursor to last line
           term.buffer.scrollTop = 1;
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'a');
           assert.equal(term.buffer.lines.get(1).loadCell(0, new CellData()).getChars(), 'c');
@@ -494,7 +494,7 @@ describe('Terminal', () => {
           term.buffer.lines.get(4).setCell(0, CellData.fromCharData([0, 'e', 0, 'e'.charCodeAt(0)]));
           term.buffer.y = 3;
           term.buffer.scrollBottom = 3;
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'b');
           assert.equal(term.buffer.lines.get(1).loadCell(0, new CellData()).getChars(), 'c');
@@ -512,7 +512,7 @@ describe('Terminal', () => {
           term.buffer.y = INIT_ROWS - 1; // Move cursor to last line
           term.buffer.scrollTop = 1;
           term.buffer.scrollBottom = 3;
-          term.scroll();
+          term.scroll(DEFAULT_ATTR_DATA.clone());
           assert.equal(term.buffer.lines.length, INIT_ROWS);
           assert.equal(term.buffer.lines.get(0).loadCell(0, new CellData()).getChars(), 'a');
           assert.equal(term.buffer.lines.get(1).loadCell(0, new CellData()).getChars(), 'c', '\'b\' should be removed from the buffer');

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -747,7 +747,7 @@ describe('Terminal', () => {
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.buffer.x = term.cols - 1;
-        term.wraparoundMode = true;
+
         term.writeSync('a' + high + String.fromCharCode(i));
         expect(term.buffer.lines.get(0).loadCell(term.cols - 1, cell).getChars()).eql('a');
         expect(term.buffer.lines.get(1).loadCell(0, cell).getChars()).eql(high + String.fromCharCode(i));
@@ -761,7 +761,7 @@ describe('Terminal', () => {
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.buffer.x = term.cols - 1;
-        term.wraparoundMode = false;
+        term.writeSync('\x1b[?7l'); // Disable wraparound mode
         const width = wcwidth((0xD800 - 0xD800) * 0x400 + i - 0xDC00 + 0x10000);
         if (width !== 1) {
           continue;
@@ -812,7 +812,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(1);
     });
     it('multiple combined é', () => {
-      term.wraparoundMode = true;
       term.writeSync(Array(100).join('e\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
@@ -826,7 +825,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(1);
     });
     it('multiple surrogate with combined', () => {
-      term.wraparoundMode = true;
       term.writeSync(Array(100).join('\uD800\uDC00\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
@@ -855,7 +853,6 @@ describe('Terminal', () => {
       expect(term.buffer.x).eql(3);
     });
     it('line of ￥ even', () => {
-      term.wraparoundMode = true;
       term.writeSync(Array(50).join('￥'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
@@ -875,7 +872,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(2);
     });
     it('line of ￥ odd', () => {
-      term.wraparoundMode = true;
       term.buffer.x = 1;
       term.writeSync(Array(50).join('￥'));
       for (let i = 1; i < term.cols - 1; ++i) {
@@ -900,7 +896,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(2);
     });
     it('line of ￥ with combining odd', () => {
-      term.wraparoundMode = true;
       term.buffer.x = 1;
       term.writeSync(Array(50).join('￥\u0301'));
       for (let i = 1; i < term.cols - 1; ++i) {
@@ -925,7 +920,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(2);
     });
     it('line of ￥ with combining even', () => {
-      term.wraparoundMode = true;
       term.writeSync(Array(50).join('￥\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);
@@ -945,7 +939,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(2);
     });
     it('line of surrogate fullwidth with combining odd', () => {
-      term.wraparoundMode = true;
       term.buffer.x = 1;
       term.writeSync(Array(50).join('\ud843\ude6d\u0301'));
       for (let i = 1; i < term.cols - 1; ++i) {
@@ -970,7 +963,6 @@ describe('Terminal', () => {
       expect(cell.getWidth()).eql(2);
     });
     it('line of surrogate fullwidth with combining even', () => {
-      term.wraparoundMode = true;
       term.writeSync(Array(50).join('\ud843\ude6d\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0).loadCell(i, cell);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -122,9 +122,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   // misc
   public savedCols: number;
 
-  public curAttrData: IAttributeData;
-  private _eraseAttrData: IAttributeData;
-
   public params: (string | number)[];
   public currentParam: string | number;
 
@@ -254,9 +251,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     // charset
     this._charsetService.reset();
 
-    this.curAttrData = DEFAULT_ATTR_DATA.clone();
-    this._eraseAttrData = DEFAULT_ATTR_DATA.clone();
-
     this.params = [];
     this.currentParam = 0;
 
@@ -291,15 +285,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
   public get buffers(): IBufferSet {
     return this._bufferService.buffers;
-  }
-
-  /**
-   * back_color_erase feature for xterm.
-   */
-  public eraseAttrData(): IAttributeData {
-    this._eraseAttrData.bg &= ~(Attributes.CM_MASK | 0xFFFFFF);
-    this._eraseAttrData.bg |= this.curAttrData.bg & ~0xFC000000;
-    return this._eraseAttrData;
   }
 
   /**
@@ -946,10 +931,9 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
    * Scroll the terminal down 1 row, creating a blank line.
    * @param isWrapped Whether the new line is wrapped from the previous line.
    */
-  public scroll(isWrapped: boolean = false): void {
+  public scroll(eraseAttr: IAttributeData, isWrapped: boolean = false): void {
     let newLine: IBufferLine;
     newLine = this._blankLine;
-    const eraseAttr = this.eraseAttrData();
     if (!newLine || newLine.length !== this.cols || newLine.getFg(0) !== eraseAttr.fg || newLine.getBg(0) !== eraseAttr.bg) {
       newLine = this.buffer.getBlankLine(eraseAttr, isWrapped);
       this._blankLine = newLine;

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -74,10 +74,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   public element: HTMLElement;
   public screenElement: HTMLElement;
 
-  /**
-   * The HTMLElement that the terminal is created in, set by Terminal.open.
-   */
-  private _parent: HTMLElement | null;
   private _document: Document;
   private _viewportScrollArea: HTMLElement;
   private _viewportElement: HTMLElement;
@@ -236,8 +232,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   }
 
   private _setup(): void {
-    this._parent = document ? document.body : null;
-
     this._customKeyEventHandler = null;
 
     // modes
@@ -456,9 +450,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
    * @param parent The element to create the terminal within.
    */
   public open(parent: HTMLElement): void {
-    this._parent = parent || this._parent;
-
-    if (!this._parent) {
+    if (!parent) {
       throw new Error('Terminal requires a parent element.');
     }
 
@@ -466,7 +458,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
       this._logService.warn('Terminal.open was called on an element that was not attached to the DOM');
     }
 
-    this._document = this._parent.ownerDocument;
+    this._document = parent.ownerDocument;
 
     // Create main element container
     this.element = this._document.createElement('div');
@@ -474,7 +466,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this.element.classList.add('terminal');
     this.element.classList.add('xterm');
     this.element.setAttribute('tabindex', '0');
-    this._parent.appendChild(this.element);
+    parent.appendChild(this.element);
 
     // Performance: Use a document fragment to build the terminal
     // viewport and helper elements detached from the DOM

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -255,14 +255,18 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     this._userScrolling = false;
 
-    // Register input handler and refire/handle events
-    this._inputHandler = new InputHandler(this, this._bufferService, this._charsetService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
-    this._inputHandler.onRequestBell(() => this.bell());
-    this._inputHandler.onRequestRefreshRows((start, end) => this.refresh(start, end));
-    this._inputHandler.onRequestReset(() => this.reset());
-    this._inputHandler.onCursorMove(() => this._onCursorMove.fire());
-    this._inputHandler.onLineFeed(() => this._onLineFeed.fire());
-    this.register(this._inputHandler);
+    if (this._inputHandler) {
+      this._inputHandler.reset();
+    } else {
+      // Register input handler and refire/handle events
+      this._inputHandler = new InputHandler(this, this._bufferService, this._charsetService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
+      this._inputHandler.onRequestBell(() => this.bell());
+      this._inputHandler.onRequestRefreshRows((start, end) => this.refresh(start, end));
+      this._inputHandler.onRequestReset(() => this.reset());
+      this._inputHandler.onCursorMove(() => this._onCursorMove.fire());
+      this._inputHandler.onLineFeed(() => this._onLineFeed.fire());
+      this.register(this._inputHandler);
+    }
 
     this.linkifier = this.linkifier || new Linkifier(this._bufferService, this._logService);
 
@@ -1464,7 +1468,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this.options.rows = this.rows;
     this.options.cols = this.cols;
     const customKeyEventHandler = this._customKeyEventHandler;
-    const inputHandler = this._inputHandler;
     const userScrolling = this._userScrolling;
 
     this._setup();
@@ -1475,7 +1478,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     // reattach
     this._customKeyEventHandler = customKeyEventHandler;
-    this._inputHandler = inputHandler;
     this._userScrolling = userScrolling;
 
     // do a full screen refresh

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -277,6 +277,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     // Register input handler and refire/handle events
     this._inputHandler = new InputHandler(this, this._bufferService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
+    this._inputHandler.onRequestRefreshRows((start, end) => this.refresh(start, end));
     this._inputHandler.onCursorMove(() => this._onCursorMove.fire());
     this._inputHandler.onLineFeed(() => this._onLineFeed.fire());
     this.register(this._inputHandler);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -53,7 +53,6 @@ import { CharSizeService } from 'browser/services/CharSizeService';
 import { BufferService, MINIMUM_COLS, MINIMUM_ROWS } from 'common/services/BufferService';
 import { Disposable } from 'common/Lifecycle';
 import { IBufferSet, IBuffer } from 'common/buffer/Types';
-import { Attributes } from 'common/buffer/Constants';
 import { MouseService } from 'browser/services/MouseService';
 import { IParams, IFunctionIdentifier } from 'common/parser/Types';
 import { CoreService } from 'common/services/CoreService';
@@ -259,6 +258,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     // Register input handler and refire/handle events
     this._inputHandler = new InputHandler(this, this._bufferService, this._charsetService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
     this._inputHandler.onRequestRefreshRows((start, end) => this.refresh(start, end));
+    this._inputHandler.onRequestReset(() => this.reset());
     this._inputHandler.onCursorMove(() => this._onCursorMove.fire());
     this._inputHandler.onLineFeed(() => this._onLineFeed.fire());
     this.register(this._inputHandler);

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -115,7 +115,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   public applicationKeypad: boolean;
   public originMode: boolean;
   public insertMode: boolean;
-  public wraparoundMode: boolean; // defaults: xterm - true, vt100 - false
   public bracketedPasteMode: boolean;
 
   // mouse properties
@@ -254,7 +253,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this.applicationKeypad = false;
     this.originMode = false;
     this.insertMode = false;
-    this.wraparoundMode = true; // defaults: xterm - true, vt100 - false
+    // this._coreService.decPrivateModes.wraparound = true;
     this.bracketedPasteMode = false;
 
     // charset

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -46,7 +46,7 @@ import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
 import { handleWindowsModeLineFeed } from 'common/WindowsMode';
 import { ColorManager } from 'browser/ColorManager';
 import { RenderService } from 'browser/services/RenderService';
-import { IOptionsService, IBufferService, ICoreMouseService, ICoreService, ILogService, IDirtyRowService, IInstantiationService } from 'common/services/Services';
+import { IOptionsService, IBufferService, ICoreMouseService, ICoreService, ILogService, IDirtyRowService, IInstantiationService, ICharsetService } from 'common/services/Services';
 import { OptionsService } from 'common/services/OptionsService';
 import { ICharSizeService, IRenderService, IMouseService, ISelectionService, ISoundService, ICoreBrowserService } from 'browser/services/Services';
 import { CharSizeService } from 'browser/services/CharSizeService';
@@ -64,6 +64,7 @@ import { InstantiationService } from 'common/services/InstantiationService';
 import { CoreMouseService } from 'common/services/CoreMouseService';
 import { WriteBuffer } from 'common/input/WriteBuffer';
 import { CoreBrowserService } from 'browser/services/CoreBrowserService';
+import { CharsetService } from 'common/services/CharsetService';
 
 // Let it work inside Node.js for automated testing purposes.
 const document = (typeof window !== 'undefined') ? window.document : null;
@@ -96,6 +97,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   // common services
   private _bufferService: IBufferService;
   private _coreService: ICoreService;
+  private _charsetService: ICharsetService;
   private _coreMouseService: ICoreMouseService;
   private _dirtyRowService: IDirtyRowService;
   private _instantiationService: IInstantiationService;
@@ -221,6 +223,8 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this._instantiationService.setService(ICoreMouseService, this._coreMouseService);
     this._dirtyRowService = this._instantiationService.createInstance(DirtyRowService);
     this._instantiationService.setService(IDirtyRowService, this._dirtyRowService);
+    this._charsetService = this._instantiationService.createInstance(CharsetService);
+    this._instantiationService.setService(ICharsetService, this._charsetService);
 
     this._setupOptionsListeners();
     this._setup();
@@ -254,7 +258,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this.bracketedPasteMode = false;
 
     // charset
-    this._coreService.softReset();
+    this._charsetService.reset();
 
     this.curAttrData = DEFAULT_ATTR_DATA.clone();
     this._eraseAttrData = DEFAULT_ATTR_DATA.clone();
@@ -265,7 +269,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this._userScrolling = false;
 
     // Register input handler and refire/handle events
-    this._inputHandler = new InputHandler(this, this._bufferService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
+    this._inputHandler = new InputHandler(this, this._bufferService, this._charsetService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
     this._inputHandler.onRequestRefreshRows((start, end) => this.refresh(start, end));
     this._inputHandler.onCursorMove(() => this._onCursorMove.fire());
     this._inputHandler.onLineFeed(() => this._onLineFeed.fire());

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -112,8 +112,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   private _soundService: ISoundService;
 
   // modes
-  public applicationKeypad: boolean;
-  public originMode: boolean;
   public insertMode: boolean;
   public bracketedPasteMode: boolean;
 
@@ -250,10 +248,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this._customKeyEventHandler = null;
 
     // modes
-    this.applicationKeypad = false;
-    this.originMode = false;
     this.insertMode = false;
-    // this._coreService.decPrivateModes.wraparound = true;
     this.bracketedPasteMode = false;
 
     // charset

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -247,9 +247,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this.insertMode = false;
     this.bracketedPasteMode = false;
 
-    // charset
-    this._charsetService.reset();
-
     this.params = [];
     this.currentParam = 0;
 
@@ -268,7 +265,9 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
       this.register(this._inputHandler);
     }
 
-    this.linkifier = this.linkifier || new Linkifier(this._bufferService, this._logService);
+    if (!this.linkifier) {
+      this.linkifier = new Linkifier(this._bufferService, this._logService);
+    }
 
     if (this.options.windowsMode) {
       this._enableWindowsMode();
@@ -1472,6 +1471,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     this._setup();
     this._bufferService.reset();
+    this._charsetService.reset();
     this._coreService.reset();
     this._coreMouseService.reset();
     this._selectionService?.reset();

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -121,9 +121,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   // misc
   public savedCols: number;
 
-  public params: (string | number)[];
-  public currentParam: string | number;
-
   // write buffer
   private _writeBuffer: WriteBuffer;
 
@@ -246,9 +243,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     // modes
     this.insertMode = false;
     this.bracketedPasteMode = false;
-
-    this.params = [];
-    this.currentParam = 0;
 
     this._userScrolling = false;
 

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -39,7 +39,7 @@ import { MouseZoneManager } from 'browser/MouseZoneManager';
 import { AccessibilityManager } from './AccessibilityManager';
 import { ITheme, IMarker, IDisposable, ISelectionPosition } from 'xterm';
 import { DomRenderer } from 'browser/renderer/dom/DomRenderer';
-import { IKeyboardEvent, KeyboardResultType, ICharset, IBufferLine, IAttributeData, CoreMouseEventType, CoreMouseButton, CoreMouseAction } from 'common/Types';
+import { IKeyboardEvent, KeyboardResultType, IBufferLine, IAttributeData, CoreMouseEventType, CoreMouseButton, CoreMouseAction } from 'common/Types';
 import { evaluateKeyboardEvent } from 'common/input/Keyboard';
 import { EventEmitter, IEvent } from 'common/EventEmitter';
 import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
@@ -115,13 +115,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
   public insertMode: boolean;
   public wraparoundMode: boolean; // defaults: xterm - true, vt100 - false
   public bracketedPasteMode: boolean;
-
-  // charset
-  // The current charset
-  public charset: ICharset;
-  public gcharset: number;
-  public glevel: number;
-  public charsets: ICharset[];
 
   // mouse properties
   public mouseEvents: CoreMouseEventType = CoreMouseEventType.NONE;
@@ -261,11 +254,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
     this.bracketedPasteMode = false;
 
     // charset
-    this.charset = null;
-    this.gcharset = null;
-    this.glevel = 0;
-    // TODO: Can this be just []?
-    this.charsets = [null];
+    this._coreService.softReset();
 
     this.curAttrData = DEFAULT_ATTR_DATA.clone();
     this._eraseAttrData = DEFAULT_ATTR_DATA.clone();
@@ -1305,27 +1294,6 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     // Don't invoke for arrows, pageDown, home, backspace, etc. (on non-keypress events)
     return thirdLevelKey && (!ev.keyCode || ev.keyCode > 47);
-  }
-
-  /**
-   * Set the G level of the terminal
-   * @param g
-   */
-  public setgLevel(g: number): void {
-    this.glevel = g;
-    this.charset = this.charsets[g];
-  }
-
-  /**
-   * Set the charset for the given G level of the terminal
-   * @param g
-   * @param charset
-   */
-  public setgCharset(g: number, charset: ICharset): void {
-    this.charsets[g] = charset;
-    if (this.glevel === g) {
-      this.charset = charset;
-    }
   }
 
   protected _keyUp(ev: KeyboardEvent): void {

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -257,6 +257,7 @@ export class Terminal extends Disposable implements ITerminal, IDisposable, IInp
 
     // Register input handler and refire/handle events
     this._inputHandler = new InputHandler(this, this._bufferService, this._charsetService, this._coreService, this._dirtyRowService, this._logService, this.optionsService, this._coreMouseService);
+    this._inputHandler.onRequestBell(() => this.bell());
     this._inputHandler.onRequestRefreshRows((start, end) => this.refresh(start, end));
     this._inputHandler.onRequestReset(() => this.reset());
     this._inputHandler.onCursorMove(() => this._onCursorMove.fire());

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -201,10 +201,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   options: ITerminalOptions = {};
   cols: number;
   rows: number;
-  charset: { [key: string]: string; };
-  gcharset: number;
-  glevel: number;
-  charsets: { [key: string]: string; }[];
   applicationKeypad: boolean;
   applicationCursor: boolean;
   originMode: boolean;
@@ -243,9 +239,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   nextStop(x?: number): number {
     throw new Error('Method not implemented.');
   }
-  setgLevel(g: number): void {
-    throw new Error('Method not implemented.');
-  }
   eraseAttrData(): IAttributeData {
     throw new Error('Method not implemented.');
   }
@@ -264,9 +257,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   is(term: string): boolean {
     throw new Error('Method not implemented.');
   }
-  setgCharset(g: number, charset: { [key: string]: string; }): void {
-    throw new Error('Method not implemented.');
-  }
   resize(x: number, y: number): void {
     throw new Error('Method not implemented.');
   }
@@ -277,9 +267,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
     throw new Error('Method not implemented.');
   }
   showCursor(): void {
-    throw new Error('Method not implemented.');
-  }
-  refresh(start: number, end: number): void {
     throw new Error('Method not implemented.');
   }
   matchColor(r1: number, g1: number, b1: number): number {

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -6,7 +6,7 @@
 import { IRenderer, IRenderDimensions, CharacterJoinerHandler, IRequestRefreshRowsEvent } from 'browser/renderer/Types';
 import { IInputHandlingTerminal, ICompositionHelper, ITerminal, IBrowser, ITerminalOptions } from './Types';
 import { IBuffer, IBufferStringIterator, IBufferSet } from 'common/buffer/Types';
-import { IBufferLine, ICellData, IAttributeData, ICircularList, XtermListener, ICharset, CoreMouseEventType } from 'common/Types';
+import { IBufferLine, ICellData, IAttributeData, ICircularList, XtermListener, ICharset } from 'common/Types';
 import { Buffer } from 'common/buffer/Buffer';
 import * as Browser from 'common/Platform';
 import { IDisposable, IMarker, IEvent, ISelectionPosition } from 'xterm';
@@ -198,55 +198,14 @@ export class MockTerminal implements ITerminal {
 export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   onA11yCharEmitter: EventEmitter<string>;
   onA11yTabEmitter: EventEmitter<number>;
-  element: HTMLElement;
-  options: ITerminalOptions = {};
-  cols: number;
-  rows: number;
   insertMode: boolean;
   bracketedPasteMode: boolean;
   savedCols: number;
-  x10Mouse: boolean;
-  vt200Mouse: boolean;
-  normalMouse: boolean;
-  mouseEvents: CoreMouseEventType;
   sendFocus: boolean;
-  utfMouse: boolean;
-  sgrMouse: boolean;
-  urxvtMouse: boolean;
-  cursorHidden: boolean;
   buffers: IBufferSet;
   buffer: IBuffer = new MockBuffer();
   viewport: IViewport;
-  selectionService: ISelectionService;
-  focus(): void {
-    throw new Error('Method not implemented.');
-  }
-  convertEol: boolean;
-  bell(): void {
-    throw new Error('Method not implemented.');
-  }
-  updateRange(y: number): void {
-    throw new Error('Method not implemented.');
-  }
   scroll(eraseAttr: IAttributeData, isWrapped?: boolean): void {
-    throw new Error('Method not implemented.');
-  }
-  nextStop(x?: number): number {
-    throw new Error('Method not implemented.');
-  }
-  eraseAttrData(): IAttributeData {
-    throw new Error('Method not implemented.');
-  }
-  eraseRight(x: number, y: number): void {
-    throw new Error('Method not implemented.');
-  }
-  eraseLine(y: number): void {
-    throw new Error('Method not implemented.');
-  }
-  eraseLeft(x: number, y: number): void {
-    throw new Error('Method not implemented.');
-  }
-  prevStop(x?: number): number {
     throw new Error('Method not implemented.');
   }
   is(term: string): boolean {
@@ -255,34 +214,7 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   resize(x: number, y: number): void {
     throw new Error('Method not implemented.');
   }
-  log(text: string, data?: any): void {
-    throw new Error('Method not implemented.');
-  }
-  reset(): void {
-    throw new Error('Method not implemented.');
-  }
   showCursor(): void {
-    throw new Error('Method not implemented.');
-  }
-  matchColor(r1: number, g1: number, b1: number): number {
-    throw new Error('Method not implemented.');
-  }
-  error(text: string, data?: any): void {
-    throw new Error('Method not implemented.');
-  }
-  setOption(key: string, value: any): void {
-    (<any>this.options)[key] = value;
-  }
-  on(type: string, listener: XtermListener): void {
-    throw new Error('Method not implemented.');
-  }
-  off(type: string, listener: XtermListener): void {
-    throw new Error('Method not implemented.');
-  }
-  emit(type: string, data?: any): void {
-    throw new Error('Method not implemented.');
-  }
-  addDisposableListener(type: string, handler: XtermListener): IDisposable {
     throw new Error('Method not implemented.');
   }
   handler(data: string): void {

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -201,9 +201,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   options: ITerminalOptions = {};
   cols: number;
   rows: number;
-  applicationKeypad: boolean;
-  applicationCursor: boolean;
-  originMode: boolean;
   insertMode: boolean;
   bracketedPasteMode: boolean;
   curAttrData = new AttributeData();

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -205,7 +205,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   applicationCursor: boolean;
   originMode: boolean;
   insertMode: boolean;
-  wraparoundMode: boolean;
   bracketedPasteMode: boolean;
   curAttrData = new AttributeData();
   savedCols: number;

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -204,7 +204,6 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   rows: number;
   insertMode: boolean;
   bracketedPasteMode: boolean;
-  curAttrData = new AttributeData();
   savedCols: number;
   x10Mouse: boolean;
   vt200Mouse: boolean;
@@ -226,11 +225,10 @@ export class MockInputHandlingTerminal implements IInputHandlingTerminal {
   bell(): void {
     throw new Error('Method not implemented.');
   }
-
   updateRange(y: number): void {
     throw new Error('Method not implemented.');
   }
-  scroll(isWrapped?: boolean): void {
+  scroll(eraseAttr: IAttributeData, isWrapped?: boolean): void {
     throw new Error('Method not implemented.');
   }
   nextStop(x?: number): number {

--- a/src/TestUtils.test.ts
+++ b/src/TestUtils.test.ts
@@ -19,6 +19,7 @@ import { IParams, IFunctionIdentifier } from 'common/parser/Types';
 import { ISelectionService } from 'browser/services/Services';
 
 export class TestTerminal extends Terminal {
+  get curAttrData(): IAttributeData { return (this as any)._inputHandler._curAttrData; }
   keyDown(ev: any): boolean { return this._keyDown(ev); }
   keyPress(ev: any): boolean { return this._keyPress(ev); }
 }

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -28,7 +28,6 @@ export interface IInputHandlingTerminal {
   applicationKeypad: boolean;
   originMode: boolean;
   insertMode: boolean;
-  wraparoundMode: boolean;
   bracketedPasteMode: boolean;
   curAttrData: IAttributeData;
   savedCols: number;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -21,14 +21,9 @@ export type LineData = CharData[];
  * InputHandler cleanly from the ITerminal interface.
  */
 export interface IInputHandlingTerminal {
-  element: HTMLElement;
-  options: ITerminalOptions;
-  cols: number;
-  rows: number;
   insertMode: boolean;
   bracketedPasteMode: boolean;
   savedCols: number;
-  mouseEvents: CoreMouseEventType;
   sendFocus: boolean;
 
   buffers: IBufferSet;
@@ -38,7 +33,6 @@ export interface IInputHandlingTerminal {
   onA11yCharEmitter: IEventEmitter<string>;
   onA11yTabEmitter: IEventEmitter<number>;
 
-  focus(): void;
   scroll(eraseAttr: IAttributeData, isWrapped?: boolean): void;
   is(term: string): boolean;
   resize(x: number, y: number): void;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -56,7 +56,6 @@ export interface IInputHandlingTerminal {
   resize(x: number, y: number): void;
   reset(): void;
   showCursor(): void;
-  refresh(start: number, end: number): void;
   handleTitle(title: string): void;
 }
 

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -43,7 +43,6 @@ export interface IInputHandlingTerminal {
   scroll(eraseAttr: IAttributeData, isWrapped?: boolean): void;
   is(term: string): boolean;
   resize(x: number, y: number): void;
-  reset(): void;
   showCursor(): void;
   handleTitle(title: string): void;
 }

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -27,7 +27,6 @@ export interface IInputHandlingTerminal {
   rows: number;
   insertMode: boolean;
   bracketedPasteMode: boolean;
-  curAttrData: IAttributeData;
   savedCols: number;
   mouseEvents: CoreMouseEventType;
   sendFocus: boolean;
@@ -41,8 +40,7 @@ export interface IInputHandlingTerminal {
 
   bell(): void;
   focus(): void;
-  scroll(isWrapped?: boolean): void;
-  eraseAttrData(): IAttributeData;
+  scroll(eraseAttr: IAttributeData, isWrapped?: boolean): void;
   is(term: string): boolean;
   resize(x: number, y: number): void;
   reset(): void;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -25,7 +25,6 @@ export interface IInputHandlingTerminal {
   options: ITerminalOptions;
   cols: number;
   rows: number;
-  applicationKeypad: boolean;
   insertMode: boolean;
   bracketedPasteMode: boolean;
   curAttrData: IAttributeData;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -121,7 +121,7 @@ export interface IInputHandler {
   /** ESC D */ index(): void;
   /** ESC H */ tabSet(): void;
   /** ESC M */ reverseIndex(): void;
-  /** ESC c */ reset(): void;
+  /** ESC c */ fullReset(): void;
   /** ESC n
       ESC o
       ESC |

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -38,7 +38,6 @@ export interface IInputHandlingTerminal {
   onA11yCharEmitter: IEventEmitter<string>;
   onA11yTabEmitter: IEventEmitter<number>;
 
-  bell(): void;
   focus(): void;
   scroll(eraseAttr: IAttributeData, isWrapped?: boolean): void;
   is(term: string): boolean;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -26,7 +26,6 @@ export interface IInputHandlingTerminal {
   cols: number;
   rows: number;
   applicationKeypad: boolean;
-  originMode: boolean;
   insertMode: boolean;
   bracketedPasteMode: boolean;
   curAttrData: IAttributeData;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -25,10 +25,6 @@ export interface IInputHandlingTerminal {
   options: ITerminalOptions;
   cols: number;
   rows: number;
-  charset: ICharset;
-  gcharset: number;
-  glevel: number;
-  charsets: ICharset[];
   applicationKeypad: boolean;
   originMode: boolean;
   insertMode: boolean;
@@ -49,10 +45,8 @@ export interface IInputHandlingTerminal {
   bell(): void;
   focus(): void;
   scroll(isWrapped?: boolean): void;
-  setgLevel(g: number): void;
   eraseAttrData(): IAttributeData;
   is(term: string): boolean;
-  setgCharset(g: number, charset: ICharset): void;
   resize(x: number, y: number): void;
   reset(): void;
   showCursor(): void;

--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -5,28 +5,28 @@
 
 import { IDisposable } from 'common/Types';
 
-interface IListener<T> {
-  (e: T): void;
+interface IListener<T, U = void> {
+  (arg1: T, arg2: U): void;
 }
 
-export interface IEvent<T> {
-  (listener: (e: T) => any): IDisposable;
+export interface IEvent<T, U = void> {
+  (listener: (arg1: T, arg2: U) => any): IDisposable;
 }
 
-export interface IEventEmitter<T> {
-  event: IEvent<T>;
-  fire(data: T): void;
+export interface IEventEmitter<T, U = void> {
+  event: IEvent<T, U>;
+  fire(arg1: T, arg2: U): void;
   dispose(): void;
 }
 
-export class EventEmitter<T> implements IEventEmitter<T> {
-  private _listeners: IListener<T>[] = [];
-  private _event?: IEvent<T>;
+export class EventEmitter<T, U = void> implements IEventEmitter<T, U> {
+  private _listeners: IListener<T, U>[] = [];
+  private _event?: IEvent<T, U>;
   private _disposed: boolean = false;
 
-  public get event(): IEvent<T> {
+  public get event(): IEvent<T, U> {
     if (!this._event) {
-      this._event = (listener: (e: T) => any) => {
+      this._event = (listener: (arg1: T, arg2: U) => any) => {
         this._listeners.push(listener);
         const disposable = {
           dispose: () => {
@@ -46,13 +46,13 @@ export class EventEmitter<T> implements IEventEmitter<T> {
     return this._event;
   }
 
-  public fire(data: T): void {
-    const queue: IListener<T>[] = [];
+  public fire(arg1: T, arg2: U): void {
+    const queue: IListener<T, U>[] = [];
     for (let i = 0; i < this._listeners.length; i++) {
       queue.push(this._listeners[i]);
     }
     for (let i = 0; i < queue.length; i++) {
-      queue[i].call(undefined, data);
+      queue[i].call(undefined, arg1, arg2);
     }
   }
 

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -3,13 +3,13 @@
  * @license MIT
  */
 
-import { IBufferService, ICoreService, ILogService, IOptionsService, ITerminalOptions, IPartialTerminalOptions, IDirtyRowService, ICoreMouseService } from 'common/services/Services';
+import { IBufferService, ICoreService, ILogService, IOptionsService, ITerminalOptions, IPartialTerminalOptions, IDirtyRowService, ICoreMouseService, ICharsetService } from 'common/services/Services';
 import { IEvent, EventEmitter } from 'common/EventEmitter';
 import { clone } from 'common/Clone';
 import { DEFAULT_OPTIONS } from 'common/services/OptionsService';
 import { IBufferSet, IBuffer } from 'common/buffer/Types';
 import { BufferSet } from 'common/buffer/BufferSet';
-import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEventType, ICharsetModes, ICharset } from 'common/Types';
+import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEventType, ICharset } from 'common/Types';
 
 export class MockBufferService implements IBufferService {
   serviceBrand: any;
@@ -42,24 +42,26 @@ export class MockCoreMouseService implements ICoreMouseService {
   }
 }
 
+export class MockCharsetService implements ICharsetService {
+  serviceBrand: any;
+  charset: ICharset | undefined;
+  glevel: number = 0;
+  charsets: readonly ICharset[] = [];
+  reset(): void {}
+  setgLevel(g: number): void {}
+  setgCharset(g: number, charset: ICharset): void {}
+}
+
 export class MockCoreService implements ICoreService {
+  serviceBrand: any;
   isCursorInitialized: boolean = false;
   isCursorHidden: boolean = false;
   isFocused: boolean = false;
-  serviceBrand: any;
-  charsetModes: ICharsetModes = {
-    charset: undefined,
-    charsets: [],
-    glevel: 0
-  };
   decPrivateModes: IDecPrivateModes = {} as any;
   onData: IEvent<string> = new EventEmitter<string>().event;
   onUserInput: IEvent<void> = new EventEmitter<void>().event;
   onBinary: IEvent<string> = new EventEmitter<string>().event;
   reset(): void {}
-  softReset(): void {}
-  setgLevel(g: number): void {}
-  setgCharset(g: number, charset: ICharset): void {}
   triggerDataEvent(data: string, wasUserInput?: boolean): void {}
   triggerBinaryEvent(data: string): void {}
 }

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -59,6 +59,7 @@ export class MockCoreService implements ICoreService {
   isFocused: boolean = false;
   decPrivateModes: IDecPrivateModes = {
     applicationCursorKeys: false,
+    origin: false,
     wraparound: true
   };
   onData: IEvent<string> = new EventEmitter<string>().event;

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -57,7 +57,10 @@ export class MockCoreService implements ICoreService {
   isCursorInitialized: boolean = false;
   isCursorHidden: boolean = false;
   isFocused: boolean = false;
-  decPrivateModes: IDecPrivateModes = {} as any;
+  decPrivateModes: IDecPrivateModes = {
+    applicationCursorKeys: false,
+    wraparound: true
+  };
   onData: IEvent<string> = new EventEmitter<string>().event;
   onUserInput: IEvent<void> = new EventEmitter<void>().event;
   onBinary: IEvent<string> = new EventEmitter<string>().event;

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -59,6 +59,7 @@ export class MockCoreService implements ICoreService {
   isFocused: boolean = false;
   decPrivateModes: IDecPrivateModes = {
     applicationCursorKeys: false,
+    applicationKeypad: false,
     origin: false,
     wraparound: true
   };

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -9,7 +9,7 @@ import { clone } from 'common/Clone';
 import { DEFAULT_OPTIONS } from 'common/services/OptionsService';
 import { IBufferSet, IBuffer } from 'common/buffer/Types';
 import { BufferSet } from 'common/buffer/BufferSet';
-import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEventType } from 'common/Types';
+import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEventType, ICharsetModes, ICharset } from 'common/Types';
 
 export class MockBufferService implements IBufferService {
   serviceBrand: any;
@@ -47,11 +47,19 @@ export class MockCoreService implements ICoreService {
   isCursorHidden: boolean = false;
   isFocused: boolean = false;
   serviceBrand: any;
+  charsetModes: ICharsetModes = {
+    charset: undefined,
+    charsets: [],
+    glevel: 0
+  };
   decPrivateModes: IDecPrivateModes = {} as any;
   onData: IEvent<string> = new EventEmitter<string>().event;
   onUserInput: IEvent<void> = new EventEmitter<void>().event;
   onBinary: IEvent<string> = new EventEmitter<string>().event;
   reset(): void {}
+  softReset(): void {}
+  setgLevel(g: number): void {}
+  setgCharset(g: number, charset: ICharset): void {}
   triggerDataEvent(data: string, wasUserInput?: boolean): void {}
   triggerBinaryEvent(data: string): void {}
 }

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -152,6 +152,7 @@ export interface IMarker extends IDisposable {
 
 export interface IDecPrivateModes {
   applicationCursorKeys: boolean;
+  wraparound: boolean; // defaults: xterm - true, vt100 - false
 }
 
 export interface IRowRange {

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -152,6 +152,7 @@ export interface IMarker extends IDisposable {
 
 export interface IDecPrivateModes {
   applicationCursorKeys: boolean;
+  origin: boolean;
   wraparound: boolean; // defaults: xterm - true, vt100 - false
 }
 

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -62,13 +62,7 @@ export interface IKeyboardResult {
 }
 
 export interface ICharset {
-  [key: string]: string;
-}
-
-export interface ICharsetModes {
-  charset: ICharset | undefined;
-  glevel: number;
-  charsets: ICharset[];
+  [key: string]: string | undefined;
 }
 
 export type CharData = [number, string, number, number];

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -65,6 +65,12 @@ export interface ICharset {
   [key: string]: string;
 }
 
+export interface ICharsetModes {
+  charset: ICharset | undefined;
+  glevel: number;
+  charsets: ICharset[];
+}
+
 export type CharData = [number, string, number, number];
 export type IColorRGB = [number, number, number];
 

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -152,6 +152,7 @@ export interface IMarker extends IDisposable {
 
 export interface IDecPrivateModes {
   applicationCursorKeys: boolean;
+  applicationKeypad: boolean;
   origin: boolean;
   wraparound: boolean; // defaults: xterm - true, vt100 - false
 }

--- a/src/common/services/CharsetService.ts
+++ b/src/common/services/CharsetService.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { ICharsetService } from 'common/services/Services';
+import { ICharset } from 'common/Types';
+
+export class CharsetService implements ICharsetService {
+  serviceBrand: any;
+
+  public charset: ICharset | undefined;
+  public charsets: ICharset[] = [];
+  public glevel: number = 0;
+
+  public reset(): void {
+    this.charset = undefined;
+    this.charsets = [];
+    this.glevel = 0;
+  }
+
+  public setgLevel(g: number): void {
+    this.glevel = g;
+    this.charset = this.charsets[g];
+  }
+
+  public setgCharset(g: number, charset: ICharset): void {
+    this.charsets[g] = charset;
+    if (this.glevel === g) {
+      this.charset = charset;
+    }
+  }
+}

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -10,6 +10,7 @@ import { clone } from 'common/Clone';
 
 const DEFAULT_DEC_PRIVATE_MODES: IDecPrivateModes = Object.freeze({
   applicationCursorKeys: false,
+  applicationKeypad: false,
   origin: false,
   wraparound: true // defaults: xterm - true, vt100 - false
 });

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -5,7 +5,7 @@
 
 import { ICoreService, ILogService, IOptionsService, IBufferService } from 'common/services/Services';
 import { EventEmitter, IEvent } from 'common/EventEmitter';
-import { IDecPrivateModes } from 'common/Types';
+import { IDecPrivateModes, ICharset, ICharsetModes } from 'common/Types';
 import { clone } from 'common/Clone';
 
 const DEFAULT_DEC_PRIVATE_MODES: IDecPrivateModes = Object.freeze({
@@ -18,6 +18,11 @@ export class CoreService implements ICoreService {
   public isCursorInitialized: boolean = false;
   public isCursorHidden: boolean = false;
   public decPrivateModes: IDecPrivateModes;
+  public charsetModes: ICharsetModes = {
+    charset: undefined,
+    charsets: [],
+    glevel: 0
+  };
 
   private _onData = new EventEmitter<string>();
   public get onData(): IEvent<string> { return this._onData.event; }
@@ -38,6 +43,12 @@ export class CoreService implements ICoreService {
 
   public reset(): void {
     this.decPrivateModes = clone(DEFAULT_DEC_PRIVATE_MODES);
+  }
+
+  public softReset(): void {
+    this.charsetModes.charset = undefined;
+    this.charsetModes.charsets = [];
+    this.charsetModes.glevel = 0;
   }
 
   public triggerDataEvent(data: string, wasUserInput: boolean = false): void {
@@ -68,5 +79,17 @@ export class CoreService implements ICoreService {
     }
     this._logService.debug(`sending binary "${data}"`, () => data.split('').map(e => e.charCodeAt(0)));
     this._onBinary.fire(data);
+  }
+
+  public setgLevel(g: number): void {
+    this.charsetModes.glevel = g;
+    this.charsetModes.charset = this.charsetModes.charsets[g];
+  }
+
+  public setgCharset(g: number, charset: ICharset): void {
+    this.charsetModes.charsets[g] = charset;
+    if (this.charsetModes.glevel === g) {
+      this.charsetModes.charset = charset;
+    }
   }
 }

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -5,7 +5,7 @@
 
 import { ICoreService, ILogService, IOptionsService, IBufferService } from 'common/services/Services';
 import { EventEmitter, IEvent } from 'common/EventEmitter';
-import { IDecPrivateModes, ICharset, ICharsetModes } from 'common/Types';
+import { IDecPrivateModes, ICharset } from 'common/Types';
 import { clone } from 'common/Clone';
 
 const DEFAULT_DEC_PRIVATE_MODES: IDecPrivateModes = Object.freeze({
@@ -18,11 +18,6 @@ export class CoreService implements ICoreService {
   public isCursorInitialized: boolean = false;
   public isCursorHidden: boolean = false;
   public decPrivateModes: IDecPrivateModes;
-  public charsetModes: ICharsetModes = {
-    charset: undefined,
-    charsets: [],
-    glevel: 0
-  };
 
   private _onData = new EventEmitter<string>();
   public get onData(): IEvent<string> { return this._onData.event; }
@@ -43,12 +38,6 @@ export class CoreService implements ICoreService {
 
   public reset(): void {
     this.decPrivateModes = clone(DEFAULT_DEC_PRIVATE_MODES);
-  }
-
-  public softReset(): void {
-    this.charsetModes.charset = undefined;
-    this.charsetModes.charsets = [];
-    this.charsetModes.glevel = 0;
   }
 
   public triggerDataEvent(data: string, wasUserInput: boolean = false): void {
@@ -79,17 +68,5 @@ export class CoreService implements ICoreService {
     }
     this._logService.debug(`sending binary "${data}"`, () => data.split('').map(e => e.charCodeAt(0)));
     this._onBinary.fire(data);
-  }
-
-  public setgLevel(g: number): void {
-    this.charsetModes.glevel = g;
-    this.charsetModes.charset = this.charsetModes.charsets[g];
-  }
-
-  public setgCharset(g: number, charset: ICharset): void {
-    this.charsetModes.charsets[g] = charset;
-    if (this.charsetModes.glevel === g) {
-      this.charsetModes.charset = charset;
-    }
   }
 }

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -9,7 +9,8 @@ import { IDecPrivateModes, ICharset } from 'common/Types';
 import { clone } from 'common/Clone';
 
 const DEFAULT_DEC_PRIVATE_MODES: IDecPrivateModes = Object.freeze({
-  applicationCursorKeys: false
+  applicationCursorKeys: false,
+  wraparound: true // defaults: xterm - true, vt100 - false
 });
 
 export class CoreService implements ICoreService {

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -10,6 +10,7 @@ import { clone } from 'common/Clone';
 
 const DEFAULT_DEC_PRIVATE_MODES: IDecPrivateModes = Object.freeze({
   applicationCursorKeys: false,
+  origin: false,
   wraparound: true // defaults: xterm - true, vt100 - false
 });
 

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -5,7 +5,7 @@
 
 import { IEvent } from 'common/EventEmitter';
 import { IBuffer, IBufferSet } from 'common/buffer/Types';
-import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEncoding, ICoreMouseProtocol, CoreMouseEventType, ICharsetModes, ICharset } from 'common/Types';
+import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEncoding, ICoreMouseProtocol, CoreMouseEventType, ICharset } from 'common/Types';
 import { createDecorator } from 'common/services/ServiceRegistry';
 
 export const IBufferService = createDecorator<IBufferService>('BufferService');
@@ -65,8 +65,6 @@ export interface ICoreService {
   isCursorInitialized: boolean;
   isCursorHidden: boolean;
 
-  charsetModes: ICharsetModes;
-
   readonly decPrivateModes: IDecPrivateModes;
 
   readonly onData: IEvent<string>;
@@ -74,7 +72,6 @@ export interface ICoreService {
   readonly onBinary: IEvent<string>;
 
   reset(): void;
-  softReset(): void;
 
   /**
    * Triggers the onData event in the public API.
@@ -91,6 +88,17 @@ export interface ICoreService {
    * @param data The data that is being emitted.
    */
    triggerBinaryEvent(data: string): void;
+}
+
+export const ICharsetService = createDecorator<ICharsetService>('CharsetService');
+export interface ICharsetService {
+  serviceBrand: any;
+
+  charset: ICharset | undefined;
+  readonly glevel: number;
+  readonly charsets: ReadonlyArray<ICharset>;
+
+  reset(): void;
 
   /**
    * Set the G level of the terminal.

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -5,7 +5,7 @@
 
 import { IEvent } from 'common/EventEmitter';
 import { IBuffer, IBufferSet } from 'common/buffer/Types';
-import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEncoding, ICoreMouseProtocol, CoreMouseEventType } from 'common/Types';
+import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEncoding, ICoreMouseProtocol, CoreMouseEventType, ICharsetModes, ICharset } from 'common/Types';
 import { createDecorator } from 'common/services/ServiceRegistry';
 
 export const IBufferService = createDecorator<IBufferService>('BufferService');
@@ -64,6 +64,9 @@ export interface ICoreService {
    */
   isCursorInitialized: boolean;
   isCursorHidden: boolean;
+
+  charsetModes: ICharsetModes;
+
   readonly decPrivateModes: IDecPrivateModes;
 
   readonly onData: IEvent<string>;
@@ -71,6 +74,7 @@ export interface ICoreService {
   readonly onBinary: IEvent<string>;
 
   reset(): void;
+  softReset(): void;
 
   /**
    * Triggers the onData event in the public API.
@@ -87,6 +91,19 @@ export interface ICoreService {
    * @param data The data that is being emitted.
    */
    triggerBinaryEvent(data: string): void;
+
+  /**
+   * Set the G level of the terminal.
+   * @param g
+   */
+   setgLevel(g: number): void;
+
+  /**
+   * Set the charset for the given G level of the terminal.
+   * @param g
+   * @param charset
+   */
+  setgCharset(g: number, charset: ICharset): void;
 }
 
 export const IDirtyRowService = createDecorator<IDirtyRowService>('DirtyRowService');

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -336,8 +336,8 @@ declare module 'xterm' {
    * An event that can be listened to.
    * @returns an `IDisposable` to stop listening.
    */
-  export interface IEvent<T> {
-    (listener: (e: T) => any): IDisposable;
+  export interface IEvent<T, U = void> {
+    (listener: (arg1: T, arg2: U) => any): IDisposable;
   }
 
   /**
@@ -444,7 +444,7 @@ declare module 'xterm' {
      * Currently this is only used for a certain type of mouse reports that
      * happen to be not UTF-8 compatible.
      * The event value is a JS string, pass it to the underlying pty as
-     * binary data, e.g. `pty.write(Buffer.from(data, 'binary'))`. 
+     * binary data, e.g. `pty.write(Buffer.from(data, 'binary'))`.
      * @returns an `IDisposable` to stop listening.
      */
     onBinary: IEvent<string>;


### PR DESCRIPTION
Part of #1507 

Behavior changes:

- `parser.reset()` is now called when `Terminal.reset` is called (before it was only on `RIS`)
- Calling `Terminal.open(undefined|null)` (compile error in strict TS) will no longer work, previously if it was opened on an element that parent would be a fallback

EventEmitter now support 2 arguments, allowing to pass in 2 primitives (start and end for request refresh). This can be extended to support more in the future as required.