### PR TITLE
feat(build): allow require from NodeJS

### DIFF
--- a/addons/xterm-addon-attach/webpack.config.js
+++ b/addons/xterm-addon-attach/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/addons/xterm-addon-fit/webpack.config.js
+++ b/addons/xterm-addon-fit/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/addons/xterm-addon-ligatures/webpack.config.js
+++ b/addons/xterm-addon-ligatures/webpack.config.js
@@ -26,7 +26,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production',
   externals: {

--- a/addons/xterm-addon-search/webpack.config.js
+++ b/addons/xterm-addon-search/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/addons/xterm-addon-serialize/webpack.config.js
+++ b/addons/xterm-addon-serialize/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/addons/xterm-addon-unicode11/webpack.config.js
+++ b/addons/xterm-addon-unicode11/webpack.config.js
@@ -32,7 +32,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/addons/xterm-addon-web-links/webpack.config.js
+++ b/addons/xterm-addon-web-links/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/addons/xterm-addon-webgl/webpack.config.js
+++ b/addons/xterm-addon-webgl/webpack.config.js
@@ -33,7 +33,8 @@ module.exports = {
     filename: mainFile,
     path: path.resolve('./lib'),
     library: addonName,
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,8 @@ module.exports = {
   output: {
     filename: 'xterm.js',
     path: path.resolve('./lib'),
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   mode: 'production'
 };


### PR DESCRIPTION
Currently when requiring `lib/xterm.js` from NodeJS you'll see this:
```
UnhandledPromiseRejectionWarning: ReferenceError: window is not defined:
at xterm.js:1 (xterm.js:1:178)
```

This fixes that issue by defining the module on self instead of window for NodeJS environments.