### PR TITLE
Remove multiple usance of background-color in dom renderer

### DIFF
--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -156,7 +156,6 @@ export class DomRenderer extends Disposable implements IRenderer {
     let styles =
         `${this._terminalSelector} .${ROW_CONTAINER_CLASS} {` +
         ` color: ${this._colors.foreground.css};` +
-        ` background-color: ${this._colors.background.css};` +
         ` font-family: ${this._optionsService.options.fontFamily};` +
         ` font-size: ${this._optionsService.options.fontSize}px;` +
         `}`;


### PR DESCRIPTION
Edit `_injectCss` function to remove background-color in `xterm/src/browser/renderer/dom/DomRenderer.ts`

Fixes #2586