### PR TITLE
Fix serialize addon peer dependency to xterm

### DIFF
--- a/addons/xterm-addon-serialize/package.json
+++ b/addons/xterm-addon-serialize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-serialize",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "The xterm.js authors",
     "url": "https://xtermjs.org/"
@@ -18,6 +18,6 @@
     "benchmark-eval": "NODE_PATH=../../out:./out:./out-benchmark/ ../../node_modules/.bin/xterm-benchmark -r 5 -c benchmark/benchmark.json --eval out-benchmark/addons/xterm-addon-serialize/benchmark/*benchmark.js"
   },
   "peerDependencies": {
-    "xterm": "^3.14.0"
+    "xterm": "^4.0.0"
   }
 }


### PR DESCRIPTION
The serialize addon has an outdated peer dependency to `xterm@3.14.0`. I think it at least requires `xterm@4.0.0`?

@Tyriar Not sure if bumping the minor version of the addon is a good idea...