### PR TITLE
Make all eslint rules warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,22 +30,22 @@
   ],
   "rules": {
     "@typescript-eslint/array-type": [
-      "error",
+      "warn",
       {
         "default": "array-simple",
         "readonly": "generic"
       }
     ],
-    "@typescript-eslint/class-name-casing": "error",
-    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/class-name-casing": "warn",
+    "@typescript-eslint/consistent-type-definitions": "warn",
     "@typescript-eslint/explicit-function-return-type": [
-      "error",
+      "warn",
       {
         "allowExpressions": true
       }
     ],
     "@typescript-eslint/explicit-member-accessibility": [
-      "error",
+      "warn",
       {
         "accessibility": "explicit",
         "overrides": {
@@ -54,15 +54,15 @@
       }
     ],
     "@typescript-eslint/indent": [
-      "error",
+      "warn",
       2
     ],
     "@typescript-eslint/interface-name-prefix": [
-      "error",
+      "warn",
       "always"
     ],
     "@typescript-eslint/member-delimiter-style": [
-      "error",
+      "warn",
       {
         "multiline": {
           "delimiter": "semi",
@@ -75,7 +75,7 @@
       }
     ],
     "@typescript-eslint/naming-convention": [
-      "error",
+      "warn",
       { "selector": "default", "format": ["camelCase"] },
       // variableLike
       { "selector": "variable", "format": ["camelCase", "UPPER_CASE"] },
@@ -91,19 +91,19 @@
       { "selector": "typeLike", "format": ["PascalCase"] },
       { "selector": "interface", "format": ["PascalCase"], "prefix": ["I"] }
     ],
-    "@typescript-eslint/prefer-namespace-keyword": "error",
-    "@typescript-eslint/type-annotation-spacing": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "warn",
+    "@typescript-eslint/type-annotation-spacing": "warn",
     "@typescript-eslint/quotes": [
-      "error",
+      "warn",
       "single",
       { "allowTemplateLiterals": true }
     ],
     "@typescript-eslint/semi": [
-      "error",
+      "warn",
       "always"
     ],
     "comma-dangle": [
-      "error",
+      "warn",
       {
         "objects": "never",
         "arrays": "never",
@@ -111,43 +111,43 @@
       }
     ],
     "curly": [
-      "error",
+      "warn",
       "multi-line"
     ],
-    "eol-last": "error",
+    "eol-last": "warn",
     "eqeqeq": [
-      "error",
+      "warn",
       "always"
     ],
-    "keyword-spacing": "error",
-    "new-parens": "error",
-    "no-duplicate-imports": "error",
+    "keyword-spacing": "warn",
+    "new-parens": "warn",
+    "no-duplicate-imports": "warn",
     "no-else-return": [
-      "error",
+      "warn",
       {
         "allowElseIf": false
       }
     ],
-    "no-eval": "error",
-    "no-irregular-whitespace": "error",
+    "no-eval": "warn",
+    "no-irregular-whitespace": "warn",
     "no-restricted-imports": [
-      "error",
+      "warn",
       {
         "patterns": [
           ".*\\/out\\/.*"
         ]
       }
     ],
-    "no-trailing-spaces": "error",
-    "no-unsafe-finally": "error",
-    "no-var": "error",
+    "no-trailing-spaces": "warn",
+    "no-unsafe-finally": "warn",
+    "no-var": "warn",
     "one-var": [
-      "error",
+      "warn",
       "never"
     ],
-    "prefer-const": "error",
+    "prefer-const": "warn",
     "spaced-comment": [
-      "error",
+      "warn",
       "always",
       {
         "markers": ["/"],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepackage": "npm run build",
     "package": "webpack",
     "start": "node demo/start",
-    "lint": "eslint -c .eslintrc.json --ext .ts src/ addons/",
+    "lint": "eslint -c .eslintrc.json --max-warnings 0 --ext .ts src/ addons/",
     "test": "npm run test-unit",
     "posttest": "npm run lint",
     "test-api": "npm run test-api-chromium",


### PR DESCRIPTION
eslint warnings normally don't exit with non-zero when warnings fail unless
'--max-warnings 0' is used. This commit adds that and changes all rules to
be warnings in order to improve feedback in the editor. After this commit
all warning diagnostics (yellow) are stylistic/lint-related ones that will
still fail lint, which error diagnostics (red) are actual errors that will
fail compilation (from tsc).

Fixes #2886