### PR TITLE
fix: update font-finder to v1.1.0

### DIFF
--- a/addons/xterm-addon-ligatures/package.json
+++ b/addons/xterm-addon-ligatures/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "font-finder": "^1.0.4",
+    "font-finder": "^1.1.0",
     "font-ligatures": "^1.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Update font-finder in ligatures addon to prevent font loading errors.

fixes #3174 
