### PR TITLE
fix missing jekyll header in vtfeatures template

### DIFF
--- a/bin/extract_vtfeatures.js
+++ b/bin/extract_vtfeatures.js
@@ -33,7 +33,14 @@ const TYPES = [
 ];
 
 const MARKDOWN_TMPL = `
+---
+title: Supported Terminal Sequences
+category: API
+---
+
 {::options parse_block_html="true" /}
+
+# Supported Terminal Sequences
 
 xterm.js version: {{version}}
 


### PR DESCRIPTION
Jekyll refuses to compile the md file to html, if the header is missing.