### PR TITLE
keyboard fixes

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -336,11 +336,11 @@ export class Terminal extends CoreTerminal implements ITerminal {
     //this.register(addDisposableDomListener(this.textarea!, 'keyup', (ev: KeyboardEvent) => this._keyUp(ev), true));
     //this.register(addDisposableDomListener(this.textarea!, 'keydown', (ev: KeyboardEvent) => this._keyDown(ev), true));
     //this.register(addDisposableDomListener(this.textarea!, 'keypress', (ev: KeyboardEvent) => this._keyPress(ev), true));
-    const keyboardHelper = new KeyboardHelper();
-    this.register(addDisposableDomListener(this.textarea!, 'keyup', keyboardHelper.up, true));
-    this.register(addDisposableDomListener(this.textarea!, 'keydown', keyboardHelper.down, true));
-    this.register(addDisposableDomListener(this.textarea!, 'keypress', keyboardHelper.press, true));
-    this.register(addDisposableDomListener(this.textarea!, 'input', keyboardHelper.input, true));
+    const keyboardHelper = new KeyboardHelper(this._coreService);
+    //this.register(addDisposableDomListener(this.textarea!, 'keyup', keyboardHelper.up.bind(keyboardHelper), true));
+    this.register(addDisposableDomListener(this.textarea!, 'keydown', keyboardHelper.down.bind(keyboardHelper), true));
+    //this.register(addDisposableDomListener(this.textarea!, 'keypress', keyboardHelper.press.bind(keyboardHelper), true));
+    this.register(addDisposableDomListener(this.textarea!, 'input', keyboardHelper.input.bind(keyboardHelper), true));
 
     this.register(addDisposableDomListener(this.textarea!, 'compositionstart', () => this._compositionHelper!.compositionstart()));
     this.register(addDisposableDomListener(this.textarea!, 'compositionupdate', (e: CompositionEvent) => this._compositionHelper!.compositionupdate(e)));

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -53,6 +53,7 @@ import { Linkifier2 } from 'browser/Linkifier2';
 import { CoreBrowserService } from 'browser/services/CoreBrowserService';
 import { CoreTerminal } from 'common/CoreTerminal';
 import { ITerminalOptions as IInitializedTerminalOptions } from 'common/services/Services';
+import { KeyboardHelper } from 'browser/input/KeyboardHelper';
 
 // Let it work inside Node.js for automated testing purposes.
 const document: Document = (typeof window !== 'undefined') ? window.document : null as any;
@@ -332,9 +333,15 @@ export class Terminal extends CoreTerminal implements ITerminal {
    * Apply key handling to the terminal
    */
   private _bindKeys(): void {
-    this.register(addDisposableDomListener(this.textarea!, 'keyup', (ev: KeyboardEvent) => this._keyUp(ev), true));
-    this.register(addDisposableDomListener(this.textarea!, 'keydown', (ev: KeyboardEvent) => this._keyDown(ev), true));
-    this.register(addDisposableDomListener(this.textarea!, 'keypress', (ev: KeyboardEvent) => this._keyPress(ev), true));
+    //this.register(addDisposableDomListener(this.textarea!, 'keyup', (ev: KeyboardEvent) => this._keyUp(ev), true));
+    //this.register(addDisposableDomListener(this.textarea!, 'keydown', (ev: KeyboardEvent) => this._keyDown(ev), true));
+    //this.register(addDisposableDomListener(this.textarea!, 'keypress', (ev: KeyboardEvent) => this._keyPress(ev), true));
+    const keyboardHelper = new KeyboardHelper();
+    this.register(addDisposableDomListener(this.textarea!, 'keyup', keyboardHelper.up, true));
+    this.register(addDisposableDomListener(this.textarea!, 'keydown', keyboardHelper.down, true));
+    this.register(addDisposableDomListener(this.textarea!, 'keypress', keyboardHelper.press, true));
+    this.register(addDisposableDomListener(this.textarea!, 'input', keyboardHelper.input, true));
+
     this.register(addDisposableDomListener(this.textarea!, 'compositionstart', () => this._compositionHelper!.compositionstart()));
     this.register(addDisposableDomListener(this.textarea!, 'compositionupdate', (e: CompositionEvent) => this._compositionHelper!.compositionupdate(e)));
     this.register(addDisposableDomListener(this.textarea!, 'compositionend', () => this._compositionHelper!.compositionend()));

--- a/src/browser/input/KeyboardHelper.ts
+++ b/src/browser/input/KeyboardHelper.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2020 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+// non printable keys that never trigger an input event
+// these keys only trigger down/up events, repeated only trigger multiple down events
+const NON_PRINTABLE = [
+  // code
+  'Escape',
+  'F1',
+  'F2',
+  'F3',
+  'F4',
+  'F5',
+  'F6',
+  'F7',
+  'F8',
+  'F9',
+  'F10',
+  'F11',
+  'F12',        // some browsers/platforms support up to F24
+  'Insert',
+  'Delete',     // note: produces input if there is content in the element ({inputType: 'deleteContentForward', data: null})
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+  'Backspace',  // note: produces input if there is content in the element ({inputType: 'deleteContentBackward', data: null})
+  'NumLock',
+  'Tab',
+  'Enter',
+  'ShiftLeft',
+  'ShiftRight',
+  'ControlLeft',
+  'MetaLeft',     // windows key under chrome
+  'OSLeft',       // windows key under firefox
+  'AltLeft',
+  'AltRight',     // key: AltGraph
+  'ControlRight',
+  'ArrowUp',
+  'ArrowRight',
+  'ArrowDown',
+  'ArrowLeft'
+]
+
+// dead keys - is this layout specific?
+// dead keys trigger input on second press or a decorated char by following key
+const OPTIONAL_INPUT = [
+  // [key, code]
+  ['Dead', 'Backquote'],
+  ['Dead', 'Equal'],
+]
+
+// KeyboardEvent.getModifierState()
+const MODIFIERS = [
+  'Alt',
+  'AltGraph',
+  'CapsLock',
+  'Control',
+  //'Fn',         // on android FUNCTION key, else unsupported
+  //'FnLock',     // unsupported
+  //'Hyper',      // unsupported
+  'Meta',         // META in GTK (remappable), COMMAND in OSX, windows unsupported
+  'NumLock',      // NumLock LED is on, every number key on numpad (OSX)
+  'OS',           // WINDOWS key, not supported on OSX
+  'ScrollLock',   // ScrollLock LED is on, not supported on Linux and OSX
+  'Shift',        // while SHIFT is pressed
+  //'Super',      // unsupported
+  //'Symbol',     // unsupported
+  //'SymbolLock', // unsupported
+]
+
+// mapped modifiers on KeyboardEvent
+const MODIFIERS_MAPPED = [
+  'altKey',       // ALT or OPTION pressed
+  'ctrlKey',      // CONTROL pressed
+  'metaKey',      // META pressed - COMMAND on OSX keyboards, WINDOWS on PC keyboards
+  'shiftKey'      // SHIFT pressed
+]
+
+export class KeyboardHelper {
+  public down(ev: KeyboardEvent): boolean {
+    console.log('down', ev);
+    return true;
+  }
+  public up(ev: KeyboardEvent): boolean {
+    console.log('up', ev);
+    return true;
+  }
+  public input(ev: KeyboardEvent): boolean {
+    console.log('input', ev);
+    return true;
+  }
+  public press(ev: KeyboardEvent): boolean {
+    console.log('press', ev);
+    return true;
+  }
+}

--- a/src/browser/input/KeyboardHelper.ts
+++ b/src/browser/input/KeyboardHelper.ts
@@ -3,6 +3,8 @@
  * @license MIT
  */
 
+import { ICoreService } from 'common/services/Services';
+
 // non printable keys that never trigger an input event
 // these keys only trigger down/up events, repeated only trigger multiple down events
 const NON_PRINTABLE = [
@@ -38,6 +40,36 @@ const NON_PRINTABLE = [
   'AltLeft',
   'AltRight',     // key: AltGraph
   'ControlRight',
+  'ArrowUp',
+  'ArrowRight',
+  'ArrowDown',
+  'ArrowLeft'
+]
+
+const TERM_RELEVANT = [
+  'Escape',
+  'F1',
+  'F2',
+  'F3',
+  'F4',
+  'F5',
+  'F6',
+  'F7',
+  'F8',
+  'F9',
+  'F10',
+  'F11',
+  'F12',
+  'Insert',
+  'Delete',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+  'Backspace',
+  'NumLock',
+  'Tab',
+  'Enter',
   'ArrowUp',
   'ArrowRight',
   'ArrowDown',
@@ -80,20 +112,46 @@ const MODIFIERS_MAPPED = [
 ]
 
 export class KeyboardHelper {
+
+  constructor(
+    @ICoreService private readonly _coreService: ICoreService
+  ) {}
+
+  private _logPrintable(ev: InputEvent) {
+    console.log('PRINTABLE:', [ev.data]);
+  }
+  private _logNonPrintable(ev: KeyboardEvent) {
+    console.log('NON-PRINTABLE:', {key: ev.key, alt: ev.altKey, ctrl: ev.ctrlKey, meta: ev.metaKey, shift: ev.shiftKey});
+  }
+
   public down(ev: KeyboardEvent): boolean {
-    console.log('down', ev);
+    //console.log('down', ev);
+    if (NON_PRINTABLE.indexOf(ev.code) !== -1 || NON_PRINTABLE.indexOf(ev.key) !== -1) {
+      if (TERM_RELEVANT.indexOf(ev.code) !== -1 || TERM_RELEVANT.indexOf(ev.key) !== -1) {
+        this._logNonPrintable(ev);
+      }
+      this._cancel(ev);
+    } else if (ev.altKey || ev.ctrlKey || ev.metaKey) {
+      this._logNonPrintable(ev);
+      this._cancel(ev);
+    }
     return true;
   }
   public up(ev: KeyboardEvent): boolean {
     console.log('up', ev);
     return true;
   }
-  public input(ev: KeyboardEvent): boolean {
-    console.log('input', ev);
+  public input(ev: InputEvent): boolean {
+    if (ev.data) {
+      this._logPrintable(ev);
+      this._cancel(ev);
+    }
     return true;
   }
-  public press(ev: KeyboardEvent): boolean {
-    console.log('press', ev);
-    return true;
+
+  public _cancel(ev: Event): boolean | undefined {
+    ev.preventDefault();
+    ev.stopPropagation();
+    return false;
   }
 }


### PR DESCRIPTION
Shall fix #2151.

TODO:
- [ ] collect key and event info from systems / browsers
- [ ] create `KeyboardService`, move handlers over
- [ ] pull printables from `input` event, others from `keydown`
- [ ] special deadkey state (passthrough to next input)
- [ ] IME compat?
- [ ] How to test automatically?

@Tyriar Did some further tests with https://w3c.github.io/uievents/tools/key-event-viewer.html and some spec reading to get an idea, what we can/should use. Specwise `beforeinput` is the best event to grab pending input data, but thats currently not supported by firefox (got fixed a few weeks ago, but not yet rolled out). `input` is the second best, but only gets fired AFTER the content change was made, which is abit cumbersome (we might have to clear the textarea afterwards, not sure yet, if this might cause problems with IMEs). Featurewise `keypress` is the best event, but it is deprecated, we should not rely on it anymore. For non printable chars we can basically stick with the `keydown` handler we already have, but need to extend it to pass printables along to be caught by the later `input` event.