### PR TITLE
Fix last/first line of selection sometimes not drawing

### DIFF
--- a/src/browser/renderer/SelectionRenderLayer.ts
+++ b/src/browser/renderer/SelectionRenderLayer.ts
@@ -75,6 +75,7 @@ export class SelectionRenderLayer extends BaseRenderLayer {
 
     // No need to draw the selection
     if (viewportCappedStartRow >= this._bufferService.rows || viewportCappedEndRow < 0) {
+      this._state.ydisp = this._bufferService.buffer.ydisp;
       return;
     }
 


### PR DESCRIPTION
The last ydisp wasn't being updated on early exits.

Fixes #3080