### PR TITLE
Use RenderService.dimensions instead of CharSizeService for textarea position

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -297,19 +297,23 @@ export class Terminal extends CoreTerminal implements ITerminal {
   }
 
   private _syncTextArea(): void {
-    if (!this.textarea || !this.buffer.isCursorInViewport || this._compositionHelper!.isComposing) {
+    if (!this.textarea || !this.buffer.isCursorInViewport || this._compositionHelper!.isComposing || !this._renderService) {
       return;
     }
-
-    const cellHeight = Math.ceil(this._charSizeService!.height * this.optionsService.options.lineHeight);
-    const cursorTop = this._bufferService.buffer.y * cellHeight;
-    const cursorLeft = this._bufferService.buffer.x * this._charSizeService!.width;
+    const cursorY = this.buffer.ybase + this.buffer.y;
+    const viewportRelativeCursorY = cursorY - this.buffer.ydisp;
+    const cursorX = Math.min(this.buffer.x, this.cols - 1);
+    const cellHeight = this._renderService.dimensions.actualCellHeight;
+    const width = this.buffer.lines.get(cursorY)!.getWidth(cursorX);
+    const cellWidth = this._renderService.dimensions.actualCellWidth * width;
+    const cursorTop = viewportRelativeCursorY * this._renderService.dimensions.actualCellHeight;
+    const cursorLeft = cursorX * this._renderService.dimensions.actualCellWidth;
 
     // Sync the textarea to the exact position of the composition view so the IME knows where the
     // text is.
     this.textarea.style.left = cursorLeft + 'px';
     this.textarea.style.top = cursorTop + 'px';
-    this.textarea.style.width = this._charSizeService!.width + 'px';
+    this.textarea.style.width = cellWidth +'px';
     this.textarea.style.height = cellHeight + 'px';
     this.textarea.style.lineHeight = cellHeight + 'px';
     this.textarea.style.zIndex = '-5';
@@ -438,14 +442,6 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this._charSizeService = this._instantiationService.createInstance(CharSizeService, this._document, this._helperContainer);
     this._instantiationService.setService(ICharSizeService, this._charSizeService);
 
-    this._compositionView = document.createElement('div');
-    this._compositionView.classList.add('composition-view');
-    this._compositionHelper = this._instantiationService.createInstance(CompositionHelper, this.textarea, this._compositionView);
-    this._helperContainer.appendChild(this._compositionView);
-
-    // Performance: Add viewport and helper elements from the fragment
-    this.element.appendChild(fragment);
-
     this._theme = this.options.theme || this._theme;
     this._colorManager = new ColorManager(document, this.options.allowTransparency);
     this.register(this.optionsService.onOptionChange(e => this._colorManager!.onOptionsChange(e)));
@@ -456,6 +452,14 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this._instantiationService.setService(IRenderService, this._renderService);
     this.register(this._renderService.onRenderedBufferChange(e => this._onRender.fire(e)));
     this.onResize(e => this._renderService!.resize(e.cols, e.rows));
+
+    this._compositionView = document.createElement('div');
+    this._compositionView.classList.add('composition-view');
+    this._compositionHelper = this._instantiationService.createInstance(CompositionHelper, this.textarea, this._compositionView);
+    this._helperContainer.appendChild(this._compositionView);
+
+    // Performance: Add viewport and helper elements from the fragment
+    this.element.appendChild(fragment);
 
     this._soundService = this._instantiationService.createInstance(SoundService);
     this._instantiationService.setService(ISoundService, this._soundService);

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -301,21 +301,22 @@ export class Terminal extends CoreTerminal implements ITerminal {
       return;
     }
     const cursorY = this.buffer.ybase + this.buffer.y;
-    const viewportRelativeCursorY = cursorY - this.buffer.ydisp;
+    const bufferLine = this.buffer.lines.get(cursorY);
+    if (!bufferLine) {
+      return;
+    }
     const cursorX = Math.min(this.buffer.x, this.cols - 1);
     const cellHeight = this._renderService.dimensions.actualCellHeight;
-    const bufferLine = this.buffer.lines.get(cursorY);
-    if (!bufferLine) return;
     const width = bufferLine.getWidth(cursorX);
     const cellWidth = this._renderService.dimensions.actualCellWidth * width;
-    const cursorTop = viewportRelativeCursorY * this._renderService.dimensions.actualCellHeight;
+    const cursorTop = this.buffer.y * this._renderService.dimensions.actualCellHeight;
     const cursorLeft = cursorX * this._renderService.dimensions.actualCellWidth;
 
     // Sync the textarea to the exact position of the composition view so the IME knows where the
     // text is.
     this.textarea.style.left = cursorLeft + 'px';
     this.textarea.style.top = cursorTop + 'px';
-    this.textarea.style.width = cellWidth +'px';
+    this.textarea.style.width = cellWidth + 'px';
     this.textarea.style.height = cellHeight + 'px';
     this.textarea.style.lineHeight = cellHeight + 'px';
     this.textarea.style.zIndex = '-5';

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -304,7 +304,9 @@ export class Terminal extends CoreTerminal implements ITerminal {
     const viewportRelativeCursorY = cursorY - this.buffer.ydisp;
     const cursorX = Math.min(this.buffer.x, this.cols - 1);
     const cellHeight = this._renderService.dimensions.actualCellHeight;
-    const width = this.buffer.lines.get(cursorY)!.getWidth(cursorX);
+    const bufferLine = this.buffer.lines.get(cursorY);
+    if (!bufferLine) return;
+    const width = bufferLine.getWidth(cursorX);
     const cellWidth = this._renderService.dimensions.actualCellWidth * width;
     const cursorTop = viewportRelativeCursorY * this._renderService.dimensions.actualCellHeight;
     const cursorLeft = cursorX * this._renderService.dimensions.actualCellWidth;

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -5,7 +5,7 @@
 
 import { assert } from 'chai';
 import { CompositionHelper } from 'browser/input/CompositionHelper';
-import { MockCharSizeService } from 'browser/TestUtils.test';
+import { MockCharSizeService, MockRenderService } from 'browser/TestUtils.test';
 import { MockCoreService, MockBufferService, MockOptionsService } from 'common/TestUtils.test';
 
 describe('CompositionHelper', () => {
@@ -42,7 +42,7 @@ describe('CompositionHelper', () => {
     };
     handledText = '';
     const bufferService = new MockBufferService(10, 5);
-    compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), new MockCharSizeService(10, 10), coreService);
+    compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), new MockCharSizeService(10, 10), coreService, new MockRenderService());
   });
 
   describe('Input', () => {

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -5,7 +5,7 @@
 
 import { assert } from 'chai';
 import { CompositionHelper } from 'browser/input/CompositionHelper';
-import { MockCharSizeService, MockRenderService } from 'browser/TestUtils.test';
+import { MockRenderService } from 'browser/TestUtils.test';
 import { MockCoreService, MockBufferService, MockOptionsService } from 'common/TestUtils.test';
 
 describe('CompositionHelper', () => {
@@ -42,7 +42,7 @@ describe('CompositionHelper', () => {
     };
     handledText = '';
     const bufferService = new MockBufferService(10, 5);
-    compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), new MockCharSizeService(10, 10), coreService, new MockRenderService());
+    compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), coreService, new MockRenderService());
   });
 
   describe('Input', () => {

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { ICharSizeService, IRenderService } from 'browser/services/Services';
+import { IRenderService } from 'browser/services/Services';
 import { IBufferService, ICoreService, IOptionsService } from 'common/services/Services';
 
 interface IPosition {
@@ -45,7 +45,6 @@ export class CompositionHelper {
     private readonly _compositionView: HTMLElement,
     @IBufferService private readonly _bufferService: IBufferService,
     @IOptionsService private readonly _optionsService: IOptionsService,
-    @ICharSizeService private readonly _charSizeService: ICharSizeService,
     @ICoreService private readonly _coreService: ICoreService,
     @IRenderService private readonly _renderService: IRenderService
   ) {

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -207,12 +207,10 @@ export class CompositionHelper {
     }
 
     if (this._bufferService.buffer.isCursorInViewport) {
-      const cursorY = this._bufferService.buffer.ybase + this._bufferService.buffer.y;
-      const viewportRelativeCursorY = cursorY - this._bufferService.buffer.ydisp;
       const cursorX = Math.min(this._bufferService.buffer.x, this._bufferService.cols - 1);
 
       const cellHeight = this._renderService.dimensions.actualCellHeight;
-      const cursorTop = viewportRelativeCursorY * this._renderService.dimensions.actualCellHeight;
+      const cursorTop = this._bufferService.buffer.y * this._renderService.dimensions.actualCellHeight;
       const cursorLeft = cursorX * this._renderService.dimensions.actualCellWidth;
 
       this._compositionView.style.left = cursorLeft + 'px';

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -202,7 +202,7 @@ export class CompositionHelper {
    *   necessary as the IME events across browsers are not consistently triggered.
    */
   public updateCompositionElements(dontRecurse?: boolean): void {
-    if (!this._isComposing || !this._renderService) {
+    if (!this._isComposing) {
       return;
     }
 


### PR DESCRIPTION
Fixes #3034


- Before
![Kapture 2020-11-09 at 0 44 17](https://user-images.githubusercontent.com/29003390/98469783-06506b00-2225-11eb-87f6-2a1d8eaba7b2.gif)

- After
![Kapture 2020-11-09 at 0 31 11](https://user-images.githubusercontent.com/29003390/98469809-241dd000-2225-11eb-9ed6-b0f255b3f7a0.gif)

