### PR TITLE
vtfeatures v2

### DIFF
--- a/bin/extract_vtfeatures.js
+++ b/bin/extract_vtfeatures.js
@@ -32,8 +32,7 @@ const TYPES = [
   'SOS'
 ];
 
-const MARKDOWN_TMPL = `
----
+const MARKDOWN_TMPL = `---
 title: Supported Terminal Sequences
 category: API
 ---


### PR DESCRIPTION
Jekyll is really picky and does not like the leading empty line before the YAML block.

@Tyriar: Not being able to devel and test this locally before adding to the repo is really annoying. Even worse here, since it spans two repos.