### PR TITLE
Only removeChild valid children in DomRenderer dispose

### DIFF
--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -102,13 +102,13 @@ export class DomRenderer extends Disposable implements IRenderer {
       this._rowContainer,
       this._selectionContainer,
       this._themeStyleElement,
-      this._dimensionsStyleElement,
+      this._dimensionsStyleElement
     ]) {
       if (element.parentElement === this._screenElement) {
         this._screenElement.removeChild(element);
       }
     }
-  
+
     super.dispose();
   }
 

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -95,10 +95,20 @@ export class DomRenderer extends Disposable implements IRenderer {
 
   public dispose(): void {
     this._element.classList.remove(TERMINAL_CLASS_PREFIX + this._terminalClass);
-    this._screenElement.removeChild(this._rowContainer);
-    this._screenElement.removeChild(this._selectionContainer);
-    this._screenElement.removeChild(this._themeStyleElement);
-    this._screenElement.removeChild(this._dimensionsStyleElement);
+
+    // Outside influences such as React unmounts may manipulate the DOM before our disposal.
+    // https://github.com/xtermjs/xterm.js/issues/2960
+    for (const element of [
+      this._rowContainer,
+      this._selectionContainer,
+      this._themeStyleElement,
+      this._dimensionsStyleElement,
+    ]) {
+      if (element.parentElement === this._screenElement) {
+        this._screenElement.removeChild(element);
+      }
+    }
+  
     super.dispose();
   }
 

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -98,16 +98,10 @@ export class DomRenderer extends Disposable implements IRenderer {
 
     // Outside influences such as React unmounts may manipulate the DOM before our disposal.
     // https://github.com/xtermjs/xterm.js/issues/2960
-    for (const element of [
-      this._rowContainer,
-      this._selectionContainer,
-      this._themeStyleElement,
-      this._dimensionsStyleElement
-    ]) {
-      if (element.parentElement === this._screenElement) {
-        this._screenElement.removeChild(element);
-      }
-    }
+    this._rowContainer.parentElement?.removeChild(this._rowContainer);
+    this._selectionContainer.parentElement?.removeChild(this._selectionContainer);
+    this._themeStyleElement.parentElement?.removeChild(this._themeStyleElement);
+    this._dimensionsStyleElement.parentElement?.removeChild(this._dimensionsStyleElement);
 
     super.dispose();
   }


### PR DESCRIPTION
Fixes #2960 

I did a scan for where I should add unit tests but it looks like the DOM renderer itself isn't unit tested - just `DomRendererRowFactory`. 