### PR TITLE
Make alt+click behavior configurable

### DIFF
--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -170,7 +170,7 @@ export class Terminal implements ITerminalApi {
     this._core.paste(data);
   }
   public getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'logLevel' | 'rendererType' | 'termName' | 'wordSeparator'): string;
-  public getOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'disableStdin' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'visualBell'): boolean;
+  public getOption(key: 'allowTransparency' | 'altClickMovesCursor' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'disableStdin' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'visualBell'): boolean;
   public getOption(key: 'cols' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;
   public getOption(key: 'fontWeight' | 'fontWeightBold'): FontWeight;
   public getOption(key: string): any;
@@ -182,7 +182,7 @@ export class Terminal implements ITerminalApi {
   public setOption(key: 'logLevel', value: 'debug' | 'info' | 'warn' | 'error' | 'off'): void;
   public setOption(key: 'bellStyle', value: 'none' | 'visual' | 'sound' | 'both'): void;
   public setOption(key: 'cursorStyle', value: 'block' | 'underline' | 'bar'): void;
-  public setOption(key: 'allowTransparency' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'disableStdin' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'visualBell', value: boolean): void;
+  public setOption(key: 'allowTransparency' | 'altClickMovesCursor' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'disableStdin' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'visualBell', value: boolean): void;
   public setOption(key: 'fontSize' | 'letterSpacing' | 'lineHeight' | 'tabStopWidth' | 'scrollback', value: number): void;
   public setOption(key: 'theme', value: ITheme): void;
   public setOption(key: 'cols' | 'rows', value: number): void;

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -676,7 +676,7 @@ export class SelectionService extends Disposable implements ISelectionService {
           this._bufferService.rows,
           false
         );
-        if (coordinates && coordinates[0] !== undefined && coordinates[1] !== undefined) {
+        if (this._optionsService.getOption('altClickMovesCursor') && coordinates && coordinates[0] !== undefined && coordinates[1] !== undefined) {
           const sequence = moveToCellSequence(coordinates[0] - 1, coordinates[1] - 1, this._bufferService, this._coreService.decPrivateModes.applicationCursorKeys);
           this._coreService.triggerDataEvent(sequence, true);
         }

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -667,7 +667,7 @@ export class SelectionService extends Disposable implements ISelectionService {
 
     this._removeMouseDownListeners();
 
-    if (this.selectionText.length <= 1 && timeElapsed < ALT_CLICK_MOVE_CURSOR_TIME && event.altKey) {
+    if (this.selectionText.length <= 1 && timeElapsed < ALT_CLICK_MOVE_CURSOR_TIME && event.altKey && this._optionsService.getOption('altClickMovesCursor')) {
       if (this._bufferService.buffer.ybase === this._bufferService.buffer.ydisp) {
         const coordinates = this._mouseService.getCoords(
           event,
@@ -676,7 +676,7 @@ export class SelectionService extends Disposable implements ISelectionService {
           this._bufferService.rows,
           false
         );
-        if (this._optionsService.getOption('altClickMovesCursor') && coordinates && coordinates[0] !== undefined && coordinates[1] !== undefined) {
+        if (coordinates && coordinates[0] !== undefined && coordinates[1] !== undefined) {
           const sequence = moveToCellSequence(coordinates[0] - 1, coordinates[1] - 1, this._bufferService, this._coreService.decPrivateModes.applicationCursorKeys);
           this._coreService.triggerDataEvent(sequence, true);
         }

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -50,7 +50,7 @@ export const DEFAULT_OPTIONS: ITerminalOptions = Object.freeze({
   windowOptions: {},
   windowsMode: false,
   wordSeparator: ' ()[]{}\',"`',
-
+  altClickMovesCursor: true,
   convertEol: false,
   termName: 'xterm',
   cancelEvents: false

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -220,6 +220,7 @@ export interface IPartialTerminalOptions {
 export interface ITerminalOptions {
   allowProposedApi: boolean;
   allowTransparency: boolean;
+  altClickMovesCursor: boolean;
   bellSound: string;
   bellStyle: 'none' | 'sound' /* | 'visual' | 'both' */;
   cols: number;

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -184,6 +184,7 @@ export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
 export type RendererType = 'dom' | 'canvas';
 
 export interface IPartialTerminalOptions {
+  altClickMovesCursor?: boolean;
   allowTransparency?: boolean;
   bellSound?: string;
   bellStyle?: 'none' | 'sound' /* | 'visual' | 'both' */;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -45,6 +45,11 @@ declare module 'xterm' {
     allowTransparency?: boolean;
 
     /**
+     * If enabled, alt + click will move the prompt cursor to position underneath the mouse.
+     */
+    altClickMovesCursor?: boolean;
+
+    /**
      * A data uri of the sound to use for the bell when `bellStyle = 'sound'`.
      */
     bellSound?: string;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -45,7 +45,8 @@ declare module 'xterm' {
     allowTransparency?: boolean;
 
     /**
-     * If enabled, alt + click will move the prompt cursor to position underneath the mouse.
+     * If enabled, alt + click will move the prompt cursor to position
+     * underneath the mouse. The default is true.
      */
     altClickMovesCursor?: boolean;
 


### PR DESCRIPTION
Adds a new Boolean option `altClickMovesCursor` which enables/disables the alt+click behavior that moves the prompt cursor to the location of the mouse.

Closes #3145 