### PR TITLE
Fix missing ybase calc in print

### DIFF
--- a/src/InputHandler.ts
+++ b/src/InputHandler.ts
@@ -491,7 +491,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     const wraparoundMode = this._coreService.decPrivateModes.wraparound;
     const insertMode = this._terminal.insertMode;
     const curAttr = this._curAttrData;
-    let bufferRow = buffer.lines.get(buffer.y + buffer.ybase);
+    let bufferRow = buffer.lines.get(buffer.ybase + buffer.y);
 
     this._dirtyRowService.markDirty(buffer.y);
 
@@ -555,10 +555,10 @@ export class InputHandler extends Disposable implements IInputHandler {
             }
             // The line already exists (eg. the initial viewport), mark it as a
             // wrapped line
-            buffer.lines.get(buffer.y).isWrapped = true;
+            buffer.lines.get(buffer.ybase + buffer.y).isWrapped = true;
           }
           // row changed, get it again
-          bufferRow = buffer.lines.get(buffer.y + buffer.ybase);
+          bufferRow = buffer.lines.get(buffer.ybase + buffer.y);
         } else {
           buffer.x = cols - 1;
           if (chWidth === 2) {
@@ -1178,7 +1178,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       return;
     }
 
-    const row: number = buffer.y + buffer.ybase;
+    const row: number = buffer.ybase + buffer.y;
 
     const scrollBottomRowsOffset = this._bufferService.rows - 1 - buffer.scrollBottom;
     const scrollBottomAbsolute = this._bufferService.rows - 1 + buffer.ybase - scrollBottomRowsOffset + 1;
@@ -1213,7 +1213,7 @@ export class InputHandler extends Disposable implements IInputHandler {
       return;
     }
 
-    const row: number = buffer.y + buffer.ybase;
+    const row: number = buffer.ybase + buffer.y;
 
     let j: number;
     j = this._bufferService.rows - 1 - buffer.scrollBottom;
@@ -1242,7 +1242,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   public insertChars(params: IParams): void {
     this._restrictCursor();
-    const line = this._bufferService.buffer.lines.get(this._bufferService.buffer.y + this._bufferService.buffer.ybase);
+    const line = this._bufferService.buffer.lines.get(this._bufferService.buffer.ybase + this._bufferService.buffer.y);
     if (line) {
       line.insertCells(
         this._bufferService.buffer.x,
@@ -1267,7 +1267,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   public deleteChars(params: IParams): void {
     this._restrictCursor();
-    const line = this._bufferService.buffer.lines.get(this._bufferService.buffer.y + this._bufferService.buffer.ybase);
+    const line = this._bufferService.buffer.lines.get(this._bufferService.buffer.ybase + this._bufferService.buffer.y);
     if (line) {
       line.deleteCells(
         this._bufferService.buffer.x,
@@ -1439,7 +1439,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    */
   public eraseChars(params: IParams): void {
     this._restrictCursor();
-    const line = this._bufferService.buffer.lines.get(this._bufferService.buffer.y + this._bufferService.buffer.ybase);
+    const line = this._bufferService.buffer.lines.get(this._bufferService.buffer.ybase + this._bufferService.buffer.y);
     if (line) {
       line.replaceCells(
         this._bufferService.buffer.x,
@@ -2712,8 +2712,8 @@ export class InputHandler extends Disposable implements IInputHandler {
       // test: echo -ne '\e[1;1H\e[44m\eM\e[0m'
       // blankLine(true) is xterm/linux behavior
       const scrollRegionHeight = buffer.scrollBottom - buffer.scrollTop;
-      buffer.lines.shiftElements(buffer.y + buffer.ybase, scrollRegionHeight, 1);
-      buffer.lines.set(buffer.y + buffer.ybase, buffer.getBlankLine(this._eraseAttrData()));
+      buffer.lines.shiftElements(buffer.ybase + buffer.y, scrollRegionHeight, 1);
+      buffer.lines.set(buffer.ybase + buffer.y, buffer.getBlankLine(this._eraseAttrData()));
       this._dirtyRowService.markRangeDirty(buffer.scrollTop, buffer.scrollBottom);
     } else {
       buffer.y--;
@@ -2778,7 +2778,7 @@ export class InputHandler extends Disposable implements IInputHandler {
 
     this._setCursor(0, 0);
     for (let yOffset = 0; yOffset < this._bufferService.rows; ++yOffset) {
-      const row = buffer.y + buffer.ybase + yOffset;
+      const row = buffer.ybase + buffer.y + yOffset;
       buffer.lines.get(row).fill(cell);
       buffer.lines.get(row).isWrapped = false;
     }


### PR DESCRIPTION
Fixes #2872.

Also changes `buffer.y + buffer.ybase` into `buffer.ybase + buffer.y` in inputhandler for coding convenience.