### PR TITLE
Fix "term.fit is not a function" error when change padding value in the demo

### DIFF
--- a/demo/client.ts
+++ b/demo/client.ts
@@ -93,7 +93,7 @@ const paddingElement = <HTMLInputElement>document.getElementById('padding');
 
 function setPadding(): void {
   term.element.style.padding = parseInt(paddingElement.value, 10).toString() + 'px';
-  term.fit();
+  addons.fit.instance.fit();
 }
 
 function getSearchOptions(e: KeyboardEvent): ISearchOptions {


### PR DESCRIPTION
When we change a padding value in the demo, a console error occurs and xterm is not correctly fitted.
![termfit](https://user-images.githubusercontent.com/29003390/96684094-0263c280-13b6-11eb-860b-30f9929e8085.png)


I replaced function call from term.fit() to addons.fit.instance.fit().