### PR TITLE
Using putout linter on xterm codebase part 2

### DIFF
--- a/bin/extract_vtfeatures.js
+++ b/bin/extract_vtfeatures.js
@@ -359,7 +359,7 @@ function empty(ar) {
 }
 
 function* parseMultiLineGen(filename, s) {
-  if (!~s.indexOf('@vt:')) {
+  if (!s.includes('@vt:')) {
     return;
   }
   const lines = s.split('\n').map(el => el.trim().replace(/[*]/, '').replace(/\s/, ''));
@@ -413,7 +413,7 @@ function parseSingleLine(filename, s) {
   const line = s.trim();
   const match = line.match(REX_VT_LINE);
   if (match !== null) {
-    if (!~TYPES.indexOf(match[2])) {
+    if (!TYPES.includes(match[2])) {
       throw new Error(`unkown vt-command type "${match[2]}" specified in "${filename}"`);
     }
     return {

--- a/bin/install-addons.js
+++ b/bin/install-addons.js
@@ -25,7 +25,7 @@ if (fs.existsSync(addonsPath)) {
 
   // walk all addon folders
   fs.readdir(addonsPath, (err, files) => {
-    files.forEach(folder => {
+    for (const folder of files) {
       const addonPath = path.join(addonsPath, folder);
 
       // install only if there are dependencies listed
@@ -51,6 +51,6 @@ if (fs.existsSync(addonsPath)) {
       } else {
         console.log('Skipped', folder);
       }
-    });
+    }
   });
 }

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -11,7 +11,7 @@ const path = require('path');
 // Setup auth
 fs.writeFileSync(`${process.env['HOME']}/.npmrc`, `//registry.npmjs.org/:_authToken=${process.env['NPM_AUTH_TOKEN']}`);
 
-const isDryRun = process.argv.indexOf('--dry') !== -1;
+const isDryRun = process.argv.includes('--dry');
 if (isDryRun) {
   console.log('Publish dry run');
 }
@@ -36,13 +36,13 @@ const addonPackageDirs = [
   path.resolve(__dirname, '../addons/xterm-addon-webgl')
 ];
 console.log(`Checking if addons need to be published`);
-addonPackageDirs.forEach(p => {
+for (const p of addonPackageDirs) {
   const addon = path.basename(p);
-  if (changedFiles.some(e => e.indexOf(addon) !== -1)) {
+  if (changedFiles.some(e => e.includes(addon))) {
     console.log(`Try publish ${addon}`);
     checkAndPublishPackage(p);
   }
-});
+}
 
 // Publish website if it's a stable release
 if (isStableRelease) {
@@ -54,7 +54,7 @@ function checkAndPublishPackage(packageDir) {
 
   // Determine if this is a stable or beta release
   const publishedVersions = getPublishedVersions(packageJson);
-  const isStableRelease = publishedVersions.indexOf(packageJson.version) === -1;
+  const isStableRelease = !publishedVersions.includes(packageJson.version);
 
   // Get the next version
   let nextVersion = isStableRelease ? packageJson.version : getNextBetaVersion(packageJson);

--- a/bin/test_api.js
+++ b/bin/test_api.js
@@ -21,7 +21,7 @@ let flagArgs = [];
 
 if (process.argv.length > 2) {
   const args = process.argv.slice(2);
-  flagArgs = args.filter(e => e.startsWith('--')).map(arg => arg.split('=')).reduce((arr, val) => arr.concat([...val], []));
+  flagArgs = args.filter(e => e.startsWith('--')).map(arg => arg.split('=')).reduce((arr, val) => arr.concat(val.split(''), []));
   console.info(flagArgs);
   // ability to inject particular test files via
   // yarn test [testFileA testFileB ...]

--- a/bin/test_api.js
+++ b/bin/test_api.js
@@ -21,7 +21,7 @@ let flagArgs = [];
 
 if (process.argv.length > 2) {
   const args = process.argv.slice(2);
-  flagArgs = args.filter(e => e.startsWith('--')).map(arg => arg.split('=')).reduce((arr, val) => arr.concat(val.split(''), []));
+  flagArgs = args.filter(e => e.startsWith('--')).map(arg => arg.split('=')).reduce((arr, val) => arr.concat([...val], []));
   console.info(flagArgs);
   // ability to inject particular test files via
   // yarn test [testFileA testFileB ...]

--- a/bin/test_mousemodes.js
+++ b/bin/test_mousemodes.js
@@ -88,19 +88,19 @@ function evalButtonCode(code) {
   if (code & 64) {
     button |= 4
   }
-  let actionS = 'press';
+  let action = 'press';
   let buttonS = reverseButtons[button];
   if (button === 3) {
     buttonS = '<none>';
-    actionS = 'release';
+    action = 'release';
   }
   if (move) {
-    actionS = 'move';
+    action = 'move';
   } else if (4 <= button && button <= 7) {
     buttonS = 'wheel';
-    actionS = button === 4 ? 'up' : button === 5 ? 'down' : button === 6 ? 'left' : 'right';
+    action = button === 4 ? 'up' : button === 5 ? 'down' : button === 6 ? 'left' : 'right';
   }
-  return {button: buttonS, action: actionS, modifier};
+  return {button: buttonS, action, modifier};
 }
 
 // protocols

--- a/src/browser/Terminal2.test.ts
+++ b/src/browser/Terminal2.test.ts
@@ -32,7 +32,7 @@ if (os.platform() === 'darwin') {
   );
 }
 // filter skipFilenames
-const FILES = TESTFILES.filter(value => SKIP_FILES.indexOf(value.split('/').slice(-1)[0]) === -1);
+const FILES = TESTFILES.filter(value => !SKIP_FILES.includes(value.split('/').slice(-1)[0]));
 
 describe('Escape Sequence Files', function(): void {
   this.timeout(1000);
@@ -104,7 +104,7 @@ describe('Escape Sequence Files', function(): void {
 function formatError(input: string, output: string, expected: string): string {
   function addLineNumber(start: number, color: string): (s: string) => string {
     let counter = start || 0;
-    return function(s: string): string {
+    return (s: string): string => {
       counter += 1;
       return '\x1b[33m' + (' ' + counter).slice(-2) + color + s;
     };

--- a/src/browser/tsconfig.json
+++ b/src/browser/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "dom",
-      "es2015",
+      "es2017"
     ],
     "outDir": "../../out",
     "types": [

--- a/src/browser/tsconfig.json
+++ b/src/browser/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": [
       "dom",
-      "es2017"
+      "es2015",
+      "es2016.Array.Include"
     ],
     "outDir": "../../out",
     "types": [

--- a/src/common/Platform.ts
+++ b/src/common/Platform.ts
@@ -17,7 +17,7 @@ const isNode = (typeof navigator === 'undefined') ? true : false;
 const userAgent = (isNode) ? 'node' : navigator.userAgent;
 const platform = (isNode) ? 'node' : navigator.platform;
 
-export const isFirefox = !!~userAgent.indexOf('Firefox');
+export const isFirefox = userAgent.includes('Firefox');
 export const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent);
 
 // Find the users platform. We use this to interpret the meta key

--- a/src/common/buffer/Buffer.test.ts
+++ b/src/common/buffer/Buffer.test.ts
@@ -700,7 +700,7 @@ describe('Buffer', () => {
             }
             const wrappedLines: number[] = [];
             for (let i = 0; i < buffer.lines.length; i++) {
-              assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+              assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
             }
           });
         });
@@ -723,7 +723,7 @@ describe('Buffer', () => {
               }
               const wrappedLines: number[] = [];
               for (let i = 0; i < buffer.lines.length; i++) {
-                assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
               }
             });
           });
@@ -754,7 +754,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines: number[] = [];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -777,7 +777,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines: number[] = [];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -814,7 +814,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines: number[] = [];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -837,7 +837,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines: number[] = [];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -891,7 +891,7 @@ describe('Buffer', () => {
             }
             const wrappedLines = [1, 3, 5];
             for (let i = 0; i < buffer.lines.length; i++) {
-              assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+              assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
             }
           });
         });
@@ -917,7 +917,7 @@ describe('Buffer', () => {
               }
               const wrappedLines = [1, 3, 5];
               for (let i = 0; i < buffer.lines.length; i++) {
-                assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
               }
             });
           });
@@ -950,7 +950,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines = [11, 13, 15];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -975,7 +975,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines = [11, 13, 15];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -1014,7 +1014,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines = [8, 10, 12];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });
@@ -1040,7 +1040,7 @@ describe('Buffer', () => {
                 }
                 const wrappedLines = [8, 10, 12];
                 for (let i = 0; i < buffer.lines.length; i++) {
-                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.indexOf(i) !== -1, `line ${i} isWrapped must equal ${wrappedLines.indexOf(i) !== -1}`);
+                  assert.equal(buffer.lines.get(i)!.isWrapped, wrappedLines.includes(i), `line ${i} isWrapped must equal ${wrappedLines.includes(i)}`);
                 }
               });
             });

