### PR TITLE
Fix a11y violation because of using role='listitem' without role='list' parent

### DIFF
--- a/src/browser/AccessibilityManager.ts
+++ b/src/browser/AccessibilityManager.ts
@@ -56,6 +56,7 @@ export class AccessibilityManager extends Disposable {
     this._accessibilityTreeRoot.classList.add('xterm-accessibility');
 
     this._rowContainer = document.createElement('div');
+    this._rowContainer.setAttribute('role', 'list');
     this._rowContainer.classList.add('xterm-accessibility-tree');
     this._rowElements = [];
     for (let i = 0; i < this._terminal.rows; i++) {


### PR DESCRIPTION
This breaks our accessibility tests:
See:
![image](https://user-images.githubusercontent.com/47335686/98686950-2c663000-2337-11eb-9b27-530b514b6e72.png)