### PR TITLE
Move openTerminal() to common util file

### DIFF
--- a/addons/xterm-addon-attach/src/AttachAddon.api.ts
+++ b/addons/xterm-addon-attach/src/AttachAddon.api.ts
@@ -4,9 +4,8 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { assert } from 'chai';
-import { ITerminalOptions } from 'xterm';
 import WebSocket = require('ws');
+import { openTerminal, pollFor } from '../../../out-test/api/TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -37,7 +36,7 @@ describe('AttachAddon', () => {
 
   it('string', async function(): Promise<any> {
     this.timeout(20000);
-    await openTerminal({ rendererType: 'dom' });
+    await openTerminal(page, { rendererType: 'dom' });
     const port = 8080;
     const server = new WebSocket.Server({ port });
     server.on('connection', socket => socket.send('foo'));
@@ -48,7 +47,7 @@ describe('AttachAddon', () => {
 
   it('utf8', async function(): Promise<any> {
     this.timeout(20000);
-    await openTerminal({ rendererType: 'dom' });
+    await openTerminal(page, { rendererType: 'dom' });
     const port = 8080;
     const server = new WebSocket.Server({ port });
     const data = new Uint8Array([102, 111, 111]);
@@ -58,22 +57,3 @@ describe('AttachAddon', () => {
     server.close();
   });
 });
-
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}
-
-async function pollFor(page: puppeteer.Page, fn: string, val: any): Promise<void> {
-  const result = await page.evaluate(fn);
-  if (result !== val) {
-    return new Promise<void>(r => {
-      setTimeout(() => r(pollFor(page, fn, val)), 10);
-    });
-  }
-}

--- a/addons/xterm-addon-attach/src/tsconfig.json
+++ b/addons/xterm-addon-attach/src/tsconfig.json
@@ -10,7 +10,11 @@
     "outDir": "../out",
     "sourceMap": true,
     "removeComments": true,
-    "strict": true
+    "strict": true,
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",

--- a/addons/xterm-addon-fit/src/FitAddon.api.ts
+++ b/addons/xterm-addon-fit/src/FitAddon.api.ts
@@ -5,7 +5,7 @@
 
 import * as puppeteer from 'puppeteer';
 import { assert } from 'chai';
-import { ITerminalOptions } from 'xterm';
+import { openTerminal } from '../../../out-test/api/TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -24,7 +24,7 @@ describe('FitAddon', () => {
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });
     await page.goto(APP);
-    await openTerminal();
+    await openTerminal(page);
   });
 
   after(async () => {
@@ -105,14 +105,4 @@ async function loadFit(width: number = 800, height: number = 450): Promise<void>
 
 async function unloadFit(): Promise<void> {
   await page.evaluate(`window.fit.dispose();`);
-}
-
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
 }

--- a/addons/xterm-addon-fit/src/tsconfig.json
+++ b/addons/xterm-addon-fit/src/tsconfig.json
@@ -10,7 +10,11 @@
     "outDir": "../out",
     "sourceMap": true,
     "removeComments": true,
-    "strict": true
+    "strict": true,
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",

--- a/addons/xterm-addon-search/src/tsconfig.json
+++ b/addons/xterm-addon-search/src/tsconfig.json
@@ -10,7 +10,11 @@
     "outDir": "../out",
     "sourceMap": true,
     "removeComments": true,
-    "strict": true
+    "strict": true,
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",

--- a/addons/xterm-addon-serialize/src/tsconfig.json
+++ b/addons/xterm-addon-serialize/src/tsconfig.json
@@ -12,15 +12,23 @@
     "removeComments": true,
     "baseUrl": ".",
     "paths": {
-      "common/*": [ "../../../src/common/*" ]
+      "common/*": [
+        "../../../src/common/*"
+      ]
     },
-    "strict": true
+    "strict": true,
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",
     "../../../typings/xterm.d.ts"
   ],
   "references": [
-    { "path": "../../../src/common" }
+    {
+      "path": "../../../src/common"
+    }
   ]
 }

--- a/addons/xterm-addon-unicode11/src/Unicode11Addon.api.ts
+++ b/addons/xterm-addon-unicode11/src/Unicode11Addon.api.ts
@@ -4,8 +4,8 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { ITerminalOptions } from 'xterm';
 import { assert } from 'chai';
+import { openTerminal } from '../../../out-test/api/TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -32,7 +32,7 @@ describe('Unicode11Addon', () => {
   beforeEach(async function(): Promise<any> {
     this.timeout(20000);
     await page.goto(APP);
-    await openTerminal();
+    await openTerminal(page);
   });
 
   it('wcwidth V11 emoji test', async () => {
@@ -49,13 +49,3 @@ describe('Unicode11Addon', () => {
     assert.deepEqual(await page.evaluate(`window.term._core.unicodeService.getStringCellWidth('🤣🤣🤣🤣🤣🤣🤣🤣🤣🤣')`), 20);
   });
 });
-
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}

--- a/addons/xterm-addon-unicode11/src/tsconfig.json
+++ b/addons/xterm-addon-unicode11/src/tsconfig.json
@@ -13,14 +13,22 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "common/*": [ "../../../src/common/*" ]
+      "common/*": [
+        "../../../src/common/*"
+      ]
     },
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",
     "../../../typings/xterm.d.ts"
   ],
   "references": [
-    { "path": "../../../src/common" }
+    {
+      "path": "../../../src/common"
+    }
   ]
 }

--- a/addons/xterm-addon-web-links/src/WebLinksAddon.api.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.api.ts
@@ -5,7 +5,7 @@
 
 import * as puppeteer from 'puppeteer';
 import { assert } from 'chai';
