### PR TITLE
Fix selection color in Legacy Edge

### DIFF
--- a/src/browser/ColorManager.ts
+++ b/src/browser/ColorManager.ts
@@ -192,7 +192,7 @@ export class ColorManager implements IColorManager {
       const rgba: number = channels.toRgba(r, g, b, alpha);
       return {
         rgba,
-        css: channels.toCss(r, g, b, alpha)
+        css
       };
     }
 


### PR DESCRIPTION
fixes #2736 

Looks like #rrggbbaa syntax is not compatible with EdgeHTML. This way selection is rendered correctly in both canvas and dom renderer.

Tested this with Edge Chromium, EdgeHTML and Firefox.