### PR TITLE
0x7f is printable in ground state

### DIFF
--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -95,8 +95,9 @@ export const VT500_TRANSITION_TABLE = (function (): TransitionTable {
 
   // set default transition
   table.setDefault(ParserAction.ERROR, ParserState.GROUND);
-  // printables
+  // printables and 7f
   table.addMany(PRINTABLES, ParserState.GROUND, ParserAction.PRINT, ParserState.GROUND);
+  table.add(0x7f, ParserState.GROUND, ParserAction.PRINT, ParserState.GROUND);
   // global anywhere rules
   for (state in states) {
     table.addMany([0x18, 0x1a, 0x99, 0x9a], state, ParserAction.EXECUTE, ParserState.GROUND);


### PR DESCRIPTION
Align with https://vt100.net/emu/dec_ansi_parser state machine ground state rules

Currently launching the test setup, opening the console and writing: `term.write(new Uint8Array([127]))` lead to an error "xterm.js: Parsing error: ...", while it seems to me that 0x7f has to be treated as printable whenever in the GROUND state (check https://vt100.net/emu/dec_ansi_parser, upper left corner).
With this fix, that basically add to the table the rule that 0x7f is to be treated as printable whenever in GROUND state (while remaining in GROUND state), it works as intended (= nothing prints, but no error).

This came up while doing some additional work on: [repl.leaningtech.com](url), that uses xterm.js as console.

This is my first contribution to this project, I agree to code of conduct, licence and all.

I hope I have followed the proper process, thanks for the great work
Best,
Carlo