### PR TITLE
Fix cjk handling in SerializeAddon

### DIFF
--- a/addons/xterm-addon-serialize/src/SerializeAddon.api.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.api.ts
@@ -270,6 +270,35 @@ describe('SerializeAddon', () => {
     await writeSync(page, lines.join('\\r\\n'));
     assert.equal(await page.evaluate(`serializeAddon.serialize();`), expected.join('\r\n'));
   });
+
+  it('serialize CJK correctly', async () => {
+    const lines = [
+      '中文中文',
+      '12中文',
+      '中文12',
+      '1中文中文中' // this line is going to be wrapped at last character because it has line length of 11 (1+2*5)
+    ];
+    const expected = [
+      '中文中文',
+      '12中文',
+      '中文12',
+      '1中文中文',
+      '中'
+    ];
+    await writeSync(page, lines.join('\\r\\n'));
+    assert.equal(await page.evaluate(`serializeAddon.serialize();`), expected.join('\r\n'));
+  });
+
+  it('serialize CJK Mixed with tab correctly', async () => {
+    const lines = [
+      '中文\t12' // CJK mixed with tab
+    ];
+    const expected = [
+      '中文\x1b[4C12'
+    ];
+    await writeSync(page, lines.join('\\r\\n'));
+    assert.equal(await page.evaluate(`serializeAddon.serialize();`), expected.join('\r\n'));
+  });
 });
 
 function newArray<T>(initial: T | ((index: number) => T), count: number): T[] {

--- a/addons/xterm-addon-serialize/src/SerializeAddon.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.ts
@@ -138,7 +138,7 @@ class StringSerializeHandler extends BaseSerializeHandler {
     // Count number of null cells encountered after the last non-null cell and move the cursor
     // if a non-null cell is found (eg. \t or cursor move)
     if (cell.getChars() === '') {
-      this._nullCellCount++;
+      this._nullCellCount += cell.getWidth();
     } else if (this._nullCellCount > 0) {
       this._currentRow += `\x1b[${this._nullCellCount}C`;
       this._nullCellCount = 0;


### PR DESCRIPTION
Use `cell.getWidth()` to get correct cell width instead of assume 1 width of every empty cell.

https://github.com/xtermjs/xterm.js/blob/106ea62b4c5f64d7d9a9221f5fbb6270554b4212/addons/xterm-addon-serialize/src/SerializeAddon.ts#L140-L142

Fix #3066