--- a/src/common/input/UnicodeV6.test.ts
+++ b/src/common/input/UnicodeV6.test.ts
@@ -161,7 +161,7 @@ it('wcwidth should match all values from the old implementation', function(): vo
     //     ==> n = n >> m     e.g. m=12  000000000000FFEEDDCCBBAA99887766
     //   we are only interested in 2 LSBs, cut off higher bits
     //     ==> n = n & 3      e.g.       000000000000000000000000000000XX
-    return function (num: number): number {
+    return (num: number): number => {
       num = num | 0;  // get asm.js like optimization under V8
       if (num < 32) {
         return control | 0;

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -89,7 +89,7 @@ export class OptionsService implements IOptionsService {
     if (!(key in DEFAULT_OPTIONS)) {
       throw new Error('No option with key "' + key + '"');
     }
-    if (CONSTRUCTOR_ONLY_OPTIONS.indexOf(key) !== -1) {
+    if (CONSTRUCTOR_ONLY_OPTIONS.includes(key)) {
       throw new Error(`Option "${key}" can only be set in the constructor`);
     }
     if (this.options[key] === value) {
@@ -123,7 +123,7 @@ export class OptionsService implements IOptionsService {
           // already valid numeric value
           break;
         }
-        value = FONT_WEIGHT_OPTIONS.indexOf(value) !== -1 ? value : DEFAULT_OPTIONS[key];
+        value = FONT_WEIGHT_OPTIONS.includes(value) ? value : DEFAULT_OPTIONS[key];
         break;
       case 'cursorWidth':
         value = Math.floor(value);

--- a/src/common/tsconfig.json
+++ b/src/common/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig-library-base",
   "compilerOptions": {
     "lib": [
-      "es2017"
+      "es2015",
+      "es2016.Array.Include"
     ],
     "outDir": "../../out",
     "types": [

--- a/src/common/tsconfig.json
+++ b/src/common/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig-library-base",
   "compilerOptions": {
     "lib": [
-      "es2015"
+      "es2017"
     ],
     "outDir": "../../out",
     "types": [


### PR DESCRIPTION
Latest PR (https://github.com/xtermjs/xterm.js/pull/2953) was successfully merged, so I decide to do more checks with updated version of [putout](https://github.com/coderaiser/putout) and discuss improving codebase with rules approved earlier and I can disable any of rules that not fits to current code style :).

So here is config:

```json
{
    "rules": {
        "strict-mode": "off",
        "remove-useless-spread/object": "off",
        "remove-iife": "off",
        "convert-generic-to-shorthand": "off",
        "remove-console": "off",
        "remove-unused-variables": "off",
        "remove-useless-variables": "off",
        "apply-destructuring": "off",
        "merge-if-statements": "off",
        "convert-apply-to-spread": "off",
        "convert-math-pow": "off",
        "convert-for-to-for-of": "off",
        "convert-template-to-string": "off",
        "remove-empty": "on",
        "convert-index-of-to-includes": "on",
        "convert-for-each-to-for-of": "on",
        "apply-shorthand-properties": "on",
        "apply-numeric-separators": "off"
    },
}