### PR TITLE
Improve safety in CoreMouseService

### DIFF
--- a/src/common/services/CoreMouseService.test.ts
+++ b/src/common/services/CoreMouseService.test.ts
@@ -5,7 +5,7 @@
 import { CoreMouseService } from 'common/services/CoreMouseService';
 import { MockCoreService, MockBufferService } from 'common/TestUtils.test';
 import { assert } from 'chai';
-import { ICoreMouseEvent, CoreMouseEventType, CoreMouseButton, CoreMouseAction } from 'common/Types';
+import { ICoreMouseEvent, CoreMouseEventType, CoreMouseButton, CoreMouseAction, CoreMouseEncoding, ICoreMouseProtocol } from 'common/Types';
 
 // needed mock services
 const bufferService = new MockBufferService(300, 100);
@@ -20,6 +20,11 @@ function toBytes(s: string | undefined): number[] {
     res.push(s.charCodeAt(i));
   }
   return res;
+}
+
+class TestCoreMouseService extends CoreMouseService {
+  addProtocol(name: string, encoding: ICoreMouseProtocol | undefined): void { return this._addProtocol(name, encoding); }
+  addEncoding(name: string, encoding: CoreMouseEncoding | undefined): void { return this._addEncoding(name, encoding); }
 }
 
 describe('CoreMouseService', () => {
@@ -49,13 +54,13 @@ describe('CoreMouseService', () => {
     assert.throws(() => { cms.activeProtocol = 'xyz'; }, 'unknown protocol "xyz"');
   });
   it('addEncoding', () => {
-    const cms = new CoreMouseService(bufferService, coreService);
+    const cms = new TestCoreMouseService(bufferService, coreService);
     cms.addEncoding('XYZ', (e: ICoreMouseEvent) => '');
     cms.activeEncoding = 'XYZ';
     assert.equal(cms.activeEncoding, 'XYZ');
   });
   it('addProtocol', () => {
-    const cms = new CoreMouseService(bufferService, coreService);
+    const cms = new TestCoreMouseService(bufferService, coreService);
     cms.addProtocol('XYZ', { events: CoreMouseEventType.NONE, restrict: (e: ICoreMouseEvent) => false });
     cms.activeProtocol = 'XYZ';
     assert.equal(cms.activeProtocol, 'XYZ');

--- a/src/common/services/CoreMouseService.ts
+++ b/src/common/services/CoreMouseService.ts
@@ -12,7 +12,7 @@ import { ICoreMouseProtocol, ICoreMouseEvent, CoreMouseEncoding, CoreMouseEventT
 /**
  * Supported default protocols.
  */
-const DEFAULT_PROTOCOLS: {[key: string]: ICoreMouseProtocol} = {
+const DEFAULT_PROTOCOLS: { [name: string]: ICoreMouseProtocol } = {
   /**
    * NONE
    * Events: none
@@ -165,8 +165,8 @@ const DEFAULT_ENCODINGS: {[key: string]: CoreMouseEncoding} = {
  * To send a mouse event call `triggerMouseEvent`.
  */
 export class CoreMouseService implements ICoreMouseService {
-  private _protocols: {[name: string]: ICoreMouseProtocol} = {};
-  private _encodings: {[name: string]: CoreMouseEncoding} = {};
+  private _protocols: {[name: string]: ICoreMouseProtocol } = {};
+  private _encodings: {[name: string]: CoreMouseEncoding } = {};
   private _activeProtocol: string = '';
   private _activeEncoding: string = '';
   private _onProtocolChange = new EventEmitter<CoreMouseEventType>();
@@ -177,18 +177,22 @@ export class CoreMouseService implements ICoreMouseService {
     @ICoreService private readonly _coreService: ICoreService
   ) {
     // register default protocols and encodings
-    Object.keys(DEFAULT_PROTOCOLS).forEach(name => this.addProtocol(name, DEFAULT_PROTOCOLS[name]));
-    Object.keys(DEFAULT_ENCODINGS).forEach(name => this.addEncoding(name, DEFAULT_ENCODINGS[name]));
+    Object.keys(DEFAULT_PROTOCOLS).forEach(name => this._addProtocol(name, DEFAULT_PROTOCOLS[name]));
+    Object.keys(DEFAULT_ENCODINGS).forEach(name => this._addEncoding(name, DEFAULT_ENCODINGS[name]));
     // call reset to set defaults
     this.reset();
   }
 
-  public addProtocol(name: string, protocol: ICoreMouseProtocol): void {
-    this._protocols[name] = protocol;
+  protected _addProtocol(name: string, protocol: ICoreMouseProtocol | undefined ): void {
+    if (protocol) {
+      this._protocols[name] = protocol;
+    }
   }
 
-  public addEncoding(name: string, encoding: CoreMouseEncoding): void {
-    this._encodings[name] = encoding;
+  protected _addEncoding(name: string, encoding: CoreMouseEncoding | undefined ): void {
+    if (encoding) {
+      this._encodings[name] = encoding;
+    }
   }
 
   public get activeProtocol(): string {
@@ -196,11 +200,12 @@ export class CoreMouseService implements ICoreMouseService {
   }
 
   public set activeProtocol(name: string) {
-    if (!this._protocols[name]) {
+    const protocol = this._protocols[name];
+    if (!protocol) {
       throw new Error(`unknown protocol "${name}"`);
     }
     this._activeProtocol = name;
-    this._onProtocolChange.fire(this._protocols[name].events);
+    this._onProtocolChange.fire(protocol.events);
   }
 
   public get activeEncoding(): string {

--- a/src/common/services/CoreMouseService.ts
+++ b/src/common/services/CoreMouseService.ts
@@ -12,7 +12,7 @@ import { ICoreMouseProtocol, ICoreMouseEvent, CoreMouseEncoding, CoreMouseEventT
 /**
  * Supported default protocols.
  */
-const DEFAULT_PROTOCOLS: { [name: string]: ICoreMouseProtocol } = {
+const DEFAULT_PROTOCOLS: { [name: string]: ICoreMouseProtocol | undefined } = {
   /**
    * NONE
    * Events: none
@@ -120,7 +120,7 @@ const S = String.fromCharCode;
 /**
  * Supported default encodings.
  */
-const DEFAULT_ENCODINGS: {[key: string]: CoreMouseEncoding} = {
+const DEFAULT_ENCODINGS: { [key: string]: CoreMouseEncoding | undefined } = {
   /**
    * DEFAULT - CSI M Pb Px Py
    * Single byte encoding for coords and event code.

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -27,8 +27,6 @@ export const ICoreMouseService = createDecorator<ICoreMouseService>('CoreMouseSe
 export interface ICoreMouseService {
   activeProtocol: string;
   activeEncoding: string;
-  addProtocol(name: string, protocol: ICoreMouseProtocol): void;
-  addEncoding(name: string, encoding: CoreMouseEncoding): void;
   reset(): void;
 
   /**


### PR DESCRIPTION
Part of #2787

- Hide `addProtocol`/`addEncoding`
- Add `| undefined` to objects that may do that