### PR TITLE
Validate constructor options

### DIFF
--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -1533,6 +1533,12 @@ describe('Terminal', () => {
       });
     });
   });
+  it('constructor options validation', () => {
+    expect(() => new TestTerminal({cursorStyle: undefined})).to.not.throw();
+    expect(() => new TestTerminal({tabStopWidth: 0})).to.throw('value: 0');
+    expect(() => new TestTerminal({scrollback: -10})).to.throw('value: -10');
+    expect(() => new TestTerminal({scrollSensitivity: 0})).to.throw('value: 0');
+  });
 });
 
 class TestLinkifier extends Linkifier {

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -1533,12 +1533,6 @@ describe('Terminal', () => {
       });
     });
   });
-  it('constructor options validation', () => {
-    expect(() => new TestTerminal({cursorStyle: undefined})).to.not.throw();
-    expect(() => new TestTerminal({tabStopWidth: 0})).to.throw('value: 0');
-    expect(() => new TestTerminal({scrollback: -10})).to.throw('value: -10');
-    expect(() => new TestTerminal({scrollSensitivity: 0})).to.throw('value: 0');
-  });
 });
 
 class TestLinkifier extends Linkifier {

--- a/src/common/services/OptionsService.test.ts
+++ b/src/common/services/OptionsService.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { OptionsService, DEFAULT_OPTIONS } from 'common/services/OptionsService';
+
+describe('OptionsService', () => {
+  describe('constructor', () => {
+    const originalError = console.error;
+    beforeEach(() => {
+      console.error = () => {};
+    });
+    afterEach(() => {
+      console.error = originalError;
+    });
+    it('uses default value if invalid constructor option value passed', () => {
+      assert.equal(new OptionsService({tabStopWidth: 0}).getOption('tabStopWidth'), DEFAULT_OPTIONS.tabStopWidth);
+    });
+  });
+});

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -74,7 +74,7 @@ export class OptionsService implements IOptionsService {
     for (const k of Object.keys(options)) {
       if (k in this.options) {
         const newValue = options[k as keyof IPartialTerminalOptions] as any;
-        this.options[k] = newValue;
+        this.options[k] = this._sanitizeAndValidateOption(k, newValue);
       }
     }
   }

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -73,8 +73,12 @@ export class OptionsService implements IOptionsService {
     this.options = clone(DEFAULT_OPTIONS);
     for (const k of Object.keys(options)) {
       if (k in this.options) {
-        const newValue = options[k as keyof IPartialTerminalOptions] as any;
-        this.options[k] = this._sanitizeAndValidateOption(k, newValue);
+        try {
+          const newValue = options[k as keyof IPartialTerminalOptions] as any;
+          this.options[k] = this._sanitizeAndValidateOption(k, newValue);
+        } catch (e) {
+          console.error(e);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #3063

Added high level tests for Terminal, but can move it to separate test just for `OptionsService`.