-import { ITerminalOptions } from 'xterm';
+import { openTerminal, pollFor, writeSync } from '../../../out-test/api/TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -15,7 +15,7 @@ const width = 800;
 const height = 600;
 
 describe('WebLinksAddon', () => {
-  before(async function (): Promise<any> {
+  before(async function(): Promise<any> {
     this.timeout(10000);
     browser = await puppeteer.launch({
       headless: process.argv.indexOf('--headless') !== -1,
@@ -29,29 +29,29 @@ describe('WebLinksAddon', () => {
     await browser.close();
   });
 
-  beforeEach(async function (): Promise<any> {
+  beforeEach(async function(): Promise<any> {
     this.timeout(5000);
     await page.goto(APP);
   });
 
-  it('.com', async function (): Promise<any> {
+  it('.com', async function(): Promise<any> {
     this.timeout(20000);
     await testHostName('foo.com');
   });
 
-  it('.com.au', async function (): Promise<any> {
+  it('.com.au', async function(): Promise<any> {
     this.timeout(20000);
     await testHostName('foo.com.au');
   });
 
-  it('.io', async function (): Promise<any> {
+  it('.io', async function(): Promise<any> {
     this.timeout(20000);
     await testHostName('foo.io');
   });
 });
 
 async function testHostName(hostname: string): Promise<void> {
-  await openTerminal({ rendererType: 'dom', cols: 40 });
+  await openTerminal(page, { rendererType: 'dom', cols: 40 });
   await page.evaluate(`window.term.loadAddon(new window.WebLinksAddon())`);
   const data = `  http://${hostname}  \\r\\n` +
     `  http://${hostname}/a~b#c~d?e~f  \\r\\n` +
@@ -70,40 +70,10 @@ async function testHostName(hostname: string): Promise<void> {
   await pollForLinkAtCell(1, 7, `http://${hostname}/subpath/+/id`);
 }
 
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}
-
 async function pollForLinkAtCell(col: number, row: number, value: string): Promise<void> {
   const rowSelector = `.xterm-rows > :nth-child(${row})`;
   // Ensure the hover element exists before trying to hover it
   await pollFor(page, `!!document.querySelector('${rowSelector} > :nth-child(${col})')`, true);
   await pollFor(page, `document.querySelectorAll('${rowSelector} > span[style]').length >= ${value.length}`, true, async () => page.hover(`${rowSelector} > :nth-child(${col})`));
   assert.equal(await page.evaluate(`Array.prototype.reduce.call(document.querySelectorAll('${rowSelector} > span[style]'), (a, b) => a + b.textContent, '');`), value);
-}
-
-async function pollFor(page: puppeteer.Page, fn: string, val: any, preFn?: () => Promise<void>): Promise<void> {
-  if (preFn) {
-    await preFn();
-  }
-  const result = await page.evaluate(fn);
-  if (result !== val) {
-    return new Promise<void>(r => {
-      setTimeout(() => r(pollFor(page, fn, val, preFn)), 10);
-    });
-  }
-}
-
-async function writeSync(page: puppeteer.Page, data: string): Promise<void> {
-  await page.evaluate(`
-    window.ready = false;
-    window.term.write('${data}', () => window.ready = true);
-  `);
-  await pollFor(page, 'window.ready', true);
 }

--- a/addons/xterm-addon-web-links/src/tsconfig.json
+++ b/addons/xterm-addon-web-links/src/tsconfig.json
@@ -10,7 +10,11 @@
     "outDir": "../out",
     "sourceMap": true,
     "removeComments": true,
-    "strict": true
+    "strict": true,
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",

--- a/addons/xterm-addon-webgl/src/WebglRenderer.api.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.api.ts
@@ -7,7 +7,7 @@ import * as puppeteer from 'puppeteer';
 import { ITerminalOptions } from '../../../src/Types';
 import { ITheme } from 'xterm';
 import { assert } from 'chai';
-import deepEqual = require('deep-equal');
+import { openTerminal, pollFor, writeSync } from '../../../out-test/api/TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -42,7 +42,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         white: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[30m█\\x1b[31m█\\x1b[32m█\\x1b[33m█\\x1b[34m█\\x1b[35m█\\x1b[36m█\\x1b[37m█`);
+      await writeSync(page, `\\x1b[30m█\\x1b[31m█\\x1b[32m█\\x1b[33m█\\x1b[34m█\\x1b[35m█\\x1b[36m█\\x1b[37m█`);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -68,7 +68,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         window.term.setOption('theme', ${JSON.stringify(theme)});
         window.term.setOption('drawBoldTextInBrightColors', true);
       `);
-      await writeSync(`\\x1b[1;30m█\\x1b[1;31m█\\x1b[1;32m█\\x1b[1;33m█\\x1b[1;34m█\\x1b[1;35m█\\x1b[1;36m█\\x1b[1;37m█`);
+      await writeSync(page, `\\x1b[1;30m█\\x1b[1;31m█\\x1b[1;32m█\\x1b[1;33m█\\x1b[1;34m█\\x1b[1;35m█\\x1b[1;36m█\\x1b[1;37m█`);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -91,7 +91,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         white: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[40m \\x1b[41m \\x1b[42m \\x1b[43m \\x1b[44m \\x1b[45m \\x1b[46m \\x1b[47m `);
+      await writeSync(page, `\\x1b[40m \\x1b[41m \\x1b[42m \\x1b[43m \\x1b[44m \\x1b[45m \\x1b[46m \\x1b[47m `);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -114,7 +114,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         white: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[7;30m \\x1b[7;31m \\x1b[7;32m \\x1b[7;33m \\x1b[7;34m \\x1b[7;35m \\x1b[7;36m \\x1b[7;37m `);
+      await writeSync(page, `\\x1b[7;30m \\x1b[7;31m \\x1b[7;32m \\x1b[7;33m \\x1b[7;34m \\x1b[7;35m \\x1b[7;36m \\x1b[7;37m `);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -137,7 +137,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         white: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[7;40m█\\x1b[7;41m█\\x1b[7;42m█\\x1b[7;43m█\\x1b[7;44m█\\x1b[7;45m█\\x1b[7;46m█\\x1b[7;47m█`);
+      await writeSync(page, `\\x1b[7;40m█\\x1b[7;41m█\\x1b[7;42m█\\x1b[7;43m█\\x1b[7;44m█\\x1b[7;45m█\\x1b[7;46m█\\x1b[7;47m█`);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -160,7 +160,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         white: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[8;30m \\x1b[8;31m \\x1b[8;32m \\x1b[8;33m \\x1b[8;34m \\x1b[8;35m \\x1b[8;36m \\x1b[8;37m `);
+      await writeSync(page, `\\x1b[8;30m \\x1b[8;31m \\x1b[8;32m \\x1b[8;33m \\x1b[8;34m \\x1b[8;35m \\x1b[8;36m \\x1b[8;37m `);
       await pollFor(page, () => getCellColor(1, 1), [0, 0, 0, 255]);
       await pollFor(page, () => getCellColor(2, 1), [0, 0, 0, 255]);
       await pollFor(page, () => getCellColor(3, 1), [0, 0, 0, 255]);
@@ -183,7 +183,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         white: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[8;40m█\\x1b[8;41m█\\x1b[8;42m█\\x1b[8;43m█\\x1b[8;44m█\\x1b[8;45m█\\x1b[8;46m█\\x1b[8;47m█`);
+      await writeSync(page, `\\x1b[8;40m█\\x1b[8;41m█\\x1b[8;42m█\\x1b[8;43m█\\x1b[8;44m█\\x1b[8;45m█\\x1b[8;46m█\\x1b[8;47m█`);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -206,7 +206,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         brightWhite: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[90m█\\x1b[91m█\\x1b[92m█\\x1b[93m█\\x1b[94m█\\x1b[95m█\\x1b[96m█\\x1b[97m█`);
+      await writeSync(page, `\\x1b[90m█\\x1b[91m█\\x1b[92m█\\x1b[93m█\\x1b[94m█\\x1b[95m█\\x1b[96m█\\x1b[97m█`);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -229,7 +229,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         brightWhite: '#161718'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(`\\x1b[100m \\x1b[101m \\x1b[102m \\x1b[103m \\x1b[104m \\x1b[105m \\x1b[106m \\x1b[107m `);
+      await writeSync(page, `\\x1b[100m \\x1b[101m \\x1b[102m \\x1b[103m \\x1b[104m \\x1b[105m \\x1b[106m \\x1b[107m `);
       await pollFor(page, () => getCellColor(1, 1), [1, 2, 3, 255]);
       await pollFor(page, () => getCellColor(2, 1), [4, 5, 6, 255]);
       await pollFor(page, () => getCellColor(3, 1), [7, 8, 9, 255]);
@@ -248,7 +248,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 240 / 16; y++) {
         for (let x = 0; x < 16; x++) {
           const cssColor = COLORS_16_TO_255[y * 16 + x];
@@ -268,7 +268,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 240 / 16; y++) {
         for (let x = 0; x < 16; x++) {
           const cssColor = COLORS_16_TO_255[y * 16 + x];
@@ -288,7 +288,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 240 / 16; y++) {
         for (let x = 0; x < 16; x++) {
           const cssColor = COLORS_16_TO_255[y * 16 + x];
@@ -308,7 +308,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 240 / 16; y++) {
         for (let x = 0; x < 16; x++) {
           const cssColor = COLORS_16_TO_255[y * 16 + x];
@@ -328,7 +328,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 240 / 16; y++) {
         for (let x = 0; x < 16; x++) {
           const cssColor = COLORS_16_TO_255[y * 16 + x];
@@ -348,7 +348,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 240 / 16; y++) {
         for (let x = 0; x < 16; x++) {
           const cssColor = COLORS_16_TO_255[y * 16 + x];
@@ -369,7 +369,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -387,7 +387,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -405,7 +405,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -423,7 +423,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -441,7 +441,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -459,7 +459,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -477,7 +477,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -495,7 +495,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -513,7 +513,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -531,7 +531,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -549,7 +549,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -567,7 +567,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -585,7 +585,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -603,7 +603,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -621,7 +621,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -639,7 +639,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -657,7 +657,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -675,7 +675,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         }
         data += '\\r\\n';
       }
-      await writeSync(data);
+      await writeSync(page, data);
       for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
           const i = y * 16 + x;
@@ -713,7 +713,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         window.term.setOption('theme', ${JSON.stringify(theme)});
         window.term.setOption('minimumContrastRatio', 1);
       `);
-      await writeSync(
+      await writeSync(page,
         `\\x1b[30m█\\x1b[31m█\\x1b[32m█\\x1b[33m█\\x1b[34m█\\x1b[35m█\\x1b[36m█\\x1b[37m█\\r\\n` +
         `\\x1b[90m█\\x1b[91m█\\x1b[92m█\\x1b[93m█\\x1b[94m█\\x1b[95m█\\x1b[96m█\\x1b[97m█`
       );
@@ -781,7 +781,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         window.term.setOption('theme', ${JSON.stringify(theme)});
         window.term.setOption('minimumContrastRatio', 1);
       `);
-      await writeSync(
+      await writeSync(page,
         `\\x1b[30m█\\x1b[31m█\\x1b[32m█\\x1b[33m█\\x1b[34m█\\x1b[35m█\\x1b[36m█\\x1b[37m█\\r\\n` +
         `\\x1b[90m█\\x1b[91m█\\x1b[92m█\\x1b[93m█\\x1b[94m█\\x1b[95m█\\x1b[96m█\\x1b[97m█`
       );
@@ -837,7 +837,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
         selection: '#0000FF'
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
-      await writeSync(` █\\x1b[7m█\\x1b[0m`);
+      await writeSync(page, ` █\\x1b[7m█\\x1b[0m`);
       await pollFor(page, () => getCellColor(1, 1), [0, 255, 0, 255]);
       await pollFor(page, () => getCellColor(2, 1), [255, 0, 0, 255]);
       await pollFor(page, () => getCellColor(3, 1), [0, 255, 0, 255]);
@@ -850,7 +850,7 @@ describe('WebGL Renderer Integration Tests', function(): void {
   });
 
   describe('allowTransparency', async () => {
-    before(async () => setupBrowser({ rendererType: 'dom', allowTransparency: true}));
+    before(async () => setupBrowser({ rendererType: 'dom', allowTransparency: true }));
     after(async () => browser.close());
     beforeEach(async () => page.evaluate(`window.term.reset()`));
     it('transparent background inverse', async () => {
@@ -859,26 +859,12 @@ describe('WebGL Renderer Integration Tests', function(): void {
       };
       await page.evaluate(`window.term.setOption('theme', ${JSON.stringify(theme)});`);
       const data = `\\x1b[7m█\x1b[0m`;
-      await writeSync(data);
+      await writeSync(page, data);
       // Inverse background should be opaque
       await pollFor(page, () => getCellColor(1, 1), [255, 0, 0, 255]);
     });
   });
 });
-
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}
-
-async function writeSync(data: string): Promise<void> {
-  return page.evaluate(`new Promise(resolve => window.term.write('${data}', resolve))`);
-}
 
 async function getCellColor(col: number, row: number): Promise<number[]> {
   await page.evaluate(`
@@ -902,23 +888,11 @@ async function setupBrowser(options: ITerminalOptions = { rendererType: 'dom' })
   page = (await browser.pages())[0];
   await page.setViewport({ width, height });
   await page.goto(APP);
-  await openTerminal(options);
+  await openTerminal(page, options);
   await page.evaluate(`
     window.addon = new WebglAddon(true);
     window.term.loadAddon(window.addon);
   `);
-}
-
-export async function pollFor<T>(page: puppeteer.Page, evalOrFn: string | (() => Promise<T>), val: T, preFn?: () => Promise<void>): Promise<void> {
-  if (preFn) {
-    await preFn();
-  }
-  const result = typeof evalOrFn === 'string' ? await page.evaluate(evalOrFn) : await evalOrFn();
-  if (!deepEqual(result, val)) {
-    return new Promise<void>(r => {
-      setTimeout(() => r(pollFor(page, evalOrFn, val, preFn)), 1);
-    });
-  }
 }
 
 const COLORS_16_TO_255 = [

--- a/addons/xterm-addon-webgl/src/tsconfig.json
+++ b/addons/xterm-addon-webgl/src/tsconfig.json
@@ -12,17 +12,29 @@
     "removeComments": true,
     "baseUrl": ".",
     "paths": {
-      "common/*": [ "../../../src/common/*" ],
-      "browser/*": [ "../../../src/browser/*" ]
+      "common/*": [
+        "../../../src/common/*"
+      ],
+      "browser/*": [
+        "../../../src/browser/*"
+      ]
     },
-    "strict": true
+    "strict": true,
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../out-test/api/TestUtils"
+    ]
   },
   "include": [
     "./**/*",
     "../../../typings/xterm.d.ts"
   ],
   "references": [
-    { "path": "../../../src/common" },
-    { "path": "../../../src/browser" }
+    {
+      "path": "../../../src/common"
+    },
+    {
+      "path": "../../../src/browser"
+    }
   ]
 }

--- a/test/api/CharWidth.api.ts
+++ b/test/api/CharWidth.api.ts
@@ -4,8 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { ITerminalOptions } from 'xterm';
-import { pollFor } from './TestUtils';
+import { pollFor, openTerminal } from './TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -23,7 +22,7 @@ describe('CharWidth Integration Tests', function(): void {
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });
     await page.goto(APP);
-    await openTerminal({ rows: 5, cols: 30 });
+    await openTerminal(page, { rows: 5, cols: 30 });
   });
 
   after(() => {
@@ -74,16 +73,6 @@ describe('CharWidth Integration Tests', function(): void {
     // TODO: multiline tests once #1685 is resolved
   });
 });
-
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}
 
 async function sumWidths(start: number, end: number, sentinel: string): Promise<number> {
   await page.evaluate(`

--- a/test/api/MouseTracking.api.ts
+++ b/test/api/MouseTracking.api.ts
@@ -4,8 +4,7 @@
  */
 
 import * as puppeteer from 'puppeteer';
-import { ITerminalOptions } from 'xterm';
-import { pollFor, writeSync } from './TestUtils';
+import { pollFor, writeSync, openTerminal } from './TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -28,16 +27,6 @@ const noShift = process.platform === 'darwin' ? false : true;
 /**
  * Helper functions.
  */
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}
-
 async function resetMouseModes(): Promise<void> {
   return await page.evaluate(`
     window.term.write('\x1b[?9l\x1b[?1000l\x1b[?1001l\x1b[?1002l\x1b[?1003l');
@@ -77,10 +66,10 @@ async function mouseMove(col: number, row: number): Promise<void> {
   return await page.mouse.move(xPixels, yPixels);
 }
 async function mouseDown(button: 'left' | 'right' | 'middle' | undefined): Promise<void> {
-  return await page.mouse.down({button});
+  return await page.mouse.down({ button });
 }
 async function mouseUp(button: 'left' | 'right' | 'middle' | undefined): Promise<void> {
-  return await page.mouse.up({button});
+  return await page.mouse.up({ button });
 }
 async function wheelUp(): Promise<void> {
   const self = (page.mouse as any);
@@ -106,24 +95,24 @@ async function wheelDown(): Promise<void> {
 }
 
 // button definitions
-const buttons: {[key: string]: number} = {
-  '<none>':  -1,
-  left:       0,
-  middle:     1,
-  right:      2,
-  released:   3,
-  wheelUp:    4,
-  wheelDown:  5,
-  wheelLeft:  6,
+const buttons: { [key: string]: number } = {
+  '<none>': -1,
+  left: 0,
+  middle: 1,
+  right: 2,
+  released: 3,
+  wheelUp: 4,
+  wheelDown: 5,
+  wheelLeft: 6,
   wheelRight: 7,
-  aux8:       8,
-  aux9:       9,
-  aux10:      10,
-  aux11:      11,
-  aux12:      12,
-  aux13:      13,
-  aux14:      14,
-  aux15:      15
+  aux8: 8,
+  aux9: 9,
+  aux10: 10,
+  aux11: 11,
+  aux12: 12,
+  aux13: 13,
+  aux14: 14,
+  aux15: 15
 };
 const reverseButtons: any = {};
 for (const el in buttons) {
@@ -133,9 +122,9 @@ for (const el in buttons) {
 // extract button data from buttonCode
 function evalButtonCode(code: number): any {
   if (code > 255) {
-    return {button: 'invalid', action: 'invalid', modifier: {}};
+    return { button: 'invalid', action: 'invalid', modifier: {} };
   }
-  const modifier = {shift: !!(code & 4), meta: !!(code & 8), control: !!(code & 16)};
+  const modifier = { shift: !!(code & 4), meta: !!(code & 8), control: !!(code & 16) };
   const move = code & 32;
   let button = code & 3;
   if (code & 128) {
@@ -156,11 +145,11 @@ function evalButtonCode(code: number): any {
     buttonS = 'wheel';
     actionS = button === 4 ? 'up' : button === 5 ? 'down' : button === 6 ? 'left' : 'right';
   }
-  return {button: buttonS, action: actionS, modifier};
+  return { button: buttonS, action: actionS, modifier };
 }
 
 // parse a single mouse report
-function parseReport(encoding: string, msg: number[]): {state: any; row: number; col: number; } | string {
+function parseReport(encoding: string, msg: number[]): { state: any; row: number; col: number; } | string {
   let sReport: string;
   let buttonCode: number;
   let row: number;
@@ -185,7 +174,7 @@ function parseReport(encoding: string, msg: number[]): {state: any; row: number;
       if (report[report.length - 1] === 'm') {
         state.action = 'release';
       }
-      return {state, row, col};
+      return { state, row, col };
     default:
       return {
         state: evalButtonCode(report.charCodeAt(3) - 32),
@@ -212,7 +201,7 @@ describe('Mouse Tracking Tests', () => {
 
   beforeEach(async () => {
     await page.goto(APP);
-    await openTerminal();
+    await openTerminal(page);
     // patch terminal to get the onData calls
     // we encode the msg here to an array of codes to not lose bytes
     // (transmission strips non utf8 bytes)
@@ -242,7 +231,7 @@ describe('Mouse Tracking Tests', () => {
 
       // test at 0,0
       await mouseDown('left');
-      await pollFor(page, () => getReports(encoding), [{col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // mouseup should not report
       await mouseUp('left');
@@ -253,14 +242,14 @@ describe('Mouse Tracking Tests', () => {
       await pollFor(page, () => getReports(encoding), []);
       await mouseDown('left');
       await mouseUp('left');
-      await pollFor(page, () => getReports(encoding), [{col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // test at max rows/cols
       // capped at 223 (1-based)
       await mouseMove(223 - 1, rows - 1);
       await mouseDown('left');
       await mouseUp('left');
-      await pollFor(page, () => getReports(encoding), [{col: 223, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 223, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // higher than 223 should not report at all
       await mouseMove(257, rows - 1);
@@ -275,7 +264,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseMove(44, 24);
       await mouseUp('left');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
       // await mouseMove(43, 24);
@@ -291,7 +280,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('right');
       await mouseMove(44, 24);
       await mouseUp('right');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } }]);
 
       // wheel
       await mouseMove(43, 24);
@@ -311,7 +300,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseUp('left');
       await wheelDown();
       await page.keyboard.up('Control');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
 
       // ALT
@@ -323,7 +312,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseUp('left');
       await wheelDown();
       await page.keyboard.up('Alt');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // SHIFT
       // note: caught by selection manager
@@ -341,7 +330,7 @@ describe('Mouse Tracking Tests', () => {
         await pollFor(page, () => getReports(encoding), []);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
         ]);
       }
 
@@ -359,7 +348,7 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Control');
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
     });
     it('SGR encoding', async () => {
       const encoding = 'SGR';
@@ -369,7 +358,7 @@ describe('Mouse Tracking Tests', () => {
 
       // test at 0,0
       await mouseDown('left');
-      await pollFor(page, () => getReports(encoding), [{col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // mouseup should not report
       await mouseUp('left');
@@ -380,13 +369,13 @@ describe('Mouse Tracking Tests', () => {
       await pollFor(page, () => getReports(encoding), []);
       await mouseDown('left');
       await mouseUp('left');
-      await pollFor(page, () => getReports(encoding), [{col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // test at max rows/cols
       await mouseMove(cols - 1, rows - 1);
       await mouseDown('left');
       await mouseUp('left');
-      await pollFor(page, () => getReports(encoding), [{col: cols, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: cols, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // button press/move/release tests
       // left button
@@ -395,7 +384,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseMove(44, 24);
       await mouseUp('left');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
       // await mouseMove(43, 24);
@@ -411,7 +400,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('right');
       await mouseMove(44, 24);
       await mouseUp('right');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } }]);
 
       // wheel
       await mouseMove(43, 24);
@@ -431,7 +420,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseUp('left');
       await wheelDown();
       await page.keyboard.up('Control');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
 
       // ALT
@@ -443,7 +432,7 @@ describe('Mouse Tracking Tests', () => {
       await mouseUp('left');
       await wheelDown();
       await page.keyboard.up('Alt');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
 
       // SHIFT
       // note: caught by selection manager
@@ -459,7 +448,7 @@ describe('Mouse Tracking Tests', () => {
         await pollFor(page, () => getReports(encoding), []);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
         ]);
       }
 
@@ -477,7 +466,7 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Control');
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }]);
     });
   });
   describe('DECSET 1000 (VT200 mouse)', () => {
@@ -497,13 +486,13 @@ describe('Mouse Tracking Tests', () => {
       // test at 0,0
       await mouseDown('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mouseup should report, encoding cannot report released button
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mousemove should not report
@@ -512,8 +501,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 51, row: 11, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 51, row: 11, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // test at max rows/cols
@@ -522,8 +511,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 223, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 223, row: rows, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 223, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 223, row: rows, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // button press/move/release tests
@@ -534,8 +523,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
@@ -553,17 +542,17 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('right');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // wheel
       await mouseMove(43, 24);
       await getReports(encoding); // clear reports
       await wheelUp();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'up', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'up', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
       await wheelDown();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
 
       // modifiers
       // CTRL
@@ -576,9 +565,9 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Control');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: false } } }
       ]);
 
       // ALT
@@ -591,9 +580,9 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Alt');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: true } } }
       ]);
 
       // SHIFT
@@ -609,13 +598,13 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Shift');
       if (noShift) {
         await pollFor(page, () => getReports(encoding), [
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       }
 
@@ -634,9 +623,9 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: true } } }
       ]);
     });
     it('SGR encoding', async () => {
@@ -648,13 +637,13 @@ describe('Mouse Tracking Tests', () => {
       // test at 0,0
       await mouseDown('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mouseup should report
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mousemove should not report
@@ -663,8 +652,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 51, row: 11, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 51, row: 11, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // test at max rows/cols
@@ -672,8 +661,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: cols, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: cols, row: rows, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: cols, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: cols, row: rows, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // button press/move/release tests
@@ -684,8 +673,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
@@ -703,17 +692,17 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('right');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'right', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'right', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // wheel
       await mouseMove(43, 24);
       await getReports(encoding); // clear reports
       await wheelUp();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'up', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'up', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
       await wheelDown();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
 
       // modifiers
       // CTRL
@@ -726,9 +715,9 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Control');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: false } } }
       ]);
 
       // ALT
@@ -741,9 +730,9 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Alt');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: true } } }
       ]);
 
       // SHIFT
@@ -758,13 +747,13 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Shift');
       if (noShift) {
         await pollFor(page, () => getReports(encoding), [
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       }
 
@@ -783,9 +772,9 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: true } } }
       ]);
     });
   });
@@ -806,13 +795,13 @@ describe('Mouse Tracking Tests', () => {
       // test at 0,0
       await mouseDown('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mouseup should report, encoding cannot report released button
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mousemove should not report
@@ -821,8 +810,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 51, row: 11, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 51, row: 11, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // test at max rows/cols
@@ -831,8 +820,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 223, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 223, row: rows, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 223, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 223, row: rows, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // button press/move/release tests
@@ -843,9 +832,9 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
@@ -863,18 +852,18 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('right');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // wheel
       await mouseMove(43, 24);
       await getReports(encoding); // clear reports
       await wheelUp();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'up', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'up', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
       await wheelDown();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
 
       // modifiers
       // CTRL
@@ -887,10 +876,10 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Control');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: false } } }
       ]);
 
       // ALT
@@ -903,10 +892,10 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Alt');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: true } } }
       ]);
 
       // SHIFT
@@ -921,14 +910,14 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Shift');
       if (noShift) {
         await pollFor(page, () => getReports(encoding), [
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       }
 
@@ -947,10 +936,10 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: true } } }
       ]);
     });
     it('SGR encoding', async () => {
@@ -963,13 +952,13 @@ describe('Mouse Tracking Tests', () => {
       // bug: release is fired immediately
       await mouseDown('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mouseup should report, encoding cannot report released button
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mousemove should not report
@@ -978,8 +967,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 51, row: 11, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 51, row: 11, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // test at max rows/cols
@@ -987,8 +976,8 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: cols, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: cols, row: rows, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: cols, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: cols, row: rows, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // button press/move/release tests
@@ -999,9 +988,9 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
@@ -1019,18 +1008,18 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('right');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'right', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'right', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // wheel
       await mouseMove(43, 24);
       await getReports(encoding); // clear reports
       await wheelUp();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'up', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'up', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
       await wheelDown();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
 
       // modifiers
       // CTRL
@@ -1043,10 +1032,10 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Control');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: false } } }
       ]);
 
       // ALT
@@ -1059,10 +1048,10 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Alt');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: true } } }
       ]);
 
       // SHIFT
@@ -1077,14 +1066,14 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Shift');
       if (noShift) {
         await pollFor(page, () => getReports(encoding), [
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       }
 
@@ -1103,10 +1092,10 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: true } } }
       ]);
     });
   });
@@ -1124,25 +1113,25 @@ describe('Mouse Tracking Tests', () => {
       // test at 0,0
       await mouseDown('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mouseup should report, encoding cannot report released button
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mousemove should report
       await mouseMove(50, 10);
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 51, row: 11, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 51, row: 11, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // test at max rows/cols
@@ -1151,9 +1140,9 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 223, row: rows, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}},
-        {col: 223, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 223, row: rows, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 223, row: rows, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } },
+        { col: 223, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 223, row: rows, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // button press/move/release tests
@@ -1163,10 +1152,10 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
@@ -1183,19 +1172,19 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('right');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // wheel
       await mouseMove(43, 24);
       await getReports(encoding); // clear reports
       await wheelUp();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'up', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'up', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
       await wheelDown();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
 
       // modifiers
       // CTRL
@@ -1207,11 +1196,11 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Control');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: true, shift: false, meta: false}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: true, shift: false, meta: false } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: false } } }
       ]);
 
       // ALT
@@ -1223,11 +1212,11 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Alt');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: true}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: true } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: true } } }
       ]);
 
       // SHIFT
@@ -1241,16 +1230,16 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Shift');
       if (noShift) {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       }
 
@@ -1268,11 +1257,11 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: true, shift: false, meta: true}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: '<none>', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: true, shift: false, meta: true } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: '<none>', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: true } } }
       ]);
     });
     it('SGR encoding', async () => {
@@ -1284,25 +1273,25 @@ describe('Mouse Tracking Tests', () => {
       // test at 0,0
       await mouseDown('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mouseup should report, encoding cannot report released button
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 1, row: 1, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 1, row: 1, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // mousemove should report
       await mouseMove(50, 10);
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } }
       ]);
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 51, row: 11, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 51, row: 11, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 51, row: 11, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 51, row: 11, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // test at max rows/cols
@@ -1312,9 +1301,9 @@ describe('Mouse Tracking Tests', () => {
       await mouseDown('left');
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: cols, row: rows, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}},
-        {col: cols, row: rows, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: cols, row: rows, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: cols, row: rows, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } },
+        { col: cols, row: rows, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: cols, row: rows, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // button press/move/release tests
@@ -1324,10 +1313,10 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('left');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: false } } }
       ]);
       // middle button
       // bug: default action not cancelled (adds data to getReports from clipboard under X11)
@@ -1344,19 +1333,19 @@ describe('Mouse Tracking Tests', () => {
       await mouseMove(44, 24);
       await mouseUp('right');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: false}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'right', modifier: {control: false, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'right', modifier: {control: false, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: false } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'right', modifier: { control: false, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'right', modifier: { control: false, shift: false, meta: false } } }
       ]);
 
       // wheel
       await mouseMove(43, 24);
       await getReports(encoding); // clear reports
       await wheelUp();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'up', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'up', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
       await wheelDown();
-      await pollFor(page, () => getReports(encoding), [{col: 44, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: false}}}]);
+      await pollFor(page, () => getReports(encoding), [{ col: 44, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: false } } }]);
 
       // modifiers
       // CTRL
@@ -1368,11 +1357,11 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Control');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: true, shift: false, meta: false}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: true, shift: false, meta: false}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: false}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: true, shift: false, meta: false } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: true, shift: false, meta: false } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: false } } }
       ]);
 
       // ALT
@@ -1384,11 +1373,11 @@ describe('Mouse Tracking Tests', () => {
       await wheelDown();
       await page.keyboard.up('Alt');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: false, meta: true}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: false, meta: true } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: false, meta: true } } }
       ]);
 
       // SHIFT
@@ -1402,16 +1391,16 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Shift');
       if (noShift) {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       } else {
         await pollFor(page, () => getReports(encoding), [
-          {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: false, shift: true, meta: false}}},
-          {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: false, shift: true, meta: false}}},
-          {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: false, shift: true, meta: false}}}
+          { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: false, shift: true, meta: false } } },
+          { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: false, shift: true, meta: false } } },
+          { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: false, shift: true, meta: false } } }
         ]);
       }
 
@@ -1429,11 +1418,11 @@ describe('Mouse Tracking Tests', () => {
       await page.keyboard.up('Alt');
       // await page.keyboard.up('Shift');
       await pollFor(page, () => getReports(encoding), [
-        {col: 44, row: 25, state: {action: 'move', button: '<none>', modifier: {control: true, shift: false, meta: true}}},
-        {col: 44, row: 25, state: {action: 'press', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'move', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'release', button: 'left', modifier: {control: true, shift: false, meta: true}}},
-        {col: 45, row: 25, state: {action: 'down', button: 'wheel', modifier: {control: true, shift: false, meta: true}}}
+        { col: 44, row: 25, state: { action: 'move', button: '<none>', modifier: { control: true, shift: false, meta: true } } },
+        { col: 44, row: 25, state: { action: 'press', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'move', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'release', button: 'left', modifier: { control: true, shift: false, meta: true } } },
+        { col: 45, row: 25, state: { action: 'down', button: 'wheel', modifier: { control: true, shift: false, meta: true } } }
       ]);
     });
   });

--- a/test/api/Parser.api.ts
+++ b/test/api/Parser.api.ts
@@ -5,8 +5,7 @@
 
 import * as puppeteer from 'puppeteer';
 import { assert } from 'chai';
-import { ITerminalOptions } from 'xterm';
-import { writeSync } from './TestUtils';
+import { writeSync, openTerminal } from './TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -24,7 +23,7 @@ describe('Parser Integration Tests', function(): void {
     page = (await browser.pages())[0];
     await page.setViewport({ width, height });
     await page.goto(APP);
-    await openTerminal();
+    await openTerminal(page);
   });
 
   after(async () => browser.close());
@@ -110,13 +109,3 @@ describe('Parser Integration Tests', function(): void {
     });
   });
 });
-
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}

--- a/test/api/Terminal.api.ts
+++ b/test/api/Terminal.api.ts
@@ -5,8 +5,7 @@
 
 import * as puppeteer from 'puppeteer';
 import { assert } from 'chai';
-import { ITerminalOptions } from 'xterm';
-import { pollFor, timeout, writeSync } from './TestUtils';
+import { pollFor, timeout, writeSync, openTerminal } from './TestUtils';
 
 const APP = 'http://127.0.0.1:3000/test';
 
@@ -29,13 +28,13 @@ describe('API Integration Tests', function(): void {
   beforeEach(async () => page.goto(APP));
 
   it('Default options', async () => {
-    await openTerminal();
+    await openTerminal(page);
     assert.equal(await page.evaluate(`window.term.cols`), 80);
     assert.equal(await page.evaluate(`window.term.rows`), 24);
   });
 
   it('write', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       window.term.write('foo');
       window.term.write('bar');
@@ -45,7 +44,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('write with callback', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       window.term.write('foo', () => { window.__x = 'a'; });
       window.term.write('bar', () => { window.__x += 'b'; });
@@ -56,7 +55,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('write - bytes (UTF8)', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       // foo
       window.term.write(new Uint8Array([102, 111, 111]));
@@ -69,7 +68,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('write - bytes (UTF8) with callback', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       // foo
       window.term.write(new Uint8Array([102, 111, 111]), () => { window.__x = 'A'; });
@@ -83,7 +82,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('writeln', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       window.term.writeln('foo');
       window.term.writeln('bar');
@@ -95,7 +94,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('writeln with callback', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       window.term.writeln('foo', () => { window.__x = '1'; });
       window.term.writeln('bar', () => { window.__x += '2'; });
@@ -108,7 +107,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('writeln - bytes (UTF8)', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       window.term.writeln(new Uint8Array([102, 111, 111]));
       window.term.writeln(new Uint8Array([98, 97, 114]));
@@ -120,7 +119,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('paste', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`
       window.calls = [];
       window.term.onData(e => calls.push(e));
@@ -134,7 +133,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('clear', async () => {
-    await openTerminal({ rows: 5 });
+    await openTerminal(page, { rows: 5 });
     await page.evaluate(`
       window.term.write('test0');
       window.parsed = 0;
@@ -152,7 +151,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('getOption, setOption', async () => {
-    await openTerminal();
+    await openTerminal(page);
     assert.equal(await page.evaluate(`window.term.getOption('rendererType')`), 'canvas');
     await page.evaluate(`window.term.setOption('rendererType', 'dom')`);
     assert.equal(await page.evaluate(`window.term.getOption('rendererType')`), 'dom');
@@ -160,7 +159,7 @@ describe('API Integration Tests', function(): void {
 
   describe('renderer', () => {
     it('foreground', async () => {
-      await openTerminal({ rendererType: 'dom' });
+      await openTerminal(page, { rendererType: 'dom' });
       await writeSync(page, '\\x1b[30m0\\x1b[31m1\\x1b[32m2\\x1b[33m3\\x1b[34m4\\x1b[35m5\\x1b[36m6\\x1b[37m7');
       await pollFor(page, `document.querySelectorAll('.xterm-rows > :nth-child(1) > *').length`, 9);
       assert.deepEqual(await page.evaluate(`
@@ -185,7 +184,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('background', async () => {
-      await openTerminal({ rendererType: 'dom' });
+      await openTerminal(page, { rendererType: 'dom' });
       await writeSync(page, '\\x1b[40m0\\x1b[41m1\\x1b[42m2\\x1b[43m3\\x1b[44m4\\x1b[45m5\\x1b[46m6\\x1b[47m7');
       await pollFor(page, `document.querySelectorAll('.xterm-rows > :nth-child(1) > *').length`, 9);
       assert.deepEqual(await page.evaluate(`
@@ -211,7 +210,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('selection', async () => {
-    await openTerminal({ rows: 5, cols: 5 });
+    await openTerminal(page, { rows: 5, cols: 5 });
     await page.evaluate(`window.term.write('\\n\\nfoo\\n\\n\\rbar\\n\\n\\rbaz')`);
     assert.equal(await page.evaluate(`window.term.hasSelection()`), false);
     assert.equal(await page.evaluate(`window.term.getSelection()`), '');
@@ -231,7 +230,7 @@ describe('API Integration Tests', function(): void {
   });
 
   it('focus, blur', async () => {
-    await openTerminal();
+    await openTerminal(page);
     assert.equal(await page.evaluate(`document.activeElement.className`), '');
     await page.evaluate(`window.term.focus()`);
     assert.equal(await page.evaluate(`document.activeElement.className`), 'xterm-helper-textarea');
@@ -241,7 +240,7 @@ describe('API Integration Tests', function(): void {
 
   describe('loadAddon', () => {
     it('constructor', async () => {
-      await openTerminal({ cols: 5 });
+      await openTerminal(page, { cols: 5 });
       await page.evaluate(`
         window.cols = 0;
         window.term.loadAddon({
@@ -253,7 +252,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('dispose (addon)', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.disposeCalled = false
         window.addon = {
@@ -268,7 +267,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('dispose (terminal)', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.disposeCalled = false
         window.term.loadAddon({
@@ -284,7 +283,7 @@ describe('API Integration Tests', function(): void {
 
   describe('Events', () => {
     it('onCursorMove', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.callCount = 0;
         window.term.onCursorMove(e => window.callCount++);
@@ -296,7 +295,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onData', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.calls = [];
         window.term.onData(e => calls.push(e));
@@ -306,7 +305,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onKey', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.calls = [];
         window.term.onKey(e => calls.push(e.key));
@@ -316,7 +315,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onLineFeed', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.callCount = 0;
         window.term.onLineFeed(() => callCount++);
@@ -328,7 +327,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onScroll', async () => {
-      await openTerminal({ rows: 5 });
+      await openTerminal(page, { rows: 5 });
       await page.evaluate(`
         window.calls = [];
         window.term.onScroll(e => window.calls.push(e));
@@ -344,7 +343,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onSelectionChange', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.callCount = 0;
         window.term.onSelectionChange(() => window.callCount++);
@@ -356,9 +355,9 @@ describe('API Integration Tests', function(): void {
       await pollFor(page, `window.callCount`, 2);
     });
 
-    it('onRender', async function (): Promise<void> {
+    it('onRender', async function(): Promise<void> {
       this.retries(3);
-      await openTerminal();
+      await openTerminal(page);
       await timeout(20); // Ensure all init events are fired
       await page.evaluate(`
         window.calls = [];
@@ -372,7 +371,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onResize', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await timeout(20); // Ensure all init events are fired
       await page.evaluate(`
         window.calls = [];
@@ -386,7 +385,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('onTitleChange', async () => {
-      await openTerminal();
+      await openTerminal(page);
       await page.evaluate(`
         window.calls = [];
         window.term.onTitleChange(e => window.calls.push(e));
@@ -399,7 +398,7 @@ describe('API Integration Tests', function(): void {
 
   describe('buffer', () => {
     it('cursorX, cursorY', async () => {
-      await openTerminal({ rows: 5, cols: 5 });
+      await openTerminal(page, { rows: 5, cols: 5 });
       assert.equal(await page.evaluate(`window.term.buffer.cursorX`), 0);
       assert.equal(await page.evaluate(`window.term.buffer.cursorY`), 0);
       await writeSync(page, 'foo');
@@ -420,7 +419,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('viewportY', async () => {
-      await openTerminal({ rows: 5 });
+      await openTerminal(page, { rows: 5 });
       assert.equal(await page.evaluate(`window.term.buffer.viewportY`), 0);
       await writeSync(page, '\\n\\n\\n\\n');
       assert.equal(await page.evaluate(`window.term.buffer.viewportY`), 0);
@@ -435,7 +434,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('baseY', async () => {
-      await openTerminal({ rows: 5 });
+      await openTerminal(page, { rows: 5 });
       assert.equal(await page.evaluate(`window.term.buffer.baseY`), 0);
       await writeSync(page, '\\n\\n\\n\\n');
       assert.equal(await page.evaluate(`window.term.buffer.baseY`), 0);
@@ -450,7 +449,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('length', async () => {
-      await openTerminal({ rows: 5 });
+      await openTerminal(page, { rows: 5 });
       assert.equal(await page.evaluate(`window.term.buffer.length`), 5);
       await writeSync(page, '\\n\\n\\n\\n');
       assert.equal(await page.evaluate(`window.term.buffer.length`), 5);
@@ -462,13 +461,13 @@ describe('API Integration Tests', function(): void {
 
     describe('getLine', () => {
       it('invalid index', async () => {
-        await openTerminal({ rows: 5 });
+        await openTerminal(page, { rows: 5 });
         assert.equal(await page.evaluate(`window.term.buffer.getLine(-1)`), undefined);
         assert.equal(await page.evaluate(`window.term.buffer.getLine(5)`), undefined);
       });
 
       it('isWrapped', async () => {
-        await openTerminal({ cols: 5 });
+        await openTerminal(page, { cols: 5 });
         assert.equal(await page.evaluate(`window.term.buffer.getLine(0).isWrapped`), false);
         assert.equal(await page.evaluate(`window.term.buffer.getLine(1).isWrapped`), false);
         await writeSync(page, 'abcde');
@@ -480,7 +479,7 @@ describe('API Integration Tests', function(): void {
       });
 
       it('translateToString', async () => {
-        await openTerminal({ cols: 5 });
+        await openTerminal(page, { cols: 5 });
         assert.equal(await page.evaluate(`window.term.buffer.getLine(0).translateToString()`), '     ');
         assert.equal(await page.evaluate(`window.term.buffer.getLine(0).translateToString(true)`), '');
         await writeSync(page, 'foo');
@@ -495,7 +494,7 @@ describe('API Integration Tests', function(): void {
       });
 
       it('getCell', async () => {
-        await openTerminal({ cols: 5 });
+        await openTerminal(page, { cols: 5 });
         assert.equal(await page.evaluate(`window.term.buffer.getLine(0).getCell(-1)`), undefined);
         assert.equal(await page.evaluate(`window.term.buffer.getLine(0).getCell(5)`), undefined);
         assert.equal(await page.evaluate(`window.term.buffer.getLine(0).getCell(0).getChars()`), '');
@@ -520,14 +519,14 @@ describe('API Integration Tests', function(): void {
   });
 
   it('dispose (opened)', async () => {
-    await openTerminal();
+    await openTerminal(page);
     await page.evaluate(`window.term.dispose()`);
     assert.equal(await page.evaluate(`window.term._core._isDisposed`), true);
   });
 
   describe('registerLinkProvider', () => {
     it('should fire provideLink when hovering cells', async () => {
-      await openTerminal({ rendererType: 'dom' });
+      await openTerminal(page, { rendererType: 'dom' });
       await page.evaluate(`
         window.calls = [];
         window.disposable = window.term.registerLinkProvider({
@@ -546,7 +545,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('should fire hover and leave events on the link', async () => {
-      await openTerminal({ rendererType: 'dom' });
+      await openTerminal(page, { rendererType: 'dom' });
       await writeSync(page, 'foo bar baz');
       // Wait for renderer to catch up as links are cleared on render
       await pollFor(page, `document.querySelector('.xterm-rows').textContent`, 'foo bar baz ');
@@ -581,7 +580,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('should work fine when hover and leave callbacks are not provided', async () => {
-      await openTerminal({ rendererType: 'dom' });
+      await openTerminal(page, { rendererType: 'dom' });
       await writeSync(page, 'foo bar baz');
       // Wait for renderer to catch up as links are cleared on render
       await pollFor(page, `document.querySelector('.xterm-rows').textContent`, 'foo bar baz ');
@@ -614,7 +613,7 @@ describe('API Integration Tests', function(): void {
     });
 
     it('should fire activate events when clicking the link', async () => {
-      await openTerminal({ rendererType: 'dom' });
+      await openTerminal(page, { rendererType: 'dom' });
       await writeSync(page, 'a b c');
 
       // Wait for renderer to catch up as links are cleared on render
@@ -662,16 +661,6 @@ describe('API Integration Tests', function(): void {
   });
 });
 
-async function openTerminal(options: ITerminalOptions = {}): Promise<void> {
-  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
-  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
-  if (options.rendererType === 'dom') {
-    await page.waitForSelector('.xterm-rows');
-  } else {
-    await page.waitForSelector('.xterm-text-layer');
-  }
-}
-
 interface IDimensions {
   top: number;
   left: number;
@@ -713,7 +702,7 @@ async function getCellCoordinates(dimensions: IDimensions, col: number, row: num
   };
 }
 
-async function moveMouseCell(page: puppeteer.Page, dimensions: IDimensions, col: number, row: number) {
+async function moveMouseCell(page: puppeteer.Page, dimensions: IDimensions, col: number, row: number): Promise<void> {
   const coords = await getCellCoordinates(dimensions, col, row);
   await page.mouse.move(coords.x, coords.y);
 }

--- a/test/api/TestUtils.ts
+++ b/test/api/TestUtils.ts
@@ -5,6 +5,7 @@
 
 import * as puppeteer from 'puppeteer';
 import deepEqual = require('deep-equal');
+import { ITerminalOptions } from 'xterm';
 
 export async function pollFor<T>(page: puppeteer.Page, evalOrFn: string | (() => Promise<T>), val: T, preFn?: () => Promise<void>): Promise<void> {
   if (preFn) {
@@ -28,4 +29,14 @@ export async function writeSync(page: puppeteer.Page, data: string): Promise<voi
 
 export async function timeout(ms: number): Promise<void> {
   return new Promise<void>(r => setTimeout(r, ms));
+}
+
+export async function openTerminal(page: puppeteer.Page, options: ITerminalOptions = {}): Promise<void> {
+  await page.evaluate(`window.term = new Terminal(${JSON.stringify(options)})`);
+  await page.evaluate(`window.term.open(document.querySelector('#terminal-container'))`);
+  if (options.rendererType === 'dom') {
+    await page.waitForSelector('.xterm-rows');
+  } else {
+    await page.waitForSelector('.xterm-text-layer');
+  }
 }

--- a/test/api/tsconfig.json
+++ b/test/api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": [
       "dom",
-      "es6",
+      "es6"
     ],
     "rootDir": ".",
     "outDir": "../../out-test/api",
@@ -12,6 +12,8 @@
     "sourceMap": true,
     "removeComments": true,
     "pretty": true,
+    "declaration": true,
+    "composite": true,
     "strict": true
   },
   "include": [

--- a/test/api/tsconfig.json
+++ b/test/api/tsconfig.json
@@ -13,7 +13,6 @@
     "removeComments": true,
     "pretty": true,
     "declaration": true,
-    "composite": true,
     "strict": true
   },
   "include": [


### PR DESCRIPTION
Part of #2699. Moved `openTerminal()` into a common util file that is used by everything in `test/api/`. I'm not sure how to make this accessible to the addon test files. 