### PR TITLE
Incorporate shadowRoot in focus calculation.

### DIFF
--- a/src/browser/services/CoreBrowserService.ts
+++ b/src/browser/services/CoreBrowserService.ts
@@ -14,6 +14,7 @@ export class CoreBrowserService implements ICoreBrowserService {
   }
 
   public get isFocused(): boolean {
-    return document.activeElement === this._textarea && document.hasFocus();
+    const docOrShadowRoot = this._textarea.getRootNode ? this._textarea.getRootNode() as Document | ShadowRoot : document;
+    return docOrShadowRoot.activeElement === this._textarea && document.hasFocus();
   }
 }


### PR DESCRIPTION
This adds a call to getRootNode to get either the Document or the ShadowRoot to use when calculating whether the textarea has focus. This allows the cursor to render as focused when the terminal is rendered within a shadow DOM.

getRootNode is guarded for older browser compatibility (IE).
