### PR TITLE
async parser handler support

### DIFF
--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -753,7 +753,8 @@ describe('Terminal', () => {
         term.reset();
       }
     });
-    it('2 characters per cell over line end with autowrap', async () => {
+    it('2 characters per cell over line end with autowrap', async function (): Promise<void> {
+      this.timeout(10000);
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
@@ -767,7 +768,8 @@ describe('Terminal', () => {
         term.reset();
       }
     });
-    it('2 characters per cell over line end without autowrap', async () => {
+    it('2 characters per cell over line end without autowrap', async function (): Promise<void> {
+      this.timeout(10000);
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
@@ -785,7 +787,8 @@ describe('Terminal', () => {
         term.reset();
       }
     });
-    it('splitted surrogates', async () => {
+    it('splitted surrogates', async function (): Promise<void> {
+      this.timeout(10000);
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -55,22 +55,30 @@ describe('Terminal', () => {
     //   term.onData(() => done());
     //   term.handler('fake');
     // });
-    it('should fire the onCursorMove event', (done) => {
-      term.onCursorMove(() => done());
-      term.writeSync('foo');
+    it('should fire the onCursorMove event', () => {
+      return new Promise(async r => {
+        term.onCursorMove(() => r());
+        await term.writeP('foo');
+      });
     });
-    it('should fire the onLineFeed event', (done) => {
-      term.onLineFeed(() => done());
-      term.writeSync('\n');
+    it('should fire the onLineFeed event', () => {
+      return new Promise(async r => {
+        term.onLineFeed(() => r());
+        await term.writeP('\n');
+      });
     });
-    it('should fire a scroll event when scrollback is created', (done) => {
-      term.onScroll(() => done());
-      term.writeSync('\n'.repeat(INIT_ROWS));
+    it('should fire a scroll event when scrollback is created', () => {
+      return new Promise(async r => {
+        term.onScroll(() => r());
+        await term.writeP('\n'.repeat(INIT_ROWS));
+      });
     });
-    it('should fire a scroll event when scrollback is cleared', (done) => {
-      term.writeSync('\n'.repeat(INIT_ROWS));
-      term.onScroll(() => done());
-      term.clear();
+    it('should fire a scroll event when scrollback is cleared', () => {
+      return new Promise(async r => {
+        await term.writeP('\n'.repeat(INIT_ROWS));
+        term.onScroll(() => r());
+        term.clear();
+      });
     });
     it('should fire a key event after a keypress DOM event', (done) => {
       term.onKey(e => {
@@ -178,10 +186,10 @@ describe('Terminal', () => {
         assert.deepEqual(term.buffer.lines.get(i), term.buffer.getBlankLine(DEFAULT_ATTR_DATA));
       }
     });
-    it('should clear a buffer larger than rows', () => {
+    it('should clear a buffer larger than rows', async () => {
       // Fill the buffer with dummy rows
       for (let i = 0; i < term.rows * 2; i++) {
-        term.writeSync('test\n');
+        await term.writeP('test\n');
       }
 
       const promptLine = term.buffer.lines.get(term.buffer.ybase + term.buffer.y);
@@ -225,22 +233,24 @@ describe('Terminal', () => {
       });
       term.paste('\r\nfoo\nbar\r');
     });
-    it('should respect bracketed paste mode', done => {
-      term.onData(e => {
-        assert.equal(e, '\x1b[200~foo\x1b[201~');
-        done();
+    it('should respect bracketed paste mode', () => {
+      return new Promise(async r => {
+        term.onData(e => {
+          assert.equal(e, '\x1b[200~foo\x1b[201~');
+          r();
+        });
+        await term.writeP('\x1b[?2004h');
+        term.paste('foo');
       });
-      term.writeSync('\x1b[?2004h');
-      term.paste('foo');
     });
   });
 
   describe('scroll', () => {
     describe('scrollLines', () => {
       let startYDisp: number;
-      beforeEach(() => {
+      beforeEach(async () => {
         for (let i = 0; i < INIT_ROWS * 2; i++) {
-          term.writeSync('test\r\n');
+          await term.writeP('test\r\n');
         }
         startYDisp = INIT_ROWS + 1;
       });
@@ -273,9 +283,9 @@ describe('Terminal', () => {
 
     describe('scrollPages', () => {
       let startYDisp: number;
-      beforeEach(() => {
+      beforeEach(async () => {
         for (let i = 0; i < term.rows * 3; i++) {
-          term.writeSync('test\r\n');
+          await term.writeP('test\r\n');
         }
         startYDisp = (term.rows * 2) + 1;
       });
@@ -296,9 +306,9 @@ describe('Terminal', () => {
     });
 
     describe('scrollToTop', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         for (let i = 0; i < term.rows * 3; i++) {
-          term.writeSync('test\r\n');
+          await term.writeP('test\r\n');
         }
       });
       it('should scroll to the top', () => {
@@ -310,9 +320,9 @@ describe('Terminal', () => {
 
     describe('scrollToBottom', () => {
       let startYDisp: number;
-      beforeEach(() => {
+      beforeEach(async () => {
         for (let i = 0; i < term.rows * 3; i++) {
-          term.writeSync('test\r\n');
+          await term.writeP('test\r\n');
         }
         startYDisp = (term.rows * 2) + 1;
       });
@@ -331,9 +341,9 @@ describe('Terminal', () => {
 
     describe('scrollToLine', () => {
       let startYDisp: number;
-      beforeEach(() => {
+      beforeEach(async () => {
         for (let i = 0; i < term.rows * 3; i++) {
-          term.writeSync('test\r\n');
+          await term.writeP('test\r\n');
         }
         startYDisp = (term.rows * 2) + 1;
       });
@@ -375,10 +385,10 @@ describe('Terminal', () => {
         assert.equal(term.buffer.ydisp, term.buffer.ybase);
       });
 
-      it('should not scroll down, when a custom keydown handler prevents the event', () => {
+      it('should not scroll down, when a custom keydown handler prevents the event', async () => {
         // Add some output to the terminal
         for (let i = 0; i < term.rows * 3; i++) {
-          term.writeSync('test\r\n');
+          await term.writeP('test\r\n');
         }
         const startYDisp = (term.rows * 2) + 1;
         term.attachCustomKeyEventHandler(() => {
@@ -717,12 +727,12 @@ describe('Terminal', () => {
   });
 
   describe('unicode - surrogates', () => {
-    it('2 characters per cell', function (): void {
+    it('2 characters per cell', async function (): Promise<void> {
       this.timeout(10000);  // This is needed because istanbul patches code and slows it down
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
-        term.writeSync(high + String.fromCharCode(i));
+        await term.writeP(high + String.fromCharCode(i));
         const tchar = term.buffer.lines.get(0)!.loadCell(0, cell);
         expect(tchar.getChars()).eql(high + String.fromCharCode(i));
         expect(tchar.getChars().length).eql(2);
@@ -731,25 +741,25 @@ describe('Terminal', () => {
         term.reset();
       }
     });
-    it('2 characters at last cell', () => {
+    it('2 characters at last cell', async () => {
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.buffer.x = term.cols - 1;
-        term.writeSync(high + String.fromCharCode(i));
+        await term.writeP(high + String.fromCharCode(i));
         expect(term.buffer.lines.get(0)!.loadCell(term.buffer.x - 1, cell).getChars()).eql(high + String.fromCharCode(i));
         expect(term.buffer.lines.get(0)!.loadCell(term.buffer.x - 1, cell).getChars().length).eql(2);
         expect(term.buffer.lines.get(1)!.loadCell(0, cell).getChars()).eql('');
         term.reset();
       }
     });
-    it('2 characters per cell over line end with autowrap', () => {
+    it('2 characters per cell over line end with autowrap', async () => {
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.buffer.x = term.cols - 1;
 
-        term.writeSync('a' + high + String.fromCharCode(i));
+        await term.writeP('a' + high + String.fromCharCode(i));
         expect(term.buffer.lines.get(0)!.loadCell(term.cols - 1, cell).getChars()).eql('a');
         expect(term.buffer.lines.get(1)!.loadCell(0, cell).getChars()).eql(high + String.fromCharCode(i));
         expect(term.buffer.lines.get(1)!.loadCell(0, cell).getChars().length).eql(2);
@@ -757,17 +767,17 @@ describe('Terminal', () => {
         term.reset();
       }
     });
-    it('2 characters per cell over line end without autowrap', () => {
+    it('2 characters per cell over line end without autowrap', async () => {
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
         term.buffer.x = term.cols - 1;
-        term.writeSync('\x1b[?7l'); // Disable wraparound mode
+        await term.writeP('\x1b[?7l'); // Disable wraparound mode
         const width = wcwidth((0xD800 - 0xD800) * 0x400 + i - 0xDC00 + 0x10000);
         if (width !== 1) {
           continue;
         }
-        term.writeSync('a' + high + String.fromCharCode(i));
+        await term.writeP('a' + high + String.fromCharCode(i));
         // auto wraparound mode should cut off the rest of the line
         expect(term.buffer.lines.get(0)!.loadCell(term.cols - 1, cell).getChars()).eql(high + String.fromCharCode(i));
         expect(term.buffer.lines.get(0)!.loadCell(term.cols - 1, cell).getChars().length).eql(2);
@@ -775,12 +785,11 @@ describe('Terminal', () => {
         term.reset();
       }
     });
-    it('splitted surrogates', () => {
+    it('splitted surrogates', async () => {
       const high = String.fromCharCode(0xD800);
       const cell = new CellData();
       for (let i = 0xDC00; i <= 0xDCFF; ++i) {
-        term.writeSync(high);
-        term.writeSync(String.fromCharCode(i));
+        await term.writeP(high + String.fromCharCode(i));
         const tchar = term.buffer.lines.get(0)!.loadCell(0, cell);
         expect(tchar.getChars()).eql(high + String.fromCharCode(i));
         expect(tchar.getChars().length).eql(2);
@@ -793,16 +802,16 @@ describe('Terminal', () => {
 
   describe('unicode - combining characters', () => {
     const cell = new CellData();
-    it('café', () => {
-      term.writeSync('cafe\u0301');
+    it('café', async () => {
+      await term.writeP('cafe\u0301');
       term.buffer.lines.get(0)!.loadCell(3, cell);
       expect(cell.getChars()).eql('e\u0301');
       expect(cell.getChars().length).eql(2);
       expect(cell.getWidth()).eql(1);
     });
-    it('café - end of line', () => {
+    it('café - end of line', async () => {
       term.buffer.x = term.cols - 1 - 3;
-      term.writeSync('cafe\u0301');
+      await term.writeP('cafe\u0301');
       term.buffer.lines.get(0)!.loadCell(term.cols - 1, cell);
       expect(cell.getChars()).eql('e\u0301');
       expect(cell.getChars().length).eql(2);
@@ -812,8 +821,8 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(0);
       expect(cell.getWidth()).eql(1);
     });
-    it('multiple combined é', () => {
-      term.writeSync(Array(100).join('e\u0301'));
+    it('multiple combined é', async () => {
+      await term.writeP(Array(100).join('e\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         expect(cell.getChars()).eql('e\u0301');
@@ -825,8 +834,8 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(2);
       expect(cell.getWidth()).eql(1);
     });
-    it('multiple surrogate with combined', () => {
-      term.writeSync(Array(100).join('\uD800\uDC00\u0301'));
+    it('multiple surrogate with combined', async () => {
+      await term.writeP(Array(100).join('\uD800\uDC00\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         expect(cell.getChars()).eql('\uD800\uDC00\u0301');
@@ -842,19 +851,19 @@ describe('Terminal', () => {
 
   describe('unicode - fullwidth characters', () => {
     const cell = new CellData();
-    it('cursor movement even', () => {
+    it('cursor movement even', async () => {
       expect(term.buffer.x).eql(0);
-      term.writeSync('￥');
+      await term.writeP('￥');
       expect(term.buffer.x).eql(2);
     });
-    it('cursor movement odd', () => {
+    it('cursor movement odd', async () => {
       term.buffer.x = 1;
       expect(term.buffer.x).eql(1);
-      term.writeSync('￥');
+      await term.writeP('￥');
       expect(term.buffer.x).eql(3);
     });
-    it('line of ￥ even', () => {
-      term.writeSync(Array(50).join('￥'));
+    it('line of ￥ even', async () => {
+      await term.writeP(Array(50).join('￥'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         if (i % 2) {
@@ -872,9 +881,9 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(1);
       expect(cell.getWidth()).eql(2);
     });
-    it('line of ￥ odd', () => {
+    it('line of ￥ odd', async () => {
       term.buffer.x = 1;
-      term.writeSync(Array(50).join('￥'));
+      await term.writeP(Array(50).join('￥'));
       for (let i = 1; i < term.cols - 1; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         if (!(i % 2)) {
@@ -896,9 +905,9 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(1);
       expect(cell.getWidth()).eql(2);
     });
-    it('line of ￥ with combining odd', () => {
+    it('line of ￥ with combining odd', async () => {
       term.buffer.x = 1;
-      term.writeSync(Array(50).join('￥\u0301'));
+      await term.writeP(Array(50).join('￥\u0301'));
       for (let i = 1; i < term.cols - 1; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         if (!(i % 2)) {
@@ -920,8 +929,8 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(2);
       expect(cell.getWidth()).eql(2);
     });
-    it('line of ￥ with combining even', () => {
-      term.writeSync(Array(50).join('￥\u0301'));
+    it('line of ￥ with combining even', async () => {
+      await term.writeP(Array(50).join('￥\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         if (i % 2) {
@@ -939,9 +948,9 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(2);
       expect(cell.getWidth()).eql(2);
     });
-    it('line of surrogate fullwidth with combining odd', () => {
+    it('line of surrogate fullwidth with combining odd', async () => {
       term.buffer.x = 1;
-      term.writeSync(Array(50).join('\ud843\ude6d\u0301'));
+      await term.writeP(Array(50).join('\ud843\ude6d\u0301'));
       for (let i = 1; i < term.cols - 1; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         if (!(i % 2)) {
@@ -963,8 +972,8 @@ describe('Terminal', () => {
       expect(cell.getChars().length).eql(3);
       expect(cell.getWidth()).eql(2);
     });
-    it('line of surrogate fullwidth with combining even', () => {
-      term.writeSync(Array(50).join('\ud843\ude6d\u0301'));
+    it('line of surrogate fullwidth with combining even', async () => {
+      await term.writeP(Array(50).join('\ud843\ude6d\u0301'));
       for (let i = 0; i < term.cols; ++i) {
         term.buffer.lines.get(0)!.loadCell(i, cell);
         if (i % 2) {
@@ -986,24 +995,24 @@ describe('Terminal', () => {
 
   describe('insert mode', () => {
     const cell = new CellData();
-    it('halfwidth - all', () => {
-      term.writeSync(Array(9).join('0123456789').slice(-80));
+    it('halfwidth - all', async () => {
+      await term.writeP(Array(9).join('0123456789').slice(-80));
       term.buffer.x = 10;
       term.buffer.y = 0;
       term.write('\x1b[4h');
-      term.writeSync('abcde');
+      await term.writeP('abcde');
       expect(term.buffer.lines.get(0)!.length).eql(term.cols);
       expect(term.buffer.lines.get(0)!.loadCell(10, cell).getChars()).eql('a');
       expect(term.buffer.lines.get(0)!.loadCell(14, cell).getChars()).eql('e');
       expect(term.buffer.lines.get(0)!.loadCell(15, cell).getChars()).eql('0');
       expect(term.buffer.lines.get(0)!.loadCell(79, cell).getChars()).eql('4');
     });
-    it('fullwidth - insert', () => {
-      term.writeSync(Array(9).join('0123456789').slice(-80));
+    it('fullwidth - insert', async () => {
+      await term.writeP(Array(9).join('0123456789').slice(-80));
       term.buffer.x = 10;
       term.buffer.y = 0;
       term.write('\x1b[4h');
-      term.writeSync('￥￥￥');
+      await term.writeP('￥￥￥');
       expect(term.buffer.lines.get(0)!.length).eql(term.cols);
       expect(term.buffer.lines.get(0)!.loadCell(10, cell).getChars()).eql('￥');
       expect(term.buffer.lines.get(0)!.loadCell(11, cell).getChars()).eql('');
@@ -1011,17 +1020,17 @@ describe('Terminal', () => {
       expect(term.buffer.lines.get(0)!.loadCell(15, cell).getChars()).eql('');
       expect(term.buffer.lines.get(0)!.loadCell(79, cell).getChars()).eql('3');
     });
-    it('fullwidth - right border', () => {
-      term.writeSync(Array(41).join('￥'));
+    it('fullwidth - right border', async () => {
+      await term.writeP(Array(41).join('￥'));
       term.buffer.x = 10;
       term.buffer.y = 0;
       term.write('\x1b[4h');
-      term.writeSync('a');
+      await term.writeP('a');
       expect(term.buffer.lines.get(0)!.length).eql(term.cols);
       expect(term.buffer.lines.get(0)!.loadCell(10, cell).getChars()).eql('a');
       expect(term.buffer.lines.get(0)!.loadCell(11, cell).getChars()).eql('￥');
       expect(term.buffer.lines.get(0)!.loadCell(79, cell).getChars()).eql('');  // fullwidth char got replaced
-      term.writeSync('b');
+      await term.writeP('b');
       expect(term.buffer.lines.get(0)!.length).eql(term.cols);
       expect(term.buffer.lines.get(0)!.loadCell(11, cell).getChars()).eql('b');
       expect(term.buffer.lines.get(0)!.loadCell(12, cell).getChars()).eql('￥');
@@ -1043,85 +1052,87 @@ describe('Terminal', () => {
       linkifier.attachToDom({} as any, mouseZoneManager);
     });
 
-    function assertLinkifiesInTerminal(rowText: string, linkMatcherRegex: RegExp, links: {x1: number, y1: number, x2: number, y2: number}[], done: Mocha.Done): void {
-      terminal.writeSync(rowText);
-      linkifier.registerLinkMatcher(linkMatcherRegex, () => {});
-      linkifier.linkifyRows();
-      // Allow linkify to happen
-      setTimeout(() => {
-        assert.equal(mouseZoneManager.zones.length, links.length);
-        links.forEach((l, i) => {
-          assert.equal(mouseZoneManager.zones[i].x1, l.x1 + 1);
-          assert.equal(mouseZoneManager.zones[i].x2, l.x2 + 1);
-          assert.equal(mouseZoneManager.zones[i].y1, l.y1 + 1);
-          assert.equal(mouseZoneManager.zones[i].y2, l.y2 + 1);
-        });
-        done();
-      }, 0);
+    function assertLinkifiesInTerminal(rowText: string, linkMatcherRegex: RegExp, links: {x1: number, y1: number, x2: number, y2: number}[]): Promise<void> {
+      return new Promise(async r => {
+        await terminal.writeP(rowText);
+        linkifier.registerLinkMatcher(linkMatcherRegex, () => {});
+        linkifier.linkifyRows();
+        // Allow linkify to happen
+        setTimeout(() => {
+          assert.equal(mouseZoneManager.zones.length, links.length);
+          links.forEach((l, i) => {
+            assert.equal(mouseZoneManager.zones[i].x1, l.x1 + 1);
+            assert.equal(mouseZoneManager.zones[i].x2, l.x2 + 1);
+            assert.equal(mouseZoneManager.zones[i].y1, l.y1 + 1);
+            assert.equal(mouseZoneManager.zones[i].y2, l.y2 + 1);
+          });
+          r();
+        }, 0);
+      });
     }
 
     describe('unicode before the match', () => {
-      it('combining - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('e\u0301e\u0301e\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+      it('combining - match within one line', () => {
+        return assertLinkifiesInTerminal('e\u0301e\u0301e\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}]);
       });
-      it('combining - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('e\u0301e\u0301e\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      it('combining - match over two lines', () => {
+        return assertLinkifiesInTerminal('e\u0301e\u0301e\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}]);
       });
-      it('surrogate - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('𝄞𝄞𝄞 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+      it('surrogate - match within one line', () => {
+        return assertLinkifiesInTerminal('𝄞𝄞𝄞 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}]);
       });
-      it('surrogate - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('𝄞𝄞𝄞     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      it('surrogate - match over two lines', () => {
+        return assertLinkifiesInTerminal('𝄞𝄞𝄞     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}]);
       });
-      it('combining surrogate - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}], done);
+      it('combining surrogate - match within one line', () => {
+        return assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301 foo', /foo/, [{x1: 4, x2: 7, y1: 0, y2: 0}]);
       });
-      it('combining surrogate - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      it('combining surrogate - match over two lines', () => {
+        return assertLinkifiesInTerminal('𓂀\u0301𓂀\u0301𓂀\u0301     foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}]);
       });
-      it('fullwidth - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('１２ foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      it('fullwidth - match within one line', () => {
+        return assertLinkifiesInTerminal('１２ foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}]);
       });
-      it('fullwidth - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('１２    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      it('fullwidth - match over two lines', () => {
+        return assertLinkifiesInTerminal('１２    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}]);
       });
-      it('combining fullwidth - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('￥\u0301￥\u0301 foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      it('combining fullwidth - match within one line', () => {
+        return assertLinkifiesInTerminal('￥\u0301￥\u0301 foo', /foo/, [{x1: 5, x2: 8, y1: 0, y2: 0}]);
       });
-      it('combining fullwidth - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('￥\u0301￥\u0301    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}], done);
+      it('combining fullwidth - match over two lines', () => {
+        return assertLinkifiesInTerminal('￥\u0301￥\u0301    foo', /foo/, [{x1: 8, x2: 1, y1: 0, y2: 1}]);
       });
     });
     describe('unicode within the match', () => {
-      it('combining - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('test cafe\u0301', /cafe\u0301/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
+      it('combining - match within one line', () => {
+        return assertLinkifiesInTerminal('test cafe\u0301', /cafe\u0301/, [{x1: 5, x2: 9, y1: 0, y2: 0}]);
       });
-      it('combining - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('testtest cafe\u0301', /cafe\u0301/, [{x1: 9, x2: 3, y1: 0, y2: 1}], done);
+      it('combining - match over two lines', () => {
+        return assertLinkifiesInTerminal('testtest cafe\u0301', /cafe\u0301/, [{x1: 9, x2: 3, y1: 0, y2: 1}]);
       });
-      it('surrogate - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('test a𝄞b', /a𝄞b/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      it('surrogate - match within one line', () => {
+        return assertLinkifiesInTerminal('test a𝄞b', /a𝄞b/, [{x1: 5, x2: 8, y1: 0, y2: 0}]);
       });
-      it('surrogate - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('testtest a𝄞b', /a𝄞b/, [{x1: 9, x2: 2, y1: 0, y2: 1}], done);
+      it('surrogate - match over two lines', () => {
+        return assertLinkifiesInTerminal('testtest a𝄞b', /a𝄞b/, [{x1: 9, x2: 2, y1: 0, y2: 1}]);
       });
-      it('combining surrogate - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('test a𓂀\u0301b', /a𓂀\u0301b/, [{x1: 5, x2: 8, y1: 0, y2: 0}], done);
+      it('combining surrogate - match within one line', () => {
+        return assertLinkifiesInTerminal('test a𓂀\u0301b', /a𓂀\u0301b/, [{x1: 5, x2: 8, y1: 0, y2: 0}]);
       });
-      it('combining surrogate - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('testtest a𓂀\u0301b', /a𓂀\u0301b/, [{x1: 9, x2: 2, y1: 0, y2: 1}], done);
+      it('combining surrogate - match over two lines', () => {
+        return assertLinkifiesInTerminal('testtest a𓂀\u0301b', /a𓂀\u0301b/, [{x1: 9, x2: 2, y1: 0, y2: 1}]);
       });
-      it('fullwidth - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('test a１b', /a１b/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
+      it('fullwidth - match within one line', () => {
+        return assertLinkifiesInTerminal('test a１b', /a１b/, [{x1: 5, x2: 9, y1: 0, y2: 0}]);
       });
-      it('fullwidth - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('testtest a１b', /a１b/, [{x1: 9, x2: 3, y1: 0, y2: 1}], done);
+      it('fullwidth - match over two lines', () => {
+        return assertLinkifiesInTerminal('testtest a１b', /a１b/, [{x1: 9, x2: 3, y1: 0, y2: 1}]);
       });
-      it('combining fullwidth - match within one line', function(done: () => void): void {
-        assertLinkifiesInTerminal('test a￥\u0301b', /a￥\u0301b/, [{x1: 5, x2: 9, y1: 0, y2: 0}], done);
+      it('combining fullwidth - match within one line', () => {
+        return assertLinkifiesInTerminal('test a￥\u0301b', /a￥\u0301b/, [{x1: 5, x2: 9, y1: 0, y2: 0}]);
       });
-      it('combining fullwidth - match over two lines', function(done: () => void): void {
-        assertLinkifiesInTerminal('testtest a￥\u0301b', /a￥\u0301b/, [{x1: 9, x2: 3, y1: 0, y2: 1}], done);
+      it('combining fullwidth - match over two lines', () => {
+        return assertLinkifiesInTerminal('testtest a￥\u0301b', /a￥\u0301b/, [{x1: 9, x2: 3, y1: 0, y2: 1}]);
       });
     });
   });
@@ -1133,9 +1144,9 @@ describe('Terminal', () => {
       terminal = new TestTerminal({rows: 5, cols: 10, scrollback: 5});
     });
 
-    it('multiline ascii', () => {
+    it('multiline ascii', async () => {
       const input = 'This is ASCII text spanning multiple lines.';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < input.length; ++i) {
@@ -1144,9 +1155,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('combining e\u0301 in a sentence', () => {
+    it('combining e\u0301 in a sentence', async () => {
       const input = 'Sitting in the cafe\u0301 drinking coffee.';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 19; ++i) {
@@ -1164,9 +1175,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('multiline combining e\u0301', () => {
+    it('multiline combining e\u0301', async () => {
       const input = 'e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301e\u0301';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 2 string indices
@@ -1176,9 +1187,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('surrogate char in a sentence', () => {
+    it('surrogate char in a sentence', async () => {
       const input = 'The 𝄞 is a clef widely used in modern notation.';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 5; ++i) {
@@ -1196,9 +1207,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('multiline surrogate char', () => {
+    it('multiline surrogate char', async () => {
       const input = '𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞𝄞';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 2 string indices
@@ -1208,10 +1219,10 @@ describe('Terminal', () => {
       }
     });
 
-    it('surrogate char with combining', () => {
+    it('surrogate char with combining', async () => {
       // eye of Ra with acute accent - string length of 3
       const input = '𓂀\u0301 - the eye hiroglyph with an acute accent.';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // index 0..2 should map to 0
@@ -1223,9 +1234,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('multiline surrogate with combining', () => {
+    it('multiline surrogate with combining', async () => {
       const input = '𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301𓂀\u0301';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       // every buffer cell index contains 3 string indices
@@ -1235,9 +1246,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('fullwidth chars', () => {
+    it('fullwidth chars', async () => {
       const input = 'These １２３ are some fat numbers.';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < 6; ++i) {
@@ -1254,9 +1265,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('multiline fullwidth chars', () => {
+    it('multiline fullwidth chars', async () => {
       const input = '１２３４５６７８９０１２３４５６７８９０';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 9; i < input.length; ++i) {
@@ -1265,9 +1276,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('fullwidth combining with emoji - match emoji cell', () => {
+    it('fullwidth combining with emoji - match emoji cell', async () => {
       const input = 'Lots of ￥\u0301 make me 😃.';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       const stringIndex = s.match(/😃/)!.index!;
@@ -1275,14 +1286,14 @@ describe('Terminal', () => {
       assert(terminal.buffer.lines.get(bufferIndex[0])!.loadCell(bufferIndex[1], new CellData()).getChars(), '😃');
     });
 
-    it('multiline fullwidth chars with offset 1 (currently tests for broken behavior)', () => {
+    it('multiline fullwidth chars with offset 1 (currently tests for broken behavior)', async () => {
       const input = 'a１２３４５６７８９０１２３４５６７８９０';
       // the 'a' at the beginning moves all fullwidth chars one to the right
       // now the end of the line contains a dangling empty cell since
       // the next fullwidth char has to wrap early
       // the dangling last cell is wrongly added in the string
       // --> fixable after resolving #1685
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 10; i < input.length; ++i) {
@@ -1292,9 +1303,9 @@ describe('Terminal', () => {
       }
     });
 
-    it('test fully wrapped buffer up to last char', () => {
+    it('test fully wrapped buffer up to last char', async () => {
       const input = Array(6).join('1234567890');
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < input.length; ++i) {
@@ -1303,10 +1314,10 @@ describe('Terminal', () => {
       }
     });
 
-    it('test fully wrapped buffer up to last char with full width odd', () => {
+    it('test fully wrapped buffer up to last char with full width odd', async () => {
       const input = 'a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301'
                     + 'a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301a￥\u0301';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(input, s);
       for (let i = 0; i < input.length; ++i) {
@@ -1321,16 +1332,16 @@ describe('Terminal', () => {
       }
     });
 
-    it('should handle \t in lines correctly', () => {
+    it('should handle \t in lines correctly', async () => {
       const input = '\thttps://google.de';
-      terminal.writeSync(input);
+      await terminal.writeP(input);
       const s = terminal.buffer.iterator(true).next().content;
       assert.equal(s, Array(terminal.optionsService.options.tabStopWidth + 1).join(' ') + 'https://google.de');
     });
   });
 
   describe('BufferStringIterator', function(): void {
-    it('iterator does not overflow buffer limits', function(): void {
+    it('iterator does not overflow buffer limits', async () => {
       const terminal = new TestTerminal({rows: 5, cols: 10, scrollback: 5});
       const data = [
         'aaaaaaaaaa',
@@ -1344,7 +1355,7 @@ describe('Terminal', () => {
         'aaaaaaaaaa',
         'aaaaaaaaaa'
       ];
-      terminal.writeSync(data.join(''));
+      await terminal.writeP(data.join(''));
       // brute force test with insane values
       expect(() => {
         for (let overscan = 0; overscan < 20; ++overscan) {
@@ -1362,7 +1373,7 @@ describe('Terminal', () => {
   });
 
   describe('Windows Mode', () => {
-    it('should mark lines as wrapped when the line ends in a non-null character after a LF', () => {
+    it('should mark lines as wrapped when the line ends in a non-null character after a LF', async () => {
       const data = [
         'aaaaaaaaaa\n\r', // cannot wrap as it's the first
         'aaaaaaaaa\n\r',  // wrapped (windows mode only)
@@ -1370,19 +1381,19 @@ describe('Terminal', () => {
       ];
 
       const normalTerminal = new TestTerminal({rows: 5, cols: 10, windowsMode: false});
-      normalTerminal.writeSync(data.join(''));
+      await normalTerminal.writeP(data.join(''));
       assert.equal(normalTerminal.buffer.lines.get(0)!.isWrapped, false);
       assert.equal(normalTerminal.buffer.lines.get(1)!.isWrapped, false);
       assert.equal(normalTerminal.buffer.lines.get(2)!.isWrapped, false);
 
       const windowsModeTerminal = new TestTerminal({rows: 5, cols: 10, windowsMode: true});
-      windowsModeTerminal.writeSync(data.join(''));
+      await windowsModeTerminal.writeP(data.join(''));
       assert.equal(windowsModeTerminal.buffer.lines.get(0)!.isWrapped, false);
       assert.equal(windowsModeTerminal.buffer.lines.get(1)!.isWrapped, true, 'This line should wrap in Windows mode as the previous line ends in a non-null character');
       assert.equal(windowsModeTerminal.buffer.lines.get(2)!.isWrapped, false);
     });
 
-    it('should mark lines as wrapped when the line ends in a non-null character after a CUP', () => {
+    it('should mark lines as wrapped when the line ends in a non-null character after a CUP', async () => {
       const data = [
         'aaaaaaaaaa\x1b[2;1H', // cannot wrap as it's the first
         'aaaaaaaaa\x1b[3;1H',  // wrapped (windows mode only)
@@ -1390,22 +1401,22 @@ describe('Terminal', () => {
       ];
 
       const normalTerminal = new TestTerminal({rows: 5, cols: 10, windowsMode: false});
-      normalTerminal.writeSync(data.join(''));
+      await normalTerminal.writeP(data.join(''));
       assert.equal(normalTerminal.buffer.lines.get(0)!.isWrapped, false);
       assert.equal(normalTerminal.buffer.lines.get(1)!.isWrapped, false);
       assert.equal(normalTerminal.buffer.lines.get(2)!.isWrapped, false);
 
       const windowsModeTerminal = new TestTerminal({rows: 5, cols: 10, windowsMode: true});
-      windowsModeTerminal.writeSync(data.join(''));
+      await windowsModeTerminal.writeP(data.join(''));
       assert.equal(windowsModeTerminal.buffer.lines.get(0)!.isWrapped, false);
       assert.equal(windowsModeTerminal.buffer.lines.get(1)!.isWrapped, true, 'This line should wrap in Windows mode as the previous line ends in a non-null character');
       assert.equal(windowsModeTerminal.buffer.lines.get(2)!.isWrapped, false);
     });
   });
-  it('convertEol setting', function(): void {
+  it('convertEol setting', async () => {
     // not converting
     const termNotConverting = new TestTerminal({cols: 15, rows: 10});
-    termNotConverting.writeSync('Hello\nWorld');
+    await termNotConverting.writeP('Hello\nWorld');
     expect(termNotConverting.buffer.lines.get(0)!.translateToString(false)).equals('Hello          ');
     expect(termNotConverting.buffer.lines.get(1)!.translateToString(false)).equals('     World     ');
     expect(termNotConverting.buffer.lines.get(0)!.translateToString(true)).equals('Hello');
@@ -1413,7 +1424,7 @@ describe('Terminal', () => {
 
     // converting
     const termConverting = new TestTerminal({cols: 15, rows: 10, convertEol: true});
-    termConverting.writeSync('Hello\nWorld');
+    await termConverting.writeP('Hello\nWorld');
     expect(termConverting.buffer.lines.get(0)!.translateToString(false)).equals('Hello          ');
     expect(termConverting.buffer.lines.get(1)!.translateToString(false)).equals('World          ');
     expect(termConverting.buffer.lines.get(0)!.translateToString(true)).equals('Hello');
@@ -1434,54 +1445,54 @@ describe('Terminal', () => {
       beforeEach(() => {
         term = new TestTerminal({cols: 5, rows: 5, scrollback: 1});
       });
-      it('SL (scrollLeft)', () => {
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[ @');
+      it('SL (scrollLeft)', async () => {
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[ @');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '2345', '2345', '2345', '2345', '2345']);
-        term.writeSync('\x1b[0 @');
+        await term.writeP('\x1b[0 @');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '345', '345', '345', '345', '345']);
-        term.writeSync('\x1b[2 @');
+        await term.writeP('\x1b[2 @');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '5', '5', '5', '5', '5']);
       });
-      it('SR (scrollRight)', () => {
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[ A');
+      it('SR (scrollRight)', async () => {
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[ A');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', ' 1234', ' 1234', ' 1234', ' 1234', ' 1234']);
-        term.writeSync('\x1b[0 A');
+        await term.writeP('\x1b[0 A');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '  123', '  123', '  123', '  123', '  123']);
-        term.writeSync('\x1b[2 A');
+        await term.writeP('\x1b[2 A');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '    1', '    1', '    1', '    1', '    1']);
       });
-      it('insertColumns (DECIC)', () => {
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[3;3H');
-        term.writeSync('\x1b[\'}');
+      it('insertColumns (DECIC)', async () => {
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[3;3H');
+        await term.writeP('\x1b[\'}');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '12 34', '12 34', '12 34', '12 34', '12 34']);
         term.reset();
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[3;3H');
-        term.writeSync('\x1b[1\'}');
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[3;3H');
+        await term.writeP('\x1b[1\'}');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '12 34', '12 34', '12 34', '12 34', '12 34']);
         term.reset();
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[3;3H');
-        term.writeSync('\x1b[2\'}');
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[3;3H');
+        await term.writeP('\x1b[2\'}');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '12  3', '12  3', '12  3', '12  3', '12  3']);
       });
-      it('deleteColumns (DECDC)', () => {
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[3;3H');
-        term.writeSync('\x1b[\'~');
+      it('deleteColumns (DECDC)', async () => {
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[3;3H');
+        await term.writeP('\x1b[\'~');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '1245', '1245', '1245', '1245', '1245']);
         term.reset();
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[3;3H');
-        term.writeSync('\x1b[1\'~');
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[3;3H');
+        await term.writeP('\x1b[1\'~');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '1245', '1245', '1245', '1245', '1245']);
         term.reset();
-        term.writeSync('12345'.repeat(6));
-        term.writeSync('\x1b[3;3H');
-        term.writeSync('\x1b[2\'~');
+        await term.writeP('12345'.repeat(6));
+        await term.writeP('\x1b[3;3H');
+        await term.writeP('\x1b[2\'~');
         assert.deepEqual(getLines(term, term.rows + 1), ['12345', '125', '125', '125', '125', '125']);
       });
     });
@@ -1494,41 +1505,41 @@ describe('Terminal', () => {
       });
 
       describe('reverseWraparound set', () => {
-        it('should not reverse outside of scroll margins', () => {
+        it('should not reverse outside of scroll margins', async () => {
           // prepare buffer content
-          term.writeSync('#####abcdefghijklmnopqrstuvwxy');
+          await term.writeP('#####abcdefghijklmnopqrstuvwxy');
           assert.deepEqual(getLines(term, 6), ['#####', 'abcde', 'fghij', 'klmno', 'pqrst', 'uvwxy']);
           assert.equal(term.buffer.ydisp, 1);
           assert.equal(term.buffer.x, 5);
           assert.equal(term.buffer.y, 4);
-          term.writeSync(ttyBS.repeat(100));
+          await term.writeP(ttyBS.repeat(100));
           assert.deepEqual(getLines(term, 6), ['#####', 'abcde', 'fghij', 'klmno', 'pqrst', '    y']);
 
-          term.writeSync('\x1b[?45h');
-          term.writeSync('uvwxy');
+          await term.writeP('\x1b[?45h');
+          await term.writeP('uvwxy');
 
           // set top/bottom to 1/3 (0-based)
-          term.writeSync('\x1b[2;4r');
+          await term.writeP('\x1b[2;4r');
           // place cursor below scroll bottom
           term.buffer.x = 5;
           term.buffer.y = 4;
-          term.writeSync(ttyBS.repeat(100));
+          await term.writeP(ttyBS.repeat(100));
           assert.deepEqual(getLines(term, 6), ['#####', 'abcde', 'fghij', 'klmno', 'pqrst', '     ']);
 
-          term.writeSync('uvwxy');
+          await term.writeP('uvwxy');
           // place cursor within scroll margins
           term.buffer.x = 5;
           term.buffer.y = 3;
-          term.writeSync(ttyBS.repeat(100));
+          await term.writeP(ttyBS.repeat(100));
           assert.deepEqual(getLines(term, 6), ['#####', 'abcde', '     ', '     ', '     ', 'uvwxy']);
           assert.equal(term.buffer.x, 0);
           assert.equal(term.buffer.y, term.buffer.scrollTop);  // stops at 0, scrollTop
 
-          term.writeSync('fghijklmnopqrst');
+          await term.writeP('fghijklmnopqrst');
           // place cursor above scroll top
           term.buffer.x = 5;
           term.buffer.y = 0;
-          term.writeSync(ttyBS.repeat(100));
+          await term.writeP(ttyBS.repeat(100));
           assert.deepEqual(getLines(term, 6), ['#####', '     ', 'fghij', 'klmno', 'pqrst', 'uvwxy']);
         });
       });
@@ -1542,22 +1553,22 @@ describe('Terminal', () => {
     let markers: IMarker[];
     let disposeStack: IMarker[];
     let term: TestTerminal;
-    beforeEach(() => {
+    beforeEach(async () => {
       term = new TestTerminal({});
       markers = [];
       disposeStack = [];
       term.optionsService.setOption('scrollback', 1);
       term.resize(10, 5);
       markers.push(term.buffers.active.addMarker(term.buffers.active.y));
-      term.writeSync('\x1b[r0\r\n');
+      await term.writeP('\x1b[r0\r\n');
       markers.push(term.buffers.active.addMarker(term.buffers.active.y));
-      term.writeSync('1\r\n');
+      await term.writeP('1\r\n');
       markers.push(term.buffers.active.addMarker(term.buffers.active.y));
-      term.writeSync('2\r\n');
+      await term.writeP('2\r\n');
       markers.push(term.buffers.active.addMarker(term.buffers.active.y));
-      term.writeSync('3\r\n');
+      await term.writeP('3\r\n');
       markers.push(term.buffers.active.addMarker(term.buffers.active.y));
-      term.writeSync('4');
+      await term.writeP('4');
       for (let i = 0; i < markers.length; ++i) {
         const marker = markers[i];
         marker.onDispose(() => disposeStack.push(marker));
@@ -1566,15 +1577,15 @@ describe('Terminal', () => {
     it('initial', () => {
       assert.deepEqual(markers.map(m => m.line), [0, 1, 2, 3, 4]);
     });
-    it('should dispose on normal trim off the top', () => {
+    it('should dispose on normal trim off the top', async () => {
       // moves top line into scrollback
-      term.writeSync('\n');
+      await term.writeP('\n');
       assert.deepEqual(disposeStack, []);
       // trims first marker
-      term.writeSync('\n');
+      await term.writeP('\n');
       assert.deepEqual(disposeStack, [markers[0]]);
       // trims second marker
-      term.writeSync('\n');
+      await term.writeP('\n');
       assert.deepEqual(disposeStack, [markers[0], markers[1]]);
       // trimmed marker objs should be disposed
       assert.deepEqual(disposeStack.map(el => el.isDisposed), [true, true]);
@@ -1582,14 +1593,14 @@ describe('Terminal', () => {
       // trimmed markers should contain line -1
       assert.deepEqual(disposeStack.map(el => el.line), [-1, -1]);
     });
-    it('should dispose on DL', () => {
-      term.writeSync('\x1b[3;1H');  // move cursor to 0, 2
-      term.writeSync('\x1b[2M');    // delete 2 lines
+    it('should dispose on DL', async () => {
+      await term.writeP('\x1b[3;1H');  // move cursor to 0, 2
+      await term.writeP('\x1b[2M');    // delete 2 lines
       assert.deepEqual(disposeStack, [markers[2], markers[3]]);
     });
-    it('should dispose on IL', () => {
-      term.writeSync('\x1b[3;1H');  // move cursor to 0, 2
-      term.writeSync('\x1b[2L');    // insert 2 lines
+    it('should dispose on IL', async () => {
+      await term.writeP('\x1b[3;1H');  // move cursor to 0, 2
+      await term.writeP('\x1b[2L');    // insert 2 lines
       assert.deepEqual(disposeStack, [markers[4], markers[3]]);
       assert.deepEqual(markers.map(el => el.line), [0, 1, 4, -1, -1]);
     });

--- a/src/browser/Terminal2.test.ts
+++ b/src/browser/Terminal2.test.ts
@@ -74,7 +74,7 @@ describe('Escape Sequence Files', function(): void {
       let content = '';
       const OSC_CODE = 12345;
       await new Promise(resolve => {
-        customHandler = term.addOscHandler(OSC_CODE, () => {
+        customHandler = term.registerOscHandler(OSC_CODE, () => {
           // grab terminal viewport content
           content = terminalToString(term);
           resolve();

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -78,16 +78,16 @@ export class MockTerminal implements ITerminal {
   public attachCustomKeyEventHandler(customKeyEventHandler: (event: KeyboardEvent) => boolean): void {
     throw new Error('Method not implemented.');
   }
-  public addCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean): IDisposable {
+  public registerCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean | Promise<boolean>): IDisposable {
     throw new Error('Method not implemented.');
   }
-  public addDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean): IDisposable {
+  public registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean | Promise<boolean>): IDisposable {
     throw new Error('Method not implemented.');
   }
-  public addEscHandler(id: IFunctionIdentifier, handler: () => boolean): IDisposable {
+  public registerEscHandler(id: IFunctionIdentifier, handler: () => boolean | Promise<boolean>): IDisposable {
     throw new Error('Method not implemented.');
   }
-  public addOscHandler(ident: number, callback: (data: string) => boolean): IDisposable {
+  public registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable {
     throw new Error('Method not implemented.');
   }
   public registerLinkMatcher(regex: RegExp, handler: (event: MouseEvent, uri: string) => boolean | void, options?: ILinkMatcherOptions): number {

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -21,6 +21,9 @@ export class TestTerminal extends Terminal {
   public get curAttrData(): IAttributeData { return (this as any)._inputHandler._curAttrData; }
   public keyDown(ev: any): boolean | undefined { return this._keyDown(ev); }
   public keyPress(ev: any): boolean { return this._keyPress(ev); }
+  public writeP(data: string | Uint8Array): Promise<void> {
+    return new Promise(r => this.write(data, r));
+  }
 }
 
 export class MockTerminal implements ITerminal {

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -52,10 +52,10 @@ export interface IPublicTerminal extends IDisposable {
   resize(columns: number, rows: number): void;
   open(parent: HTMLElement): void;
   attachCustomKeyEventHandler(customKeyEventHandler: (event: KeyboardEvent) => boolean): void;
-  addCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean): IDisposable;
-  addDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean): IDisposable;
-  addEscHandler(id: IFunctionIdentifier, callback: () => boolean): IDisposable;
-  addOscHandler(ident: number, callback: (data: string) => boolean): IDisposable;
+  registerCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean | Promise<boolean>): IDisposable;
+  registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean | Promise<boolean>): IDisposable;
+  registerEscHandler(id: IFunctionIdentifier, callback: () => boolean | Promise<boolean>): IDisposable;
+  registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable;
   registerLinkMatcher(regex: RegExp, handler: (event: MouseEvent, uri: string) => void, options?: ILinkMatcherOptions): number;
   deregisterLinkMatcher(matcherId: number): void;
   registerLinkProvider(linkProvider: ILinkProvider): IDisposable;

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -292,28 +292,28 @@ class BufferLineApiView implements IBufferLineApi {
 class ParserApi implements IParser {
   constructor(private _core: ITerminal) { }
 
-  public registerCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean): IDisposable {
-    return this._core.addCsiHandler(id, (params: IParams) => callback(params.toArray()));
+  public registerCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean | Promise<boolean>): IDisposable {
+    return this._core.registerCsiHandler(id, (params: IParams) => callback(params.toArray()));
   }
-  public addCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean): IDisposable {
+  public addCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean | Promise<boolean>): IDisposable {
     return this.registerCsiHandler(id, callback);
   }
-  public registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean): IDisposable {
-    return this._core.addDcsHandler(id, (data: string, params: IParams) => callback(data, params.toArray()));
+  public registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean | Promise<boolean>): IDisposable {
+    return this._core.registerDcsHandler(id, (data: string, params: IParams) => callback(data, params.toArray()));
   }
-  public addDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean): IDisposable {
+  public addDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean | Promise<boolean>): IDisposable {
     return this.registerDcsHandler(id, callback);
   }
-  public registerEscHandler(id: IFunctionIdentifier, handler: () => boolean): IDisposable {
-    return this._core.addEscHandler(id, handler);
+  public registerEscHandler(id: IFunctionIdentifier, handler: () => boolean | Promise<boolean>): IDisposable {
+    return this._core.registerEscHandler(id, handler);
   }
-  public addEscHandler(id: IFunctionIdentifier, handler: () => boolean): IDisposable {
+  public addEscHandler(id: IFunctionIdentifier, handler: () => boolean | Promise<boolean>): IDisposable {
     return this.registerEscHandler(id, handler);
   }
-  public registerOscHandler(ident: number, callback: (data: string) => boolean): IDisposable {
-    return this._core.addOscHandler(ident, callback);
+  public registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable {
+    return this._core.registerOscHandler(ident, callback);
   }
-  public addOscHandler(ident: number, callback: (data: string) => boolean): IDisposable {
+  public addOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable {
     return this.registerOscHandler(ident, callback);
   }
 }

--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -278,23 +278,23 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
   }
 
   /** Add handler for ESC escape sequence. See xterm.d.ts for details. */
-  public addEscHandler(id: IFunctionIdentifier, callback: () => boolean): IDisposable {
-    return this._inputHandler.addEscHandler(id, callback);
+  public registerEscHandler(id: IFunctionIdentifier, callback: () => boolean | Promise<boolean>): IDisposable {
+    return this._inputHandler.registerEscHandler(id, callback);
   }
 
   /** Add handler for DCS escape sequence. See xterm.d.ts for details. */
-  public addDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean): IDisposable {
-    return this._inputHandler.addDcsHandler(id, callback);
+  public registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean | Promise<boolean>): IDisposable {
+    return this._inputHandler.registerDcsHandler(id, callback);
   }
 
   /** Add handler for CSI escape sequence. See xterm.d.ts for details. */
-  public addCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean): IDisposable {
-    return this._inputHandler.addCsiHandler(id, callback);
+  public registerCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean | Promise<boolean>): IDisposable {
+    return this._inputHandler.registerCsiHandler(id, callback);
   }
 
   /** Add handler for OSC escape sequence. See xterm.d.ts for details. */
-  public addOscHandler(ident: number, callback: (data: string) => boolean): IDisposable {
-    return this._inputHandler.addOscHandler(ident, callback);
+  public registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable {
+    return this._inputHandler.registerOscHandler(ident, callback);
   }
 
   protected _setup(): void {
@@ -332,7 +332,7 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
     if (!this._windowsMode) {
       const disposables: IDisposable[] = [];
       disposables.push(this.onLineFeed(updateWindowsModeWrappedState.bind(null, this._bufferService)));
-      disposables.push(this.addCsiHandler({ final: 'H' }, () => {
+      disposables.push(this.registerCsiHandler({ final: 'H' }, () => {
         updateWindowsModeWrappedState(this._bufferService);
         return false;
       }));

--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -125,7 +125,17 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
     this._writeBuffer.write(data, callback);
   }
 
+  /**
+   * Write data to terminal synchonously.
+   * 
+   * This method is unreliable with async parser handlers, thus should not
+   * be used anymore. If you need blocking semantics on data input consider
+   * `write` with a callback instead.
+   * 
+   * @deprecated Unreliable, will be removed soon.
+   */
   public writeSync(data: string | Uint8Array): void {
+    console.error('writeSync is unreliable and will be removed soon.');
     this._writeBuffer.writeSync(data);
   }
 

--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -109,7 +109,7 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
     this.register(this.optionsService.onOptionChange(key => this._updateOptions(key)));
 
     // Setup WriteBuffer
-    this._writeBuffer = new WriteBuffer(data => this._inputHandler.parse(data));
+    this._writeBuffer = new WriteBuffer((data, promiseResult) => this._inputHandler.parse(data, promiseResult));
   }
 
   public dispose(): void {

--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -127,11 +127,11 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
 
   /**
    * Write data to terminal synchonously.
-   * 
+   *
    * This method is unreliable with async parser handlers, thus should not
    * be used anymore. If you need blocking semantics on data input consider
    * `write` with a callback instead.
-   * 
+   *
    * @deprecated Unreliable, will be removed soon.
    */
   public writeSync(data: string | Uint8Array): void {

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -41,6 +41,18 @@ class TestInputHandler extends InputHandler {
   public get windowTitleStack(): string[] { return this._windowTitleStack; }
   public get iconNameStack(): string[] { return this._iconNameStack; }
   public parseAnsiColorChange(data: string): IAnsiColorChangeEvent | null { return this._parseAnsiColorChange(data); }
+
+  /**
+   * Promise based parse call to await the full resolve of given input data.
+   * This is useful to test async handlers in inputhandler directly.
+   */
+  public async parseP(data: string | Uint8Array): Promise<void> {
+    let result: Promise<boolean> | void;
+    let prev: boolean | undefined;
+    while (result = this.parse(data, prev)) {
+      prev = await result;
+    }
+  }
 }
 
 describe('InputHandler', () => {
@@ -118,7 +130,7 @@ describe('InputHandler', () => {
   describe('setMode', () => {
     it('should toggle bracketedPasteMode', () => {
       const coreService = new MockCoreService();
-      const inputHandler = new InputHandler(new MockBufferService(80, 30), new MockCharsetService(), coreService, new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      const inputHandler = new TestInputHandler(new MockBufferService(80, 30), new MockCharsetService(), coreService, new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
       // Set bracketed paste mode
       inputHandler.setModePrivate(Params.fromArray([2004]));
       assert.equal(coreService.decPrivateModes.bracketedPasteMode, true);
@@ -134,15 +146,15 @@ describe('InputHandler', () => {
       return result;
     }
 
-    it('insertChars', function(): void {
+    it('insertChars', async () => {
       const bufferService = new MockBufferService(80, 30);
-      const inputHandler = new InputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      const inputHandler = new TestInputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
 
       // insert some data in first and second line
-      inputHandler.parse(Array(bufferService.cols - 9).join('a'));
-      inputHandler.parse('1234567890');
-      inputHandler.parse(Array(bufferService.cols - 9).join('a'));
-      inputHandler.parse('1234567890');
+      await inputHandler.parseP(Array(bufferService.cols - 9).join('a'));
+      await inputHandler.parseP('1234567890');
+      await inputHandler.parseP(Array(bufferService.cols - 9).join('a'));
+      await inputHandler.parseP('1234567890');
       const line1: IBufferLine = bufferService.buffer.lines.get(0)!;
       expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '1234567890');
 
@@ -171,15 +183,15 @@ describe('InputHandler', () => {
       expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '          ');
       expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a'));
     });
-    it('deleteChars', function(): void {
+    it('deleteChars', async () => {
       const bufferService = new MockBufferService(80, 30);
-      const inputHandler = new InputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      const inputHandler = new TestInputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
 
       // insert some data in first and second line
-      inputHandler.parse(Array(bufferService.cols - 9).join('a'));
-      inputHandler.parse('1234567890');
-      inputHandler.parse(Array(bufferService.cols - 9).join('a'));
-      inputHandler.parse('1234567890');
+      await inputHandler.parseP(Array(bufferService.cols - 9).join('a'));
+      await inputHandler.parseP('1234567890');
+      await inputHandler.parseP(Array(bufferService.cols - 9).join('a'));
+      await inputHandler.parseP('1234567890');
       const line1: IBufferLine = bufferService.buffer.lines.get(0)!;
       expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '1234567890');
 
@@ -211,14 +223,14 @@ describe('InputHandler', () => {
       expect(line1.translateToString(false)).equals(Array(bufferService.cols - 9).join('a') + '          ');
       expect(line1.translateToString(true)).equals(Array(bufferService.cols - 9).join('a'));
     });
-    it('eraseInLine', function(): void {
+    it('eraseInLine', async () => {
       const bufferService = new MockBufferService(80, 30);
-      const inputHandler = new InputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      const inputHandler = new TestInputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
 
       // fill 6 lines to test 3 different states
-      inputHandler.parse(Array(bufferService.cols + 1).join('a'));
-      inputHandler.parse(Array(bufferService.cols + 1).join('a'));
-      inputHandler.parse(Array(bufferService.cols + 1).join('a'));
+      await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
+      await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
+      await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
 
       // params[0] - right erase
       bufferService.buffer.y = 0;
@@ -239,12 +251,12 @@ describe('InputHandler', () => {
       expect(bufferService.buffer.lines.get(2)!.translateToString(false)).equals(Array(bufferService.cols + 1).join(' '));
 
     });
-    it('eraseInDisplay', function(): void {
+    it('eraseInDisplay', async () => {
       const bufferService = new MockBufferService(80, 7);
-      const inputHandler = new InputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      const inputHandler = new TestInputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
 
       // fill display with a's
-      for (let i = 0; i < bufferService.rows; ++i) inputHandler.parse(Array(bufferService.cols + 1).join('a'));
+      for (let i = 0; i < bufferService.rows; ++i) await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
 
       // params [0] - right and below erase
       bufferService.buffer.y = 5;
@@ -272,7 +284,7 @@ describe('InputHandler', () => {
       // reset
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 0;
-      for (let i = 0; i < bufferService.rows; ++i) inputHandler.parse(Array(bufferService.cols + 1).join('a'));
+      for (let i = 0; i < bufferService.rows; ++i) await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
 
       // params [1] - left and above
       bufferService.buffer.y = 5;
@@ -300,7 +312,7 @@ describe('InputHandler', () => {
       // reset
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 0;
-      for (let i = 0; i < bufferService.rows; ++i) inputHandler.parse(Array(bufferService.cols + 1).join('a'));
+      for (let i = 0; i < bufferService.rows; ++i) await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
 
       // params [2] - whole screen
       bufferService.buffer.y = 5;
@@ -328,9 +340,9 @@ describe('InputHandler', () => {
       // reset and add a wrapped line
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 0;
-      inputHandler.parse(Array(bufferService.cols + 1).join('a')); // line 0
-      inputHandler.parse(Array(bufferService.cols + 10).join('a')); // line 1 and 2
-      for (let i = 3; i < bufferService.rows; ++i) inputHandler.parse(Array(bufferService.cols + 1).join('a'));
+      await inputHandler.parseP(Array(bufferService.cols + 1).join('a')); // line 0
+      await inputHandler.parseP(Array(bufferService.cols + 10).join('a')); // line 1 and 2
+      for (let i = 3; i < bufferService.rows; ++i) await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
 
       // params[1] left and above with wrap
       // confirm precondition that line 2 is wrapped
@@ -343,9 +355,9 @@ describe('InputHandler', () => {
       // reset and add a wrapped line
       bufferService.buffer.y = 0;
       bufferService.buffer.x = 0;
-      inputHandler.parse(Array(bufferService.cols + 1).join('a')); // line 0
-      inputHandler.parse(Array(bufferService.cols + 10).join('a')); // line 1 and 2
-      for (let i = 3; i < bufferService.rows; ++i) inputHandler.parse(Array(bufferService.cols + 1).join('a'));
+      await inputHandler.parseP(Array(bufferService.cols + 1).join('a')); // line 0
+      await inputHandler.parseP(Array(bufferService.cols + 10).join('a')); // line 1 and 2
+      for (let i = 3; i < bufferService.rows; ++i) await inputHandler.parseP(Array(bufferService.cols + 1).join('a'));
 
       // params[1] left and above with wrap
       // confirm precondition that line 2 is wrapped
@@ -358,45 +370,45 @@ describe('InputHandler', () => {
   });
   describe('print', () => {
     it('should not cause an infinite loop (regression test)', () => {
-      const inputHandler = new InputHandler(new MockBufferService(80, 30), new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      const inputHandler = new TestInputHandler(new MockBufferService(80, 30), new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
       const container = new Uint32Array(10);
       container[0] = 0x200B;
       inputHandler.print(container, 0, 1);
     });
-    it('should clear cells to the right on early wrap-around', () => {
+    it('should clear cells to the right on early wrap-around', async () => {
       bufferService.resize(5, 5);
       optionsService.options.scrollback = 1;
-      inputHandler.parse('12345');
+      await inputHandler.parseP('12345');
       bufferService.buffer.x = 0;
-      inputHandler.parse('￥￥￥');
+      await inputHandler.parseP('￥￥￥');
       assert.deepEqual(getLines(bufferService, 2), ['￥￥', '￥']);
     });
   });
 
   describe('alt screen', () => {
     let bufferService: IBufferService;
-    let handler: InputHandler;
+    let handler: TestInputHandler;
 
     beforeEach(() => {
       bufferService = new MockBufferService(80, 30);
-      handler = new InputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
+      handler = new TestInputHandler(bufferService, new MockCharsetService(), new MockCoreService(), new MockDirtyRowService(), new MockLogService(), new MockOptionsService(), new MockCoreMouseService(), new MockUnicodeService());
     });
-    it('should handle DECSET/DECRST 47 (alt screen buffer)', () => {
-      handler.parse('\x1b[?47h\r\n\x1b[31mJUNK\x1b[?47lTEST');
+    it('should handle DECSET/DECRST 47 (alt screen buffer)', async () => {
+      await handler.parseP('\x1b[?47h\r\n\x1b[31mJUNK\x1b[?47lTEST');
       expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('');
       expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('    TEST');
       // Text color of 'TEST' should be red
       expect((bufferService.buffer.lines.get(1)!.loadCell(4, new CellData()).getFgColor())).to.equal(1);
     });
-    it('should handle DECSET/DECRST 1047 (alt screen buffer)', () => {
-      handler.parse('\x1b[?1047h\r\n\x1b[31mJUNK\x1b[?1047lTEST');
+    it('should handle DECSET/DECRST 1047 (alt screen buffer)', async () => {
+      await handler.parseP('\x1b[?1047h\r\n\x1b[31mJUNK\x1b[?1047lTEST');
       expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('');
       expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('    TEST');
       // Text color of 'TEST' should be red
       expect((bufferService.buffer.lines.get(1)!.loadCell(4, new CellData()).getFgColor())).to.equal(1);
     });
-    it('should handle DECSET/DECRST 1048 (alt screen cursor)', () => {
-      handler.parse('\x1b[?1048h\r\n\x1b[31mJUNK\x1b[?1048lTEST');
+    it('should handle DECSET/DECRST 1048 (alt screen cursor)', async () => {
+      await handler.parseP('\x1b[?1048h\r\n\x1b[31mJUNK\x1b[?1048lTEST');
       expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('TEST');
       expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('JUNK');
       // Text color of 'TEST' should be default
@@ -404,166 +416,166 @@ describe('InputHandler', () => {
       // Text color of 'JUNK' should be red
       expect((bufferService.buffer.lines.get(1)!.loadCell(0, new CellData()).getFgColor())).to.equal(1);
     });
-    it('should handle DECSET/DECRST 1049 (alt screen buffer+cursor)', () => {
-      handler.parse('\x1b[?1049h\r\n\x1b[31mJUNK\x1b[?1049lTEST');
+    it('should handle DECSET/DECRST 1049 (alt screen buffer+cursor)', async () => {
+      await handler.parseP('\x1b[?1049h\r\n\x1b[31mJUNK\x1b[?1049lTEST');
       expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('TEST');
       expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('');
       // Text color of 'TEST' should be default
       expect(bufferService.buffer.lines.get(0)!.loadCell(0, new CellData()).fg).to.equal(DEFAULT_ATTR_DATA.fg);
     });
-    it('should handle DECSET/DECRST 1049 - maintains saved cursor for alt buffer', () => {
-      handler.parse('\x1b[?1049h\r\n\x1b[31m\x1b[s\x1b[?1049lTEST');
+    it('should handle DECSET/DECRST 1049 - maintains saved cursor for alt buffer', async () => {
+      await handler.parseP('\x1b[?1049h\r\n\x1b[31m\x1b[s\x1b[?1049lTEST');
       expect(bufferService.buffer.translateBufferLineToString(0, true)).to.equal('TEST');
       // Text color of 'TEST' should be default
       expect(bufferService.buffer.lines.get(0)!.loadCell(0, new CellData()).fg).to.equal(DEFAULT_ATTR_DATA.fg);
-      handler.parse('\x1b[?1049h\x1b[uTEST');
+      await handler.parseP('\x1b[?1049h\x1b[uTEST');
       expect(bufferService.buffer.translateBufferLineToString(1, true)).to.equal('TEST');
       // Text color of 'TEST' should be red
       expect((bufferService.buffer.lines.get(1)!.loadCell(0, new CellData()).getFgColor())).to.equal(1);
     });
-    it('should handle DECSET/DECRST 1049 - clears alt buffer with erase attributes', () => {
-      handler.parse('\x1b[42m\x1b[?1049h');
+    it('should handle DECSET/DECRST 1049 - clears alt buffer with erase attributes', async () => {
+      await handler.parseP('\x1b[42m\x1b[?1049h');
       // Buffer should be filled with green background
       expect(bufferService.buffer.lines.get(20)!.loadCell(10, new CellData()).getBgColor()).to.equal(2);
     });
   });
 
   describe('text attributes', () => {
-    it('bold', () => {
-      inputHandler.parse('\x1b[1m');
+    it('bold', async () => {
+      await inputHandler.parseP('\x1b[1m');
       assert.equal(!!inputHandler.curAttrData.isBold(), true);
-      inputHandler.parse('\x1b[22m');
+      await inputHandler.parseP('\x1b[22m');
       assert.equal(!!inputHandler.curAttrData.isBold(), false);
     });
-    it('dim', () => {
-      inputHandler.parse('\x1b[2m');
+    it('dim', async () => {
+      await inputHandler.parseP('\x1b[2m');
       assert.equal(!!inputHandler.curAttrData.isDim(), true);
-      inputHandler.parse('\x1b[22m');
+      await inputHandler.parseP('\x1b[22m');
       assert.equal(!!inputHandler.curAttrData.isDim(), false);
     });
-    it('italic', () => {
-      inputHandler.parse('\x1b[3m');
+    it('italic', async () => {
+      await inputHandler.parseP('\x1b[3m');
       assert.equal(!!inputHandler.curAttrData.isItalic(), true);
-      inputHandler.parse('\x1b[23m');
+      await inputHandler.parseP('\x1b[23m');
       assert.equal(!!inputHandler.curAttrData.isItalic(), false);
     });
-    it('underline', () => {
-      inputHandler.parse('\x1b[4m');
+    it('underline', async () => {
+      await inputHandler.parseP('\x1b[4m');
       assert.equal(!!inputHandler.curAttrData.isUnderline(), true);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(!!inputHandler.curAttrData.isUnderline(), false);
     });
-    it('blink', () => {
-      inputHandler.parse('\x1b[5m');
+    it('blink', async () => {
+      await inputHandler.parseP('\x1b[5m');
       assert.equal(!!inputHandler.curAttrData.isBlink(), true);
-      inputHandler.parse('\x1b[25m');
+      await inputHandler.parseP('\x1b[25m');
       assert.equal(!!inputHandler.curAttrData.isBlink(), false);
     });
-    it('inverse', () => {
-      inputHandler.parse('\x1b[7m');
+    it('inverse', async () => {
+      await inputHandler.parseP('\x1b[7m');
       assert.equal(!!inputHandler.curAttrData.isInverse(), true);
-      inputHandler.parse('\x1b[27m');
+      await inputHandler.parseP('\x1b[27m');
       assert.equal(!!inputHandler.curAttrData.isInverse(), false);
     });
-    it('invisible', () => {
-      inputHandler.parse('\x1b[8m');
+    it('invisible', async () => {
+      await inputHandler.parseP('\x1b[8m');
       assert.equal(!!inputHandler.curAttrData.isInvisible(), true);
-      inputHandler.parse('\x1b[28m');
+      await inputHandler.parseP('\x1b[28m');
       assert.equal(!!inputHandler.curAttrData.isInvisible(), false);
     });
-    it('colormode palette 16', () => {
+    it('colormode palette 16', async () => {
       assert.equal(inputHandler.curAttrData.getFgColorMode(), 0); // DEFAULT
       assert.equal(inputHandler.curAttrData.getBgColorMode(), 0); // DEFAULT
       // lower 8 colors
       for (let i = 0; i < 8; ++i) {
-        inputHandler.parse(`\x1b[${i + 30};${i + 40}m`);
+        await inputHandler.parseP(`\x1b[${i + 30};${i + 40}m`);
         assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_P16);
         assert.equal(inputHandler.curAttrData.getFgColor(), i);
         assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_P16);
         assert.equal(inputHandler.curAttrData.getBgColor(), i);
       }
       // reset to DEFAULT
-      inputHandler.parse(`\x1b[39;49m`);
+      await inputHandler.parseP(`\x1b[39;49m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), 0);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), 0);
     });
-    it('colormode palette 256', () => {
+    it('colormode palette 256', async () => {
       assert.equal(inputHandler.curAttrData.getFgColorMode(), 0); // DEFAULT
       assert.equal(inputHandler.curAttrData.getBgColorMode(), 0); // DEFAULT
       // lower 8 colors
       for (let i = 0; i < 256; ++i) {
-        inputHandler.parse(`\x1b[38;5;${i};48;5;${i}m`);
+        await inputHandler.parseP(`\x1b[38;5;${i};48;5;${i}m`);
         assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_P256);
         assert.equal(inputHandler.curAttrData.getFgColor(), i);
         assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_P256);
         assert.equal(inputHandler.curAttrData.getBgColor(), i);
       }
       // reset to DEFAULT
-      inputHandler.parse(`\x1b[39;49m`);
+      await inputHandler.parseP(`\x1b[39;49m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), 0);
       assert.equal(inputHandler.curAttrData.getFgColor(), -1);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), 0);
       assert.equal(inputHandler.curAttrData.getBgColor(), -1);
     });
-    it('colormode RGB', () => {
+    it('colormode RGB', async () => {
       assert.equal(inputHandler.curAttrData.getFgColorMode(), 0); // DEFAULT
       assert.equal(inputHandler.curAttrData.getBgColorMode(), 0); // DEFAULT
-      inputHandler.parse(`\x1b[38;2;1;2;3;48;2;4;5;6m`);
+      await inputHandler.parseP(`\x1b[38;2;1;2;3;48;2;4;5;6m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_RGB);
       assert.equal(inputHandler.curAttrData.getFgColor(), 1 << 16 | 2 << 8 | 3);
       assert.deepEqual(AttributeData.toColorRGB(inputHandler.curAttrData.getFgColor()), [1, 2, 3]);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_RGB);
       assert.deepEqual(AttributeData.toColorRGB(inputHandler.curAttrData.getBgColor()), [4, 5, 6]);
       // reset to DEFAULT
-      inputHandler.parse(`\x1b[39;49m`);
+      await inputHandler.parseP(`\x1b[39;49m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), 0);
       assert.equal(inputHandler.curAttrData.getFgColor(), -1);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), 0);
       assert.equal(inputHandler.curAttrData.getBgColor(), -1);
     });
-    it('colormode transition RGB to 256', () => {
+    it('colormode transition RGB to 256', async () => {
       // enter RGB for FG and BG
-      inputHandler.parse(`\x1b[38;2;1;2;3;48;2;4;5;6m`);
+      await inputHandler.parseP(`\x1b[38;2;1;2;3;48;2;4;5;6m`);
       // enter 256 for FG and BG
-      inputHandler.parse(`\x1b[38;5;255;48;5;255m`);
+      await inputHandler.parseP(`\x1b[38;5;255;48;5;255m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_P256);
       assert.equal(inputHandler.curAttrData.getFgColor(), 255);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_P256);
       assert.equal(inputHandler.curAttrData.getBgColor(), 255);
     });
-    it('colormode transition RGB to 16', () => {
+    it('colormode transition RGB to 16', async () => {
       // enter RGB for FG and BG
-      inputHandler.parse(`\x1b[38;2;1;2;3;48;2;4;5;6m`);
+      await inputHandler.parseP(`\x1b[38;2;1;2;3;48;2;4;5;6m`);
       // enter 16 for FG and BG
-      inputHandler.parse(`\x1b[37;47m`);
+      await inputHandler.parseP(`\x1b[37;47m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_P16);
       assert.equal(inputHandler.curAttrData.getFgColor(), 7);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_P16);
       assert.equal(inputHandler.curAttrData.getBgColor(), 7);
     });
-    it('colormode transition 16 to 256', () => {
+    it('colormode transition 16 to 256', async () => {
       // enter 16 for FG and BG
-      inputHandler.parse(`\x1b[37;47m`);
+      await inputHandler.parseP(`\x1b[37;47m`);
       // enter 256 for FG and BG
-      inputHandler.parse(`\x1b[38;5;255;48;5;255m`);
+      await inputHandler.parseP(`\x1b[38;5;255;48;5;255m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_P256);
       assert.equal(inputHandler.curAttrData.getFgColor(), 255);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_P256);
       assert.equal(inputHandler.curAttrData.getBgColor(), 255);
     });
-    it('colormode transition 256 to 16', () => {
+    it('colormode transition 256 to 16', async () => {
       // enter 256 for FG and BG
-      inputHandler.parse(`\x1b[38;5;255;48;5;255m`);
+      await inputHandler.parseP(`\x1b[38;5;255;48;5;255m`);
       // enter 16 for FG and BG
-      inputHandler.parse(`\x1b[37;47m`);
+      await inputHandler.parseP(`\x1b[37;47m`);
       assert.equal(inputHandler.curAttrData.getFgColorMode(), Attributes.CM_P16);
       assert.equal(inputHandler.curAttrData.getFgColor(), 7);
       assert.equal(inputHandler.curAttrData.getBgColorMode(), Attributes.CM_P16);
       assert.equal(inputHandler.curAttrData.getBgColor(), 7);
     });
-    it('should zero missing RGB values', () => {
-      inputHandler.parse(`\x1b[38;2;1;2;3m`);
-      inputHandler.parse(`\x1b[38;2;5m`);
+    it('should zero missing RGB values', async () => {
+      await inputHandler.parseP(`\x1b[38;2;1;2;3m`);
+      await inputHandler.parseP(`\x1b[38;2;5m`);
       assert.deepEqual(AttributeData.toColorRGB(inputHandler.curAttrData.getFgColor()), [5, 0, 0]);
     });
   });
@@ -573,141 +585,141 @@ describe('InputHandler', () => {
       inputHandler2 = new TestInputHandler(bufferService, new MockCharsetService(), coreService, new MockDirtyRowService(), new MockLogService(), optionsService, new MockCoreMouseService(), new MockUnicodeService());
     });
     describe('should equal to semicolon', () => {
-      it('CSI 38:2::50:100:150 m', () => {
+      it('CSI 38:2::50:100:150 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;50;100;150m');
-        inputHandler.parse('\x1b[38:2::50:100:150m');
+        await inputHandler2.parseP('\x1b[38;2;50;100;150m');
+        await inputHandler.parseP('\x1b[38:2::50:100:150m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 150);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38:2::50:100: m', () => {
+      it('CSI 38:2::50:100: m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;50;100;m');
-        inputHandler.parse('\x1b[38:2::50:100:m');
+        await inputHandler2.parseP('\x1b[38;2;50;100;m');
+        await inputHandler.parseP('\x1b[38:2::50:100:m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38:2::50:: m', () => {
+      it('CSI 38:2::50:: m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;50;;m');
-        inputHandler.parse('\x1b[38:2::50::m');
+        await inputHandler2.parseP('\x1b[38;2;50;;m');
+        await inputHandler.parseP('\x1b[38:2::50::m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 0 << 8 | 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38:2:::: m', () => {
+      it('CSI 38:2:::: m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;;;m');
-        inputHandler.parse('\x1b[38:2::::m');
+        await inputHandler2.parseP('\x1b[38;2;;;m');
+        await inputHandler.parseP('\x1b[38:2::::m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 0 << 16 | 0 << 8 | 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38;2::50:100:150 m', () => {
+      it('CSI 38;2::50:100:150 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;50;100;150m');
-        inputHandler.parse('\x1b[38;2::50:100:150m');
+        await inputHandler2.parseP('\x1b[38;2;50;100;150m');
+        await inputHandler.parseP('\x1b[38;2::50:100:150m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 150);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38;2;50:100:150 m', () => {
+      it('CSI 38;2;50:100:150 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;50;100;150m');
-        inputHandler.parse('\x1b[38;2;50:100:150m');
+        await inputHandler2.parseP('\x1b[38;2;50;100;150m');
+        await inputHandler.parseP('\x1b[38;2;50:100:150m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 150);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38;2;50;100:150 m', () => {
+      it('CSI 38;2;50;100:150 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2;50;100;150m');
-        inputHandler.parse('\x1b[38;2;50;100:150m');
+        await inputHandler2.parseP('\x1b[38;2;50;100;150m');
+        await inputHandler.parseP('\x1b[38;2;50;100:150m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 150);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38:5:50 m', () => {
+      it('CSI 38:5:50 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;5;50m');
-        inputHandler.parse('\x1b[38:5:50m');
+        await inputHandler2.parseP('\x1b[38;5;50m');
+        await inputHandler.parseP('\x1b[38:5:50m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFF, 50);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38:5: m', () => {
+      it('CSI 38:5: m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;5;m');
-        inputHandler.parse('\x1b[38:5:m');
+        await inputHandler2.parseP('\x1b[38;5;m');
+        await inputHandler.parseP('\x1b[38:5:m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFF, 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38;5:50 m', () => {
+      it('CSI 38;5:50 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;5;50m');
-        inputHandler.parse('\x1b[38;5:50m');
+        await inputHandler2.parseP('\x1b[38;5;50m');
+        await inputHandler.parseP('\x1b[38;5:50m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFF, 50);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
     });
     describe('should fill early sequence end with default of 0', () => {
-      it('CSI 38:2 m', () => {
+      it('CSI 38:2 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;2m');
-        inputHandler.parse('\x1b[38:2m');
+        await inputHandler2.parseP('\x1b[38;2m');
+        await inputHandler.parseP('\x1b[38:2m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 0 << 16 | 0 << 8 | 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 38:5 m', () => {
+      it('CSI 38:5 m', async () => {
         inputHandler.curAttrData.fg = 0xFFFFFFFF;
         inputHandler2.curAttrData.fg = 0xFFFFFFFF;
-        inputHandler2.parse('\x1b[38;5m');
-        inputHandler.parse('\x1b[38:5m');
+        await inputHandler2.parseP('\x1b[38;5m');
+        await inputHandler.parseP('\x1b[38:5m');
         assert.equal(inputHandler2.curAttrData.fg & 0xFF, 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
     });
     describe('should not interfere with leading/following SGR attrs', () => {
-      it('CSI 1 ; 38:2::50:100:150 ; 4 m', () => {
-        inputHandler2.parse('\x1b[1;38;2;50;100;150;4m');
-        inputHandler.parse('\x1b[1;38:2::50:100:150;4m');
+      it('CSI 1 ; 38:2::50:100:150 ; 4 m', async () => {
+        await inputHandler2.parseP('\x1b[1;38;2;50;100;150;4m');
+        await inputHandler.parseP('\x1b[1;38:2::50:100:150;4m');
         assert.equal(!!inputHandler2.curAttrData.isBold(), true);
         assert.equal(!!inputHandler2.curAttrData.isUnderline(), true);
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 150);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 1 ; 38:2::50:100: ; 4 m', () => {
-        inputHandler2.parse('\x1b[1;38;2;50;100;;4m');
-        inputHandler.parse('\x1b[1;38:2::50:100:;4m');
+      it('CSI 1 ; 38:2::50:100: ; 4 m', async () => {
+        await inputHandler2.parseP('\x1b[1;38;2;50;100;;4m');
+        await inputHandler.parseP('\x1b[1;38:2::50:100:;4m');
         assert.equal(!!inputHandler2.curAttrData.isBold(), true);
         assert.equal(!!inputHandler2.curAttrData.isUnderline(), true);
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 1 ; 38:2::50:100 ; 4 m', () => {
-        inputHandler2.parse('\x1b[1;38;2;50;100;;4m');
-        inputHandler.parse('\x1b[1;38:2::50:100;4m');
+      it('CSI 1 ; 38:2::50:100 ; 4 m', async () => {
+        await inputHandler2.parseP('\x1b[1;38;2;50;100;;4m');
+        await inputHandler.parseP('\x1b[1;38:2::50:100;4m');
         assert.equal(!!inputHandler2.curAttrData.isBold(), true);
         assert.equal(!!inputHandler2.curAttrData.isUnderline(), true);
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 50 << 16 | 100 << 8 | 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 1 ; 38:2:: ; 4 m', () => {
-        inputHandler2.parse('\x1b[1;38;2;;;;4m');
-        inputHandler.parse('\x1b[1;38:2::;4m');
+      it('CSI 1 ; 38:2:: ; 4 m', async () => {
+        await inputHandler2.parseP('\x1b[1;38;2;;;;4m');
+        await inputHandler.parseP('\x1b[1;38:2::;4m');
         assert.equal(!!inputHandler2.curAttrData.isBold(), true);
         assert.equal(!!inputHandler2.curAttrData.isUnderline(), true);
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 0);
         assert.equal(inputHandler.curAttrData.fg, inputHandler2.curAttrData.fg);
       });
-      it('CSI 1 ; 38;2:: ; 4 m', () => {
-        inputHandler2.parse('\x1b[1;38;2;;;;4m');
-        inputHandler.parse('\x1b[1;38;2::;4m');
+      it('CSI 1 ; 38;2:: ; 4 m', async () => {
+        await inputHandler2.parseP('\x1b[1;38;2;;;;4m');
+        await inputHandler.parseP('\x1b[1;38;2::;4m');
         assert.equal(!!inputHandler2.curAttrData.isBold(), true);
         assert.equal(!!inputHandler2.curAttrData.isUnderline(), true);
         assert.equal(inputHandler2.curAttrData.fg & 0xFFFFFF, 0);
@@ -719,372 +731,372 @@ describe('InputHandler', () => {
     beforeEach(() => {
       bufferService.resize(10, 10);
     });
-    it('cursor forward (CUF)', () => {
-      inputHandler.parse('\x1b[C');
+    it('cursor forward (CUF)', async () => {
+      await inputHandler.parseP('\x1b[C');
       assert.deepEqual(getCursor(bufferService), [1, 0]);
-      inputHandler.parse('\x1b[1C');
+      await inputHandler.parseP('\x1b[1C');
       assert.deepEqual(getCursor(bufferService), [2, 0]);
-      inputHandler.parse('\x1b[4C');
+      await inputHandler.parseP('\x1b[4C');
       assert.deepEqual(getCursor(bufferService), [6, 0]);
-      inputHandler.parse('\x1b[100C');
+      await inputHandler.parseP('\x1b[100C');
       assert.deepEqual(getCursor(bufferService), [9, 0]);
       // should not change y
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 4;
-      inputHandler.parse('\x1b[C');
+      await inputHandler.parseP('\x1b[C');
       assert.deepEqual(getCursor(bufferService), [9, 4]);
     });
-    it('cursor backward (CUB)', () => {
-      inputHandler.parse('\x1b[D');
+    it('cursor backward (CUB)', async () => {
+      await inputHandler.parseP('\x1b[D');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[1D');
+      await inputHandler.parseP('\x1b[1D');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       // place cursor at end of first line
-      inputHandler.parse('\x1b[100C');
-      inputHandler.parse('\x1b[D');
+      await inputHandler.parseP('\x1b[100C');
+      await inputHandler.parseP('\x1b[D');
       assert.deepEqual(getCursor(bufferService), [8, 0]);
-      inputHandler.parse('\x1b[1D');
+      await inputHandler.parseP('\x1b[1D');
       assert.deepEqual(getCursor(bufferService), [7, 0]);
-      inputHandler.parse('\x1b[4D');
+      await inputHandler.parseP('\x1b[4D');
       assert.deepEqual(getCursor(bufferService), [3, 0]);
-      inputHandler.parse('\x1b[100D');
+      await inputHandler.parseP('\x1b[100D');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       // should not change y
       bufferService.buffer.x = 4;
       bufferService.buffer.y = 4;
-      inputHandler.parse('\x1b[D');
+      await inputHandler.parseP('\x1b[D');
       assert.deepEqual(getCursor(bufferService), [3, 4]);
     });
-    it('cursor down (CUD)', () => {
-      inputHandler.parse('\x1b[B');
+    it('cursor down (CUD)', async () => {
+      await inputHandler.parseP('\x1b[B');
       assert.deepEqual(getCursor(bufferService), [0, 1]);
-      inputHandler.parse('\x1b[1B');
+      await inputHandler.parseP('\x1b[1B');
       assert.deepEqual(getCursor(bufferService), [0, 2]);
-      inputHandler.parse('\x1b[4B');
+      await inputHandler.parseP('\x1b[4B');
       assert.deepEqual(getCursor(bufferService), [0, 6]);
-      inputHandler.parse('\x1b[100B');
+      await inputHandler.parseP('\x1b[100B');
       assert.deepEqual(getCursor(bufferService), [0, 9]);
       // should not change x
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 0;
-      inputHandler.parse('\x1b[B');
+      await inputHandler.parseP('\x1b[B');
       assert.deepEqual(getCursor(bufferService), [8, 1]);
     });
-    it('cursor up (CUU)', () => {
-      inputHandler.parse('\x1b[A');
+    it('cursor up (CUU)', async () => {
+      await inputHandler.parseP('\x1b[A');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[1A');
+      await inputHandler.parseP('\x1b[1A');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       // place cursor at beginning of last row
-      inputHandler.parse('\x1b[100B');
-      inputHandler.parse('\x1b[A');
+      await inputHandler.parseP('\x1b[100B');
+      await inputHandler.parseP('\x1b[A');
       assert.deepEqual(getCursor(bufferService), [0, 8]);
-      inputHandler.parse('\x1b[1A');
+      await inputHandler.parseP('\x1b[1A');
       assert.deepEqual(getCursor(bufferService), [0, 7]);
-      inputHandler.parse('\x1b[4A');
+      await inputHandler.parseP('\x1b[4A');
       assert.deepEqual(getCursor(bufferService), [0, 3]);
-      inputHandler.parse('\x1b[100A');
+      await inputHandler.parseP('\x1b[100A');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       // should not change x
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 9;
-      inputHandler.parse('\x1b[A');
+      await inputHandler.parseP('\x1b[A');
       assert.deepEqual(getCursor(bufferService), [8, 8]);
     });
-    it('cursor next line (CNL)', () => {
-      inputHandler.parse('\x1b[E');
+    it('cursor next line (CNL)', async () => {
+      await inputHandler.parseP('\x1b[E');
       assert.deepEqual(getCursor(bufferService), [0, 1]);
-      inputHandler.parse('\x1b[1E');
+      await inputHandler.parseP('\x1b[1E');
       assert.deepEqual(getCursor(bufferService), [0, 2]);
-      inputHandler.parse('\x1b[4E');
+      await inputHandler.parseP('\x1b[4E');
       assert.deepEqual(getCursor(bufferService), [0, 6]);
-      inputHandler.parse('\x1b[100E');
+      await inputHandler.parseP('\x1b[100E');
       assert.deepEqual(getCursor(bufferService), [0, 9]);
       // should reset x to zero
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 0;
-      inputHandler.parse('\x1b[E');
+      await inputHandler.parseP('\x1b[E');
       assert.deepEqual(getCursor(bufferService), [0, 1]);
     });
-    it('cursor previous line (CPL)', () => {
-      inputHandler.parse('\x1b[F');
+    it('cursor previous line (CPL)', async () => {
+      await inputHandler.parseP('\x1b[F');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[1F');
+      await inputHandler.parseP('\x1b[1F');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       // place cursor at beginning of last row
-      inputHandler.parse('\x1b[100E');
-      inputHandler.parse('\x1b[F');
+      await inputHandler.parseP('\x1b[100E');
+      await inputHandler.parseP('\x1b[F');
       assert.deepEqual(getCursor(bufferService), [0, 8]);
-      inputHandler.parse('\x1b[1F');
+      await inputHandler.parseP('\x1b[1F');
       assert.deepEqual(getCursor(bufferService), [0, 7]);
-      inputHandler.parse('\x1b[4F');
+      await inputHandler.parseP('\x1b[4F');
       assert.deepEqual(getCursor(bufferService), [0, 3]);
-      inputHandler.parse('\x1b[100F');
+      await inputHandler.parseP('\x1b[100F');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       // should reset x to zero
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 9;
-      inputHandler.parse('\x1b[F');
+      await inputHandler.parseP('\x1b[F');
       assert.deepEqual(getCursor(bufferService), [0, 8]);
     });
-    it('cursor character absolute (CHA)', () => {
-      inputHandler.parse('\x1b[G');
+    it('cursor character absolute (CHA)', async () => {
+      await inputHandler.parseP('\x1b[G');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[1G');
+      await inputHandler.parseP('\x1b[1G');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[2G');
+      await inputHandler.parseP('\x1b[2G');
       assert.deepEqual(getCursor(bufferService), [1, 0]);
-      inputHandler.parse('\x1b[5G');
+      await inputHandler.parseP('\x1b[5G');
       assert.deepEqual(getCursor(bufferService), [4, 0]);
-      inputHandler.parse('\x1b[100G');
+      await inputHandler.parseP('\x1b[100G');
       assert.deepEqual(getCursor(bufferService), [9, 0]);
     });
-    it('cursor position (CUP)', () => {
+    it('cursor position (CUP)', async () => {
       bufferService.buffer.x = 5;
       bufferService.buffer.y = 5;
-      inputHandler.parse('\x1b[H');
+      await inputHandler.parseP('\x1b[H');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       bufferService.buffer.x = 5;
       bufferService.buffer.y = 5;
-      inputHandler.parse('\x1b[1H');
+      await inputHandler.parseP('\x1b[1H');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       bufferService.buffer.x = 5;
       bufferService.buffer.y = 5;
-      inputHandler.parse('\x1b[1;1H');
+      await inputHandler.parseP('\x1b[1;1H');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
       bufferService.buffer.x = 5;
       bufferService.buffer.y = 5;
-      inputHandler.parse('\x1b[8H');
+      await inputHandler.parseP('\x1b[8H');
       assert.deepEqual(getCursor(bufferService), [0, 7]);
       bufferService.buffer.x = 5;
       bufferService.buffer.y = 5;
-      inputHandler.parse('\x1b[;8H');
+      await inputHandler.parseP('\x1b[;8H');
       assert.deepEqual(getCursor(bufferService), [7, 0]);
       bufferService.buffer.x = 5;
       bufferService.buffer.y = 5;
-      inputHandler.parse('\x1b[100;100H');
+      await inputHandler.parseP('\x1b[100;100H');
       assert.deepEqual(getCursor(bufferService), [9, 9]);
     });
-    it('horizontal position absolute (HPA)', () => {
-      inputHandler.parse('\x1b[`');
+    it('horizontal position absolute (HPA)', async () => {
+      await inputHandler.parseP('\x1b[`');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[1`');
+      await inputHandler.parseP('\x1b[1`');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[2`');
+      await inputHandler.parseP('\x1b[2`');
       assert.deepEqual(getCursor(bufferService), [1, 0]);
-      inputHandler.parse('\x1b[5`');
+      await inputHandler.parseP('\x1b[5`');
       assert.deepEqual(getCursor(bufferService), [4, 0]);
-      inputHandler.parse('\x1b[100`');
+      await inputHandler.parseP('\x1b[100`');
       assert.deepEqual(getCursor(bufferService), [9, 0]);
     });
-    it('horizontal position relative (HPR)', () => {
-      inputHandler.parse('\x1b[a');
+    it('horizontal position relative (HPR)', async () => {
+      await inputHandler.parseP('\x1b[a');
       assert.deepEqual(getCursor(bufferService), [1, 0]);
-      inputHandler.parse('\x1b[1a');
+      await inputHandler.parseP('\x1b[1a');
       assert.deepEqual(getCursor(bufferService), [2, 0]);
-      inputHandler.parse('\x1b[4a');
+      await inputHandler.parseP('\x1b[4a');
       assert.deepEqual(getCursor(bufferService), [6, 0]);
-      inputHandler.parse('\x1b[100a');
+      await inputHandler.parseP('\x1b[100a');
       assert.deepEqual(getCursor(bufferService), [9, 0]);
       // should not change y
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 4;
-      inputHandler.parse('\x1b[a');
+      await inputHandler.parseP('\x1b[a');
       assert.deepEqual(getCursor(bufferService), [9, 4]);
     });
-    it('vertical position absolute (VPA)', () => {
-      inputHandler.parse('\x1b[d');
+    it('vertical position absolute (VPA)', async () => {
+      await inputHandler.parseP('\x1b[d');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[1d');
+      await inputHandler.parseP('\x1b[1d');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
-      inputHandler.parse('\x1b[2d');
+      await inputHandler.parseP('\x1b[2d');
       assert.deepEqual(getCursor(bufferService), [0, 1]);
-      inputHandler.parse('\x1b[5d');
+      await inputHandler.parseP('\x1b[5d');
       assert.deepEqual(getCursor(bufferService), [0, 4]);
-      inputHandler.parse('\x1b[100d');
+      await inputHandler.parseP('\x1b[100d');
       assert.deepEqual(getCursor(bufferService), [0, 9]);
       // should not change x
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 4;
-      inputHandler.parse('\x1b[d');
+      await inputHandler.parseP('\x1b[d');
       assert.deepEqual(getCursor(bufferService), [8, 0]);
     });
-    it('vertical position relative (VPR)', () => {
-      inputHandler.parse('\x1b[e');
+    it('vertical position relative (VPR)', async () => {
+      await inputHandler.parseP('\x1b[e');
       assert.deepEqual(getCursor(bufferService), [0, 1]);
-      inputHandler.parse('\x1b[1e');
+      await inputHandler.parseP('\x1b[1e');
       assert.deepEqual(getCursor(bufferService), [0, 2]);
-      inputHandler.parse('\x1b[4e');
+      await inputHandler.parseP('\x1b[4e');
       assert.deepEqual(getCursor(bufferService), [0, 6]);
-      inputHandler.parse('\x1b[100e');
+      await inputHandler.parseP('\x1b[100e');
       assert.deepEqual(getCursor(bufferService), [0, 9]);
       // should not change x
       bufferService.buffer.x = 8;
       bufferService.buffer.y = 4;
-      inputHandler.parse('\x1b[e');
+      await inputHandler.parseP('\x1b[e');
       assert.deepEqual(getCursor(bufferService), [8, 5]);
     });
     describe('should clamp cursor into addressible range', () => {
-      it('CUF', () => {
+      it('CUF', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[C');
+        await inputHandler.parseP('\x1b[C');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[C');
+        await inputHandler.parseP('\x1b[C');
         assert.deepEqual(getCursor(bufferService), [1, 0]);
       });
-      it('CUB', () => {
+      it('CUB', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[D');
+        await inputHandler.parseP('\x1b[D');
         assert.deepEqual(getCursor(bufferService), [8, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[D');
+        await inputHandler.parseP('\x1b[D');
         assert.deepEqual(getCursor(bufferService), [0, 0]);
       });
-      it('CUD', () => {
+      it('CUD', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[B');
+        await inputHandler.parseP('\x1b[B');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[B');
+        await inputHandler.parseP('\x1b[B');
         assert.deepEqual(getCursor(bufferService), [0, 1]);
       });
-      it('CUU', () => {
+      it('CUU', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[A');
+        await inputHandler.parseP('\x1b[A');
         assert.deepEqual(getCursor(bufferService), [9, 8]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[A');
+        await inputHandler.parseP('\x1b[A');
         assert.deepEqual(getCursor(bufferService), [0, 0]);
       });
-      it('CNL', () => {
+      it('CNL', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[E');
+        await inputHandler.parseP('\x1b[E');
         assert.deepEqual(getCursor(bufferService), [0, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[E');
+        await inputHandler.parseP('\x1b[E');
         assert.deepEqual(getCursor(bufferService), [0, 1]);
       });
-      it('CPL', () => {
+      it('CPL', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[F');
+        await inputHandler.parseP('\x1b[F');
         assert.deepEqual(getCursor(bufferService), [0, 8]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[F');
+        await inputHandler.parseP('\x1b[F');
         assert.deepEqual(getCursor(bufferService), [0, 0]);
       });
-      it('CHA', () => {
+      it('CHA', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[5G');
+        await inputHandler.parseP('\x1b[5G');
         assert.deepEqual(getCursor(bufferService), [4, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[5G');
+        await inputHandler.parseP('\x1b[5G');
         assert.deepEqual(getCursor(bufferService), [4, 0]);
       });
-      it('CUP', () => {
+      it('CUP', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[5;5H');
+        await inputHandler.parseP('\x1b[5;5H');
         assert.deepEqual(getCursor(bufferService), [4, 4]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[5;5H');
+        await inputHandler.parseP('\x1b[5;5H');
         assert.deepEqual(getCursor(bufferService), [4, 4]);
       });
-      it('HPA', () => {
+      it('HPA', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[5`');
+        await inputHandler.parseP('\x1b[5`');
         assert.deepEqual(getCursor(bufferService), [4, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[5`');
+        await inputHandler.parseP('\x1b[5`');
         assert.deepEqual(getCursor(bufferService), [4, 0]);
       });
-      it('HPR', () => {
+      it('HPR', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[a');
+        await inputHandler.parseP('\x1b[a');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[a');
+        await inputHandler.parseP('\x1b[a');
         assert.deepEqual(getCursor(bufferService), [1, 0]);
       });
-      it('VPA', () => {
+      it('VPA', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[5d');
+        await inputHandler.parseP('\x1b[5d');
         assert.deepEqual(getCursor(bufferService), [9, 4]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[5d');
+        await inputHandler.parseP('\x1b[5d');
         assert.deepEqual(getCursor(bufferService), [0, 4]);
       });
-      it('VPR', () => {
+      it('VPR', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[e');
+        await inputHandler.parseP('\x1b[e');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[e');
+        await inputHandler.parseP('\x1b[e');
         assert.deepEqual(getCursor(bufferService), [0, 1]);
       });
-      it('DCH', () => {
+      it('DCH', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[P');
+        await inputHandler.parseP('\x1b[P');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[P');
+        await inputHandler.parseP('\x1b[P');
         assert.deepEqual(getCursor(bufferService), [0, 0]);
       });
-      it('DCH - should delete last cell', () => {
-        inputHandler.parse('0123456789\x1b[P');
+      it('DCH - should delete last cell', async () => {
+        await inputHandler.parseP('0123456789\x1b[P');
         assert.equal(bufferService.buffer.lines.get(0)!.translateToString(false), '012345678 ');
       });
-      it('ECH', () => {
+      it('ECH', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[X');
+        await inputHandler.parseP('\x1b[X');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[X');
+        await inputHandler.parseP('\x1b[X');
         assert.deepEqual(getCursor(bufferService), [0, 0]);
       });
-      it('ECH - should delete last cell', () => {
-        inputHandler.parse('0123456789\x1b[X');
+      it('ECH - should delete last cell', async () => {
+        await inputHandler.parseP('0123456789\x1b[X');
         assert.equal(bufferService.buffer.lines.get(0)!.translateToString(false), '012345678 ');
       });
-      it('ICH', () => {
+      it('ICH', async () => {
         bufferService.buffer.x = 10000;
         bufferService.buffer.y = 10000;
-        inputHandler.parse('\x1b[@');
+        await inputHandler.parseP('\x1b[@');
         assert.deepEqual(getCursor(bufferService), [9, 9]);
         bufferService.buffer.x = -10000;
         bufferService.buffer.y = -10000;
-        inputHandler.parse('\x1b[@');
+        await inputHandler.parseP('\x1b[@');
         assert.deepEqual(getCursor(bufferService), [0, 0]);
       });
-      it('ICH - should delete last cell', () => {
-        inputHandler.parse('0123456789\x1b[@');
+      it('ICH - should delete last cell', async () => {
+        await inputHandler.parseP('0123456789\x1b[@');
         assert.equal(bufferService.buffer.lines.get(0)!.translateToString(false), '012345678 ');
       });
     });
@@ -1093,31 +1105,31 @@ describe('InputHandler', () => {
     beforeEach(() => {
       bufferService.resize(10, 10);
     });
-    it('should default to whole viewport', () => {
-      inputHandler.parse('\x1b[r');
+    it('should default to whole viewport', async () => {
+      await inputHandler.parseP('\x1b[r');
       assert.equal(bufferService.buffer.scrollTop, 0);
       assert.equal(bufferService.buffer.scrollBottom, 9);
-      inputHandler.parse('\x1b[3;7r');
+      await inputHandler.parseP('\x1b[3;7r');
       assert.equal(bufferService.buffer.scrollTop, 2);
       assert.equal(bufferService.buffer.scrollBottom, 6);
-      inputHandler.parse('\x1b[0;0r');
+      await inputHandler.parseP('\x1b[0;0r');
       assert.equal(bufferService.buffer.scrollTop, 0);
       assert.equal(bufferService.buffer.scrollBottom, 9);
     });
-    it('should clamp bottom', () => {
-      inputHandler.parse('\x1b[3;1000r');
+    it('should clamp bottom', async () => {
+      await inputHandler.parseP('\x1b[3;1000r');
       assert.equal(bufferService.buffer.scrollTop, 2);
       assert.equal(bufferService.buffer.scrollBottom, 9);
     });
-    it('should only apply for top < bottom', () => {
-      inputHandler.parse('\x1b[7;2r');
+    it('should only apply for top < bottom', async () => {
+      await inputHandler.parseP('\x1b[7;2r');
       assert.equal(bufferService.buffer.scrollTop, 0);
       assert.equal(bufferService.buffer.scrollBottom, 9);
     });
-    it('should home cursor', () => {
+    it('should home cursor', async () => {
       bufferService.buffer.x = 10000;
       bufferService.buffer.y = 10000;
-      inputHandler.parse('\x1b[2;7r');
+      await inputHandler.parseP('\x1b[2;7r');
       assert.deepEqual(getCursor(bufferService), [0, 0]);
     });
   });
@@ -1125,76 +1137,76 @@ describe('InputHandler', () => {
     beforeEach(() => {
       bufferService.resize(10, 10);
     });
-    it('scrollUp', () => {
-      inputHandler.parse('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[2;4r\x1b[2Sm');
+    it('scrollUp', async () => {
+      await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[2;4r\x1b[2Sm');
       assert.deepEqual(getLines(bufferService), ['m', '3', '', '', '4', '5', '6', '7', '8', '9']);
     });
-    it('scrollDown', () => {
-      inputHandler.parse('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[2;4r\x1b[2Tm');
+    it('scrollDown', async () => {
+      await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[2;4r\x1b[2Tm');
       assert.deepEqual(getLines(bufferService), ['m', '', '', '1', '4', '5', '6', '7', '8', '9']);
     });
-    it('insertLines - out of margins', () => {
-      inputHandler.parse('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
+    it('insertLines - out of margins', async () => {
+      await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
       assert.equal(bufferService.buffer.scrollTop, 2);
       assert.equal(bufferService.buffer.scrollBottom, 5);
-      inputHandler.parse('\x1b[2Lm');
+      await inputHandler.parseP('\x1b[2Lm');
       assert.deepEqual(getLines(bufferService), ['m', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
-      inputHandler.parse('\x1b[2H\x1b[2Ln');
+      await inputHandler.parseP('\x1b[2H\x1b[2Ln');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', '6', '7', '8', '9']);
       // skip below scrollbottom
-      inputHandler.parse('\x1b[7H\x1b[2Lo');
+      await inputHandler.parseP('\x1b[7H\x1b[2Lo');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', 'o', '7', '8', '9']);
-      inputHandler.parse('\x1b[8H\x1b[2Lp');
+      await inputHandler.parseP('\x1b[8H\x1b[2Lp');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', 'o', 'p', '8', '9']);
-      inputHandler.parse('\x1b[100H\x1b[2Lq');
+      await inputHandler.parseP('\x1b[100H\x1b[2Lq');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', 'o', 'p', '8', 'q']);
     });
-    it('insertLines - within margins', () => {
-      inputHandler.parse('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
+    it('insertLines - within margins', async () => {
+      await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
       assert.equal(bufferService.buffer.scrollTop, 2);
       assert.equal(bufferService.buffer.scrollBottom, 5);
-      inputHandler.parse('\x1b[3H\x1b[2Lm');
+      await inputHandler.parseP('\x1b[3H\x1b[2Lm');
       assert.deepEqual(getLines(bufferService), ['0', '1', 'm', '', '2', '3', '6', '7', '8', '9']);
-      inputHandler.parse('\x1b[6H\x1b[2Ln');
+      await inputHandler.parseP('\x1b[6H\x1b[2Ln');
       assert.deepEqual(getLines(bufferService), ['0', '1', 'm', '', '2', 'n', '6', '7', '8', '9']);
     });
-    it('deleteLines - out of margins', () => {
-      inputHandler.parse('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
+    it('deleteLines - out of margins', async () => {
+      await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
       assert.equal(bufferService.buffer.scrollTop, 2);
       assert.equal(bufferService.buffer.scrollBottom, 5);
-      inputHandler.parse('\x1b[2Mm');
+      await inputHandler.parseP('\x1b[2Mm');
       assert.deepEqual(getLines(bufferService), ['m', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
-      inputHandler.parse('\x1b[2H\x1b[2Mn');
+      await inputHandler.parseP('\x1b[2H\x1b[2Mn');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', '6', '7', '8', '9']);
       // skip below scrollbottom
-      inputHandler.parse('\x1b[7H\x1b[2Mo');
+      await inputHandler.parseP('\x1b[7H\x1b[2Mo');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', 'o', '7', '8', '9']);
-      inputHandler.parse('\x1b[8H\x1b[2Mp');
+      await inputHandler.parseP('\x1b[8H\x1b[2Mp');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', 'o', 'p', '8', '9']);
-      inputHandler.parse('\x1b[100H\x1b[2Mq');
+      await inputHandler.parseP('\x1b[100H\x1b[2Mq');
       assert.deepEqual(getLines(bufferService), ['m', 'n', '2', '3', '4', '5', 'o', 'p', '8', 'q']);
     });
-    it('deleteLines - within margins', () => {
-      inputHandler.parse('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
+    it('deleteLines - within margins', async () => {
+      await inputHandler.parseP('0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\x1b[3;6r');
       assert.equal(bufferService.buffer.scrollTop, 2);
       assert.equal(bufferService.buffer.scrollBottom, 5);
-      inputHandler.parse('\x1b[6H\x1b[2Mm');
+      await inputHandler.parseP('\x1b[6H\x1b[2Mm');
       assert.deepEqual(getLines(bufferService), ['0', '1', '2', '3', '4', 'm', '6', '7', '8', '9']);
-      inputHandler.parse('\x1b[3H\x1b[2Mn');
+      await inputHandler.parseP('\x1b[3H\x1b[2Mn');
       assert.deepEqual(getLines(bufferService), ['0', '1', 'n', 'm',  '',  '', '6', '7', '8', '9']);
     });
   });
-  it('should parse big chunks in smaller subchunks', () => {
+  it('should parse big chunks in smaller subchunks', async () => {
     // max single chunk size is hardcoded as 131072
     const calls: any[] = [];
     bufferService.resize(10, 10);
     (inputHandler as any)._parser.parse = (data: Uint32Array, length: number) => {
       calls.push([data.length, length]);
     };
-    inputHandler.parse('12345');
-    inputHandler.parse('a'.repeat(10000));
-    inputHandler.parse('a'.repeat(200000));
-    inputHandler.parse('a'.repeat(300000));
+    await inputHandler.parseP('12345');
+    await inputHandler.parseP('a'.repeat(10000));
+    await inputHandler.parseP('a'.repeat(200000));
+    await inputHandler.parseP('a'.repeat(300000));
     assert.deepEqual(calls, [
       [4096, 5],
       [10000, 10000],
@@ -1203,187 +1215,187 @@ describe('InputHandler', () => {
     ]);
   });
   describe('windowOptions', () => {
-    it('all should be disabled by default and not report', () => {
+    it('all should be disabled by default and not report', async () => {
       bufferService.resize(10, 10);
       const stack: string[] = [];
       coreService.onData(data => stack.push(data));
-      inputHandler.parse('\x1b[14t');
-      inputHandler.parse('\x1b[16t');
-      inputHandler.parse('\x1b[18t');
-      inputHandler.parse('\x1b[20t');
-      inputHandler.parse('\x1b[21t');
+      await inputHandler.parseP('\x1b[14t');
+      await inputHandler.parseP('\x1b[16t');
+      await inputHandler.parseP('\x1b[18t');
+      await inputHandler.parseP('\x1b[20t');
+      await inputHandler.parseP('\x1b[21t');
       assert.deepEqual(stack, []);
     });
-    it('14 - GetWinSizePixels', () => {
+    it('14 - GetWinSizePixels', async () => {
       bufferService.resize(10, 10);
       optionsService.options.windowOptions.getWinSizePixels = true;
       const stack: string[] = [];
       coreService.onData(data => stack.push(data));
-      inputHandler.parse('\x1b[14t');
+      await inputHandler.parseP('\x1b[14t');
       // does not report in test terminal due to missing renderer
       assert.deepEqual(stack, []);
     });
-    it('16 - GetCellSizePixels', () => {
+    it('16 - GetCellSizePixels', async () => {
       bufferService.resize(10, 10);
       optionsService.options.windowOptions.getCellSizePixels = true;
       const stack: string[] = [];
       coreService.onData(data => stack.push(data));
-      inputHandler.parse('\x1b[16t');
+      await inputHandler.parseP('\x1b[16t');
       // does not report in test terminal due to missing renderer
       assert.deepEqual(stack, []);
     });
-    it('18 - GetWinSizeChars', () => {
+    it('18 - GetWinSizeChars', async () => {
       bufferService.resize(10, 10);
       optionsService.options.windowOptions.getWinSizeChars = true;
       const stack: string[] = [];
       coreService.onData(data => stack.push(data));
-      inputHandler.parse('\x1b[18t');
+      await inputHandler.parseP('\x1b[18t');
       assert.deepEqual(stack, ['\x1b[8;10;10t']);
       bufferService.resize(50, 20);
-      inputHandler.parse('\x1b[18t');
+      await inputHandler.parseP('\x1b[18t');
       assert.deepEqual(stack, ['\x1b[8;10;10t', '\x1b[8;20;50t']);
     });
-    it('22/23 - PushTitle/PopTitle', () => {
+    it('22/23 - PushTitle/PopTitle', async () => {
       bufferService.resize(10, 10);
       optionsService.options.windowOptions.pushTitle = true;
       optionsService.options.windowOptions.popTitle = true;
       const stack: string[] = [];
       inputHandler.onTitleChange(data => stack.push(data));
-      inputHandler.parse('\x1b]0;1\x07');
-      inputHandler.parse('\x1b[22t');
-      inputHandler.parse('\x1b]0;2\x07');
-      inputHandler.parse('\x1b[22t');
-      inputHandler.parse('\x1b]0;3\x07');
-      inputHandler.parse('\x1b[22t');
+      await inputHandler.parseP('\x1b]0;1\x07');
+      await inputHandler.parseP('\x1b[22t');
+      await inputHandler.parseP('\x1b]0;2\x07');
+      await inputHandler.parseP('\x1b[22t');
+      await inputHandler.parseP('\x1b]0;3\x07');
+      await inputHandler.parseP('\x1b[22t');
       assert.deepEqual(inputHandler.windowTitleStack, ['1', '2', '3']);
       assert.deepEqual(inputHandler.iconNameStack, ['1', '2', '3']);
       assert.deepEqual(stack, ['1', '2', '3']);
-      inputHandler.parse('\x1b[23t');
-      inputHandler.parse('\x1b[23t');
-      inputHandler.parse('\x1b[23t');
-      inputHandler.parse('\x1b[23t'); // one more to test "overflow"
+      await inputHandler.parseP('\x1b[23t');
+      await inputHandler.parseP('\x1b[23t');
+      await inputHandler.parseP('\x1b[23t');
+      await inputHandler.parseP('\x1b[23t'); // one more to test "overflow"
       assert.deepEqual(inputHandler.windowTitleStack, []);
       assert.deepEqual(inputHandler.iconNameStack, []);
       assert.deepEqual(stack, ['1', '2', '3', '3', '2', '1']);
     });
-    it('22/23 - PushTitle/PopTitle with ;1', () => {
+    it('22/23 - PushTitle/PopTitle with ;1', async () => {
       bufferService.resize(10, 10);
       optionsService.options.windowOptions.pushTitle = true;
       optionsService.options.windowOptions.popTitle = true;
       const stack: string[] = [];
       inputHandler.onTitleChange(data => stack.push(data));
-      inputHandler.parse('\x1b]0;1\x07');
-      inputHandler.parse('\x1b[22;1t');
-      inputHandler.parse('\x1b]0;2\x07');
-      inputHandler.parse('\x1b[22;1t');
-      inputHandler.parse('\x1b]0;3\x07');
-      inputHandler.parse('\x1b[22;1t');
+      await inputHandler.parseP('\x1b]0;1\x07');
+      await inputHandler.parseP('\x1b[22;1t');
+      await inputHandler.parseP('\x1b]0;2\x07');
+      await inputHandler.parseP('\x1b[22;1t');
+      await inputHandler.parseP('\x1b]0;3\x07');
+      await inputHandler.parseP('\x1b[22;1t');
       assert.deepEqual(inputHandler.windowTitleStack, []);
       assert.deepEqual(inputHandler.iconNameStack, ['1', '2', '3']);
       assert.deepEqual(stack, ['1', '2', '3']);
-      inputHandler.parse('\x1b[23;1t');
-      inputHandler.parse('\x1b[23;1t');
-      inputHandler.parse('\x1b[23;1t');
-      inputHandler.parse('\x1b[23;1t'); // one more to test "overflow"
+      await inputHandler.parseP('\x1b[23;1t');
+      await inputHandler.parseP('\x1b[23;1t');
+      await inputHandler.parseP('\x1b[23;1t');
+      await inputHandler.parseP('\x1b[23;1t'); // one more to test "overflow"
       assert.deepEqual(inputHandler.windowTitleStack, []);
       assert.deepEqual(inputHandler.iconNameStack, []);
       assert.deepEqual(stack, ['1', '2', '3']);
     });
-    it('22/23 - PushTitle/PopTitle with ;2', () => {
+    it('22/23 - PushTitle/PopTitle with ;2', async () => {
       bufferService.resize(10, 10);
       optionsService.options.windowOptions.pushTitle = true;
       optionsService.options.windowOptions.popTitle = true;
       const stack: string[] = [];
       inputHandler.onTitleChange(data => stack.push(data));
-      inputHandler.parse('\x1b]0;1\x07');
-      inputHandler.parse('\x1b[22;2t');
-      inputHandler.parse('\x1b]0;2\x07');
-      inputHandler.parse('\x1b[22;2t');
-      inputHandler.parse('\x1b]0;3\x07');
-      inputHandler.parse('\x1b[22;2t');
+      await inputHandler.parseP('\x1b]0;1\x07');
+      await inputHandler.parseP('\x1b[22;2t');
+      await inputHandler.parseP('\x1b]0;2\x07');
+      await inputHandler.parseP('\x1b[22;2t');
+      await inputHandler.parseP('\x1b]0;3\x07');
+      await inputHandler.parseP('\x1b[22;2t');
       assert.deepEqual(inputHandler.windowTitleStack, ['1', '2', '3']);
       assert.deepEqual(inputHandler.iconNameStack, []);
       assert.deepEqual(stack, ['1', '2', '3']);
-      inputHandler.parse('\x1b[23;2t');
-      inputHandler.parse('\x1b[23;2t');
-      inputHandler.parse('\x1b[23;2t');
-      inputHandler.parse('\x1b[23;2t'); // one more to test "overflow"
+      await inputHandler.parseP('\x1b[23;2t');
+      await inputHandler.parseP('\x1b[23;2t');
+      await inputHandler.parseP('\x1b[23;2t');
+      await inputHandler.parseP('\x1b[23;2t'); // one more to test "overflow"
       assert.deepEqual(inputHandler.windowTitleStack, []);
       assert.deepEqual(inputHandler.iconNameStack, []);
       assert.deepEqual(stack, ['1', '2', '3', '3', '2', '1']);
     });
-    it('DECCOLM - should only work with "SetWinLines" (24) enabled', () => {
+    it('DECCOLM - should only work with "SetWinLines" (24) enabled', async () => {
       // disabled
       bufferService.resize(10, 10);
-      inputHandler.parse('\x1b[?3l');
+      await inputHandler.parseP('\x1b[?3l');
       assert.equal(bufferService.cols, 10);
-      inputHandler.parse('\x1b[?3h');
+      await inputHandler.parseP('\x1b[?3h');
       assert.equal(bufferService.cols, 10);
       // enabled
       inputHandler.reset();
       optionsService.options.windowOptions.setWinLines = true;
-      inputHandler.parse('\x1b[?3l');
+      await inputHandler.parseP('\x1b[?3l');
       assert.equal(bufferService.cols, 80);
-      inputHandler.parse('\x1b[?3h');
+      await inputHandler.parseP('\x1b[?3h');
       assert.equal(bufferService.cols, 132);
     });
   });
   describe('should correctly reset cells taken by wide chars', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       bufferService.resize(10, 5);
       optionsService.options.scrollback = 1;
-      inputHandler.parse('￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥');
+      await inputHandler.parseP('￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥￥');
     });
-    it('print', () => {
-      inputHandler.parse('\x1b[H#');
+    it('print', async () => {
+      await inputHandler.parseP('\x1b[H#');
       assert.deepEqual(getLines(bufferService), ['# ￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[1;6H######');
+      await inputHandler.parseP('\x1b[1;6H######');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '# ￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('#');
+      await inputHandler.parseP('#');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '##￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('#');
+      await inputHandler.parseP('#');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '### ￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[3;9H#');
+      await inputHandler.parseP('\x1b[3;9H#');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '### ￥￥￥', '￥￥￥￥#', '￥￥￥￥￥', '']);
-      inputHandler.parse('#');
+      await inputHandler.parseP('#');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '### ￥￥￥', '￥￥￥￥##', '￥￥￥￥￥', '']);
-      inputHandler.parse('#');
+      await inputHandler.parseP('#');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '### ￥￥￥', '￥￥￥￥##', '# ￥￥￥￥', '']);
-      inputHandler.parse('\x1b[4;10H#');
+      await inputHandler.parseP('\x1b[4;10H#');
       assert.deepEqual(getLines(bufferService), ['# ￥ #####', '### ￥￥￥', '￥￥￥￥##', '# ￥￥￥ #', '']);
     });
-    it('EL', () => {
-      inputHandler.parse('\x1b[1;6H\x1b[K#');
+    it('EL', async () => {
+      await inputHandler.parseP('\x1b[1;6H\x1b[K#');
       assert.deepEqual(getLines(bufferService), ['￥￥ #', '￥￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[2;5H\x1b[1K');
+      await inputHandler.parseP('\x1b[2;5H\x1b[1K');
       assert.deepEqual(getLines(bufferService), ['￥￥ #', '      ￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[3;6H\x1b[1K');
+      await inputHandler.parseP('\x1b[3;6H\x1b[1K');
       assert.deepEqual(getLines(bufferService), ['￥￥ #', '      ￥￥', '      ￥￥', '￥￥￥￥￥', '']);
     });
-    it('ICH', () => {
-      inputHandler.parse('\x1b[1;6H\x1b[@');
+    it('ICH', async () => {
+      await inputHandler.parseP('\x1b[1;6H\x1b[@');
       assert.deepEqual(getLines(bufferService), ['￥￥   ￥', '￥￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[2;4H\x1b[2@');
+      await inputHandler.parseP('\x1b[2;4H\x1b[2@');
       assert.deepEqual(getLines(bufferService), ['￥￥   ￥', '￥    ￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[3;4H\x1b[3@');
+      await inputHandler.parseP('\x1b[3;4H\x1b[3@');
       assert.deepEqual(getLines(bufferService), ['￥￥   ￥', '￥    ￥￥', '￥     ￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[4;4H\x1b[4@');
+      await inputHandler.parseP('\x1b[4;4H\x1b[4@');
       assert.deepEqual(getLines(bufferService), ['￥￥   ￥', '￥    ￥￥', '￥     ￥', '￥      ￥', '']);
     });
-    it('DCH', () => {
-      inputHandler.parse('\x1b[1;6H\x1b[P');
+    it('DCH', async () => {
+      await inputHandler.parseP('\x1b[1;6H\x1b[P');
       assert.deepEqual(getLines(bufferService), ['￥￥ ￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[2;6H\x1b[2P');
+      await inputHandler.parseP('\x1b[2;6H\x1b[2P');
       assert.deepEqual(getLines(bufferService), ['￥￥ ￥￥', '￥￥  ￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[3;6H\x1b[3P');
+      await inputHandler.parseP('\x1b[3;6H\x1b[3P');
       assert.deepEqual(getLines(bufferService), ['￥￥ ￥￥', '￥￥  ￥', '￥￥ ￥', '￥￥￥￥￥', '']);
     });
-    it('ECH', () => {
-      inputHandler.parse('\x1b[1;6H\x1b[X');
+    it('ECH', async () => {
+      await inputHandler.parseP('\x1b[1;6H\x1b[X');
       assert.deepEqual(getLines(bufferService), ['￥￥  ￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[2;6H\x1b[2X');
+      await inputHandler.parseP('\x1b[2;6H\x1b[2X');
       assert.deepEqual(getLines(bufferService), ['￥￥  ￥￥', '￥￥    ￥', '￥￥￥￥￥', '￥￥￥￥￥', '']);
-      inputHandler.parse('\x1b[3;6H\x1b[3X');
+      await inputHandler.parseP('\x1b[3;6H\x1b[3X');
       assert.deepEqual(getLines(bufferService), ['￥￥  ￥￥', '￥￥    ￥', '￥￥    ￥', '￥￥￥￥￥', '']);
     });
   });
@@ -1395,74 +1407,74 @@ describe('InputHandler', () => {
       optionsService.options.scrollback = 1;
     });
     describe('reverseWraparound unset (default)', () => {
-      it('cannot delete last cell', () => {
-        inputHandler.parse('12345');
-        inputHandler.parse(ttyBS);
+      it('cannot delete last cell', async () => {
+        await inputHandler.parseP('12345');
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 1), ['123 5']);
-        inputHandler.parse(ttyBS.repeat(10));
+        await inputHandler.parseP(ttyBS.repeat(10));
         assert.deepEqual(getLines(bufferService, 1), ['    5']);
       });
-      it('cannot access prev line', () => {
-        inputHandler.parse('12345'.repeat(2));
-        inputHandler.parse(ttyBS);
+      it('cannot access prev line', async () => {
+        await inputHandler.parseP('12345'.repeat(2));
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['12345', '123 5']);
-        inputHandler.parse(ttyBS.repeat(10));
+        await inputHandler.parseP(ttyBS.repeat(10));
         assert.deepEqual(getLines(bufferService, 2), ['12345', '    5']);
       });
     });
     describe('reverseWraparound set', () => {
-      it('can delete last cell', () => {
-        inputHandler.parse('\x1b[?45h');
-        inputHandler.parse('12345');
-        inputHandler.parse(ttyBS);
+      it('can delete last cell', async () => {
+        await inputHandler.parseP('\x1b[?45h');
+        await inputHandler.parseP('12345');
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 1), ['1234 ']);
-        inputHandler.parse(ttyBS.repeat(7));
+        await inputHandler.parseP(ttyBS.repeat(7));
         assert.deepEqual(getLines(bufferService, 1), ['     ']);
       });
-      it('can access prev line if wrapped', () => {
-        inputHandler.parse('\x1b[?45h');
-        inputHandler.parse('12345'.repeat(2));
-        inputHandler.parse(ttyBS);
+      it('can access prev line if wrapped', async () => {
+        await inputHandler.parseP('\x1b[?45h');
+        await inputHandler.parseP('12345'.repeat(2));
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['12345', '1234 ']);
-        inputHandler.parse(ttyBS.repeat(7));
+        await inputHandler.parseP(ttyBS.repeat(7));
         assert.deepEqual(getLines(bufferService, 2), ['12   ', '     ']);
       });
-      it('should lift isWrapped', () => {
-        inputHandler.parse('\x1b[?45h');
-        inputHandler.parse('12345'.repeat(2));
+      it('should lift isWrapped', async () => {
+        await inputHandler.parseP('\x1b[?45h');
+        await inputHandler.parseP('12345'.repeat(2));
         assert.equal(bufferService.buffer.lines.get(1)?.isWrapped, true);
-        inputHandler.parse(ttyBS.repeat(7));
+        await inputHandler.parseP(ttyBS.repeat(7));
         assert.equal(bufferService.buffer.lines.get(1)?.isWrapped, false);
       });
-      it('stops at hard NLs', () => {
-        inputHandler.parse('\x1b[?45h');
-        inputHandler.parse('12345\r\n');
-        inputHandler.parse('12345'.repeat(2));
-        inputHandler.parse(ttyBS.repeat(50));
+      it('stops at hard NLs', async () => {
+        await inputHandler.parseP('\x1b[?45h');
+        await inputHandler.parseP('12345\r\n');
+        await inputHandler.parseP('12345'.repeat(2));
+        await inputHandler.parseP(ttyBS.repeat(50));
         assert.deepEqual(getLines(bufferService, 3), ['12345', '     ', '     ']);
         assert.equal(bufferService.buffer.x, 0);
         assert.equal(bufferService.buffer.y, 1);
       });
-      it('handles wide chars correctly', () => {
-        inputHandler.parse('\x1b[?45h');
-        inputHandler.parse('￥￥￥');
+      it('handles wide chars correctly', async () => {
+        await inputHandler.parseP('\x1b[?45h');
+        await inputHandler.parseP('￥￥￥');
         assert.deepEqual(getLines(bufferService, 2), ['￥￥', '￥']);
-        inputHandler.parse(ttyBS);
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['￥￥', '  ']);
         assert.equal(bufferService.buffer.x, 1);
-        inputHandler.parse(ttyBS);
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['￥￥', '  ']);
         assert.equal(bufferService.buffer.x, 0);
-        inputHandler.parse(ttyBS);
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['￥  ', '  ']);
         assert.equal(bufferService.buffer.x, 3);  // x=4 skipped due to early wrap-around
-        inputHandler.parse(ttyBS);
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['￥  ', '  ']);
         assert.equal(bufferService.buffer.x, 2);
-        inputHandler.parse(ttyBS);
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['    ', '  ']);
         assert.equal(bufferService.buffer.x, 1);
-        inputHandler.parse(ttyBS);
+        await inputHandler.parseP(ttyBS);
         assert.deepEqual(getLines(bufferService, 2), ['    ', '  ']);
         assert.equal(bufferService.buffer.x, 0);
       });
@@ -1473,72 +1485,72 @@ describe('InputHandler', () => {
     beforeEach(() => {
       bufferService.resize(10, 5);
     });
-    it('4 | 24', () => {
-      inputHandler.parse('\x1b[4m');
+    it('4 | 24', async () => {
+      await inputHandler.parseP('\x1b[4m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.SINGLE);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('21 | 24', () => {
-      inputHandler.parse('\x1b[21m');
+    it('21 | 24', async () => {
+      await inputHandler.parseP('\x1b[21m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DOUBLE);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('4:1 | 4:0', () => {
-      inputHandler.parse('\x1b[4:1m');
+    it('4:1 | 4:0', async () => {
+      await inputHandler.parseP('\x1b[4:1m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.SINGLE);
-      inputHandler.parse('\x1b[4:0m');
+      await inputHandler.parseP('\x1b[4:0m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
-      inputHandler.parse('\x1b[4:1m');
+      await inputHandler.parseP('\x1b[4:1m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.SINGLE);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('4:2 | 4:0', () => {
-      inputHandler.parse('\x1b[4:2m');
+    it('4:2 | 4:0', async () => {
+      await inputHandler.parseP('\x1b[4:2m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DOUBLE);
-      inputHandler.parse('\x1b[4:0m');
+      await inputHandler.parseP('\x1b[4:0m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
-      inputHandler.parse('\x1b[4:2m');
+      await inputHandler.parseP('\x1b[4:2m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DOUBLE);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('4:3 | 4:0', () => {
-      inputHandler.parse('\x1b[4:3m');
+    it('4:3 | 4:0', async () => {
+      await inputHandler.parseP('\x1b[4:3m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.CURLY);
-      inputHandler.parse('\x1b[4:0m');
+      await inputHandler.parseP('\x1b[4:0m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
-      inputHandler.parse('\x1b[4:3m');
+      await inputHandler.parseP('\x1b[4:3m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.CURLY);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('4:4 | 4:0', () => {
-      inputHandler.parse('\x1b[4:4m');
+    it('4:4 | 4:0', async () => {
+      await inputHandler.parseP('\x1b[4:4m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DOTTED);
-      inputHandler.parse('\x1b[4:0m');
+      await inputHandler.parseP('\x1b[4:0m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
-      inputHandler.parse('\x1b[4:4m');
+      await inputHandler.parseP('\x1b[4:4m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DOTTED);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('4:5 | 4:0', () => {
-      inputHandler.parse('\x1b[4:5m');
+    it('4:5 | 4:0', async () => {
+      await inputHandler.parseP('\x1b[4:5m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DASHED);
-      inputHandler.parse('\x1b[4:0m');
+      await inputHandler.parseP('\x1b[4:0m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
-      inputHandler.parse('\x1b[4:5m');
+      await inputHandler.parseP('\x1b[4:5m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DASHED);
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('\x1b[24m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.NONE);
     });
-    it('4:x --> 4 should revert to single underline', () => {
-      inputHandler.parse('\x1b[4:5m');
+    it('4:x --> 4 should revert to single underline', async () => {
+      await inputHandler.parseP('\x1b[4:5m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.DASHED);
-      inputHandler.parse('\x1b[4m');
+      await inputHandler.parseP('\x1b[4m');
       assert.equal(inputHandler.curAttrData.getUnderlineStyle(), UnderlineStyle.SINGLE);
     });
   });
@@ -1546,9 +1558,9 @@ describe('InputHandler', () => {
     beforeEach(() => {
       bufferService.resize(10, 5);
     });
-    it('defaults to FG color', () => {
+    it('defaults to FG color', async () => {
       for (const s of ['', '\x1b[30m', '\x1b[38;510m', '\x1b[38;2;1;2;3m']) {
-        inputHandler.parse(s);
+        await inputHandler.parseP(s);
         assert.equal(inputHandler.curAttrData.getUnderlineColor(), inputHandler.curAttrData.getFgColor());
         assert.equal(inputHandler.curAttrData.getUnderlineColorMode(), inputHandler.curAttrData.getFgColorMode());
         assert.equal(inputHandler.curAttrData.isUnderlineColorRGB(), inputHandler.curAttrData.isFgRGB());
@@ -1556,31 +1568,31 @@ describe('InputHandler', () => {
         assert.equal(inputHandler.curAttrData.isUnderlineColorDefault(), inputHandler.curAttrData.isFgDefault());
       }
     });
-    it('correctly sets P256/RGB colors', () => {
-      inputHandler.parse('\x1b[4m');
-      inputHandler.parse('\x1b[58;5;123m');
+    it('correctly sets P256/RGB colors', async () => {
+      await inputHandler.parseP('\x1b[4m');
+      await inputHandler.parseP('\x1b[58;5;123m');
       assert.equal(inputHandler.curAttrData.getUnderlineColor(), 123);
       assert.equal(inputHandler.curAttrData.getUnderlineColorMode(), Attributes.CM_P256);
       assert.equal(inputHandler.curAttrData.isUnderlineColorRGB(), false);
       assert.equal(inputHandler.curAttrData.isUnderlineColorPalette(), true);
       assert.equal(inputHandler.curAttrData.isUnderlineColorDefault(), false);
-      inputHandler.parse('\x1b[58;2::1:2:3m');
+      await inputHandler.parseP('\x1b[58;2::1:2:3m');
       assert.equal(inputHandler.curAttrData.getUnderlineColor(), (1 << 16) | (2 << 8) | 3);
       assert.equal(inputHandler.curAttrData.getUnderlineColorMode(), Attributes.CM_RGB);
       assert.equal(inputHandler.curAttrData.isUnderlineColorRGB(), true);
       assert.equal(inputHandler.curAttrData.isUnderlineColorPalette(), false);
       assert.equal(inputHandler.curAttrData.isUnderlineColorDefault(), false);
     });
-    it('P256/RGB persistence', () => {
+    it('P256/RGB persistence', async () => {
       const cell = new CellData();
-      inputHandler.parse('\x1b[4m');
-      inputHandler.parse('\x1b[58;5;123m');
+      await inputHandler.parseP('\x1b[4m');
+      await inputHandler.parseP('\x1b[58;5;123m');
       assert.equal(inputHandler.curAttrData.getUnderlineColor(), 123);
       assert.equal(inputHandler.curAttrData.getUnderlineColorMode(), Attributes.CM_P256);
       assert.equal(inputHandler.curAttrData.isUnderlineColorRGB(), false);
       assert.equal(inputHandler.curAttrData.isUnderlineColorPalette(), true);
       assert.equal(inputHandler.curAttrData.isUnderlineColorDefault(), false);
-      inputHandler.parse('ab');
+      await inputHandler.parseP('ab');
       bufferService.buffer!.lines.get(0)!.loadCell(1, cell);
       assert.equal(cell.getUnderlineColor(), 123);
       assert.equal(cell.getUnderlineColorMode(), Attributes.CM_P256);
@@ -1588,13 +1600,13 @@ describe('InputHandler', () => {
       assert.equal(cell.isUnderlineColorPalette(), true);
       assert.equal(cell.isUnderlineColorDefault(), false);
 
-      inputHandler.parse('\x1b[4:0m');
+      await inputHandler.parseP('\x1b[4:0m');
       assert.equal(inputHandler.curAttrData.getUnderlineColor(), inputHandler.curAttrData.getFgColor());
       assert.equal(inputHandler.curAttrData.getUnderlineColorMode(), inputHandler.curAttrData.getFgColorMode());
       assert.equal(inputHandler.curAttrData.isUnderlineColorRGB(), inputHandler.curAttrData.isFgRGB());
       assert.equal(inputHandler.curAttrData.isUnderlineColorPalette(), inputHandler.curAttrData.isFgPalette());
       assert.equal(inputHandler.curAttrData.isUnderlineColorDefault(), inputHandler.curAttrData.isFgDefault());
-      inputHandler.parse('a');
+      await inputHandler.parseP('a');
       bufferService.buffer!.lines.get(0)!.loadCell(1, cell);
       assert.equal(cell.getUnderlineColor(), 123);
       assert.equal(cell.getUnderlineColorMode(), Attributes.CM_P256);
@@ -1608,15 +1620,15 @@ describe('InputHandler', () => {
       assert.equal(cell.isUnderlineColorPalette(), inputHandler.curAttrData.isFgPalette());
       assert.equal(cell.isUnderlineColorDefault(), inputHandler.curAttrData.isFgDefault());
 
-      inputHandler.parse('\x1b[4m');
-      inputHandler.parse('\x1b[58;2::1:2:3m');
+      await inputHandler.parseP('\x1b[4m');
+      await inputHandler.parseP('\x1b[58;2::1:2:3m');
       assert.equal(inputHandler.curAttrData.getUnderlineColor(), (1 << 16) | (2 << 8) | 3);
       assert.equal(inputHandler.curAttrData.getUnderlineColorMode(), Attributes.CM_RGB);
       assert.equal(inputHandler.curAttrData.isUnderlineColorRGB(), true);
       assert.equal(inputHandler.curAttrData.isUnderlineColorPalette(), false);
       assert.equal(inputHandler.curAttrData.isUnderlineColorDefault(), false);
-      inputHandler.parse('a');
-      inputHandler.parse('\x1b[24m');
+      await inputHandler.parseP('a');
+      await inputHandler.parseP('\x1b[24m');
       bufferService.buffer!.lines.get(0)!.loadCell(1, cell);
       assert.equal(cell.getUnderlineColor(), 123);
       assert.equal(cell.getUnderlineColorMode(), Attributes.CM_P256);
@@ -1645,51 +1657,51 @@ describe('InputHandler', () => {
     });
   });
   describe('DECSTR', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       bufferService.resize(10, 5);
       optionsService.options.scrollback = 1;
-      inputHandler.parse('01234567890123');
+      await inputHandler.parseP('01234567890123');
     });
-    it('should reset IRM', () => {
-      inputHandler.parse('\x1b[4h');
+    it('should reset IRM', async () => {
+      await inputHandler.parseP('\x1b[4h');
       assert.equal(coreService.modes.insertMode, true);
-      inputHandler.parse('\x1b[!p');
+      await inputHandler.parseP('\x1b[!p');
       assert.equal(coreService.modes.insertMode, false);
     });
-    it('should reset cursor visibility', () => {
-      inputHandler.parse('\x1b[?25l');
+    it('should reset cursor visibility', async () => {
+      await inputHandler.parseP('\x1b[?25l');
       assert.equal(coreService.isCursorHidden, true);
-      inputHandler.parse('\x1b[!p');
+      await inputHandler.parseP('\x1b[!p');
       assert.equal(coreService.isCursorHidden, false);
     });
-    it('should reset scroll margins', () => {
-      inputHandler.parse('\x1b[2;4r');
+    it('should reset scroll margins', async () => {
+      await inputHandler.parseP('\x1b[2;4r');
       assert.equal(bufferService.buffer.scrollTop, 1);
       assert.equal(bufferService.buffer.scrollBottom, 3);
-      inputHandler.parse('\x1b[!p');
+      await inputHandler.parseP('\x1b[!p');
       assert.equal(bufferService.buffer.scrollTop, 0);
       assert.equal(bufferService.buffer.scrollBottom, bufferService.rows - 1);
     });
-    it('should reset text attributes', () => {
-      inputHandler.parse('\x1b[1;2;32;43m');
+    it('should reset text attributes', async () => {
+      await inputHandler.parseP('\x1b[1;2;32;43m');
       assert.equal(!!inputHandler.curAttrData.isBold(), true);
-      inputHandler.parse('\x1b[!p');
+      await inputHandler.parseP('\x1b[!p');
       assert.equal(!!inputHandler.curAttrData.isBold(), false);
       assert.equal(inputHandler.curAttrData.fg, 0);
       assert.equal(inputHandler.curAttrData.bg, 0);
     });
-    it('should reset DECSC data', () => {
-      inputHandler.parse('\x1b7');
+    it('should reset DECSC data', async () => {
+      await inputHandler.parseP('\x1b7');
       assert.equal(bufferService.buffer.savedX, 4);
       assert.equal(bufferService.buffer.savedY, 1);
-      inputHandler.parse('\x1b[!p');
+      await inputHandler.parseP('\x1b[!p');
       assert.equal(bufferService.buffer.savedX, 0);
       assert.equal(bufferService.buffer.savedY, 0);
     });
-    it('should reset DECOM', () => {
-      inputHandler.parse('\x1b[?6h');
+    it('should reset DECOM', async () => {
+      await inputHandler.parseP('\x1b[?6h');
       assert.equal(coreService.decPrivateModes.origin, true);
-      inputHandler.parse('\x1b[!p');
+      await inputHandler.parseP('\x1b[!p');
       assert.equal(coreService.decPrivateModes.origin, false);
     });
   });
@@ -1733,15 +1745,17 @@ describe('InputHandler', () => {
       assert.equal(event!.colors.length, 1);
       assert.deepEqual(event!.colors[0], { colorIndex: 19, red: 0xa1, green: 0xb2, blue: 0xc3 });
     });
-    it('4: should fire event on Ansi color change', (done) => {
-      inputHandler.onAnsiColorChange(e => {
-        assert.isNotNull(e);
-        assert.isNotNull(e!.colors);
-        assert.deepEqual(e!.colors[0], { colorIndex: 17, red: 0x1a, green: 0x2b, blue: 0x3c });
-        assert.deepEqual(e!.colors[1], { colorIndex: 12, red: 0x11, green: 0x22, blue: 0x33 });
-        done();
+    it('4: should fire event on Ansi color change', async () => {
+      return new Promise(async r => {
+        inputHandler.onAnsiColorChange(e => {
+          assert.isNotNull(e);
+          assert.isNotNull(e!.colors);
+          assert.deepEqual(e!.colors[0], { colorIndex: 17, red: 0x1a, green: 0x2b, blue: 0x3c });
+          assert.deepEqual(e!.colors[1], { colorIndex: 12, red: 0x11, green: 0x22, blue: 0x33 });
+          r();
+        });
+        await inputHandler.parseP('\x1b]4;17;rgb:1a/2b/3c;12;rgb:11/22/33\x1b\\');
       });
-      inputHandler.parse('\x1b]4;17;rgb:1a/2b/3c;12;rgb:11/22/33\x1b\\');
     });
   });
 });

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -701,9 +701,9 @@ export class InputHandler extends Disposable implements IInputHandler {
   }
 
   /**
-   * Forward addCsiHandler from parser.
+   * Forward registerCsiHandler from parser.
    */
-  public addCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean): IDisposable {
+  public registerCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean | Promise<boolean>): IDisposable {
     if (id.final === 't' && !id.prefix && !id.intermediates) {
       // security: always check whether window option is allowed
       return this._parser.registerCsiHandler(id, params => {
@@ -717,23 +717,23 @@ export class InputHandler extends Disposable implements IInputHandler {
   }
 
   /**
-   * Forward addDcsHandler from parser.
+   * Forward registerDcsHandler from parser.
    */
-  public addDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean): IDisposable {
+  public registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean | Promise<boolean>): IDisposable {
     return this._parser.registerDcsHandler(id, new DcsHandler(callback));
   }
 
   /**
-   * Forward addEscHandler from parser.
+   * Forward registerEscHandler from parser.
    */
-  public addEscHandler(id: IFunctionIdentifier, callback: () => boolean): IDisposable {
+  public registerEscHandler(id: IFunctionIdentifier, callback: () => boolean | Promise<boolean>): IDisposable {
     return this._parser.registerEscHandler(id, callback);
   }
 
   /**
-   * Forward addOscHandler from parser.
+   * Forward registerOscHandler from parser.
    */
-  public addOscHandler(ident: number, callback: (data: string) => boolean): IDisposable {
+  public registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable {
     return this._parser.registerOscHandler(ident, new OscHandler(callback));
   }
 

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -460,7 +460,9 @@ export class InputHandler extends Disposable implements IInputHandler {
     super.dispose();
   }
 
-  // FIXME: cleanup async handling
+  /**
+   * Async parse support.
+   */
   private _parseStack = {
     paused: false,
     cursorStartX: 0,
@@ -468,7 +470,6 @@ export class InputHandler extends Disposable implements IInputHandler {
     decodedLength: 0,
     position: 0
   };
-
   private _preserveStack(cursorStartX: number, cursorStartY: number, decodedLength: number, position: number): void {
     this._parseStack.paused = true;
     this._parseStack.cursorStartX = cursorStartX;
@@ -477,6 +478,19 @@ export class InputHandler extends Disposable implements IInputHandler {
     this._parseStack.position = position;
   }
 
+  /**
+   * Parse call with async handler support.
+   *
+   * Whether the stack state got preserved for the next call, is indicated by the return value:
+   * - undefined (void):
+   *   all handlers were sync, no stack save, continue normally with next chunk
+   * - Promise\<boolean\>:
+   *   execution stopped at async handler, stack saved, continue with
+   *   same chunk and the promise resolve value as `promiseResult` until the method returns `undefined`
+   *
+   * Note: Never call this directly for a running terminal instance in production.
+   * Always use `Terminal.write`, which provides in-band blocking and correct exection order.
+   */
   public parse(data: string | Uint8Array, promiseResult?: boolean): void | Promise<boolean> {
     let result: void | Promise<boolean>;
     let buffer = this._bufferService.buffer;

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -484,8 +484,13 @@ export class InputHandler extends Disposable implements IInputHandler {
   private _logSlowResolvingAsync(p: Promise<boolean>): void {
     // log a limited warning about an async taking too long
     if ((this._logService as any)._logLevel <= LogLevel.WARN) {
-      Promise.race([p, new Promise((res, rej) => setTimeout(rej, SLOW_ASYNC_LIMIT))])
-        .catch(() => console.warn(`async parser handler taking longer than ${SLOW_ASYNC_LIMIT} ms`));
+      Promise.race([p, new Promise((res, rej) => setTimeout(() => rej('#SLOW_TIMEOUT'), SLOW_ASYNC_LIMIT))])
+        .catch(err => {
+          if (err !== '#SLOW_TIMEOUT') {
+            throw err;
+          }
+          console.warn(`async parser handler taking longer than ${SLOW_ASYNC_LIMIT} ms`);
+        });
     }
   }
 

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -488,8 +488,8 @@ export class InputHandler extends Disposable implements IInputHandler {
    *   execution stopped at async handler, stack saved, continue with
    *   same chunk and the promise resolve value as `promiseResult` until the method returns `undefined`
    *
-   * Note: Never call this directly for a running terminal instance in production.
-   * Always use `Terminal.write`, which provides in-band blocking and correct exection order.
+   * Note: This method should only be called by `Terminal.write` to ensure correct execution order and
+   * proper continuation of async parser handlers.
    */
   public parse(data: string | Uint8Array, promiseResult?: boolean): void | Promise<boolean> {
     let result: void | Promise<boolean>;

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { IBufferService, ICoreService, ILogService, IOptionsService, ITerminalOptions, IPartialTerminalOptions, IDirtyRowService, ICoreMouseService, ICharsetService, IUnicodeService, IUnicodeVersionProvider } from 'common/services/Services';
+import { IBufferService, ICoreService, ILogService, IOptionsService, ITerminalOptions, IPartialTerminalOptions, IDirtyRowService, ICoreMouseService, ICharsetService, IUnicodeService, IUnicodeVersionProvider, LogLevelEnum } from 'common/services/Services';
 import { IEvent, EventEmitter } from 'common/EventEmitter';
 import { clone } from 'common/Clone';
 import { DEFAULT_OPTIONS } from 'common/services/OptionsService';
@@ -92,6 +92,7 @@ export class MockDirtyRowService implements IDirtyRowService {
 
 export class MockLogService implements ILogService {
   public serviceBrand: any;
+  public logLevel = LogLevelEnum.DEBUG;
   public debug(message: any, ...optionalParams: any[]): void {}
   public info(message: any, ...optionalParams: any[]): void {}
   public warn(message: any, ...optionalParams: any[]): void {}

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { ITerminalOptions as IPublicTerminalOptions } from 'xterm';
+import { IFunctionIdentifier, ITerminalOptions as IPublicTerminalOptions } from 'xterm';
 import { IEvent, IEventEmitter } from 'common/EventEmitter';
 import { IDeleteEvent, IInsertEvent } from 'common/CircularList';
 import { IParams } from 'common/parser/Types';
@@ -351,6 +351,10 @@ export interface IInputHandler {
 
   parse(data: string | Uint8Array): void;
   print(data: Uint32Array, start: number, end: number): void;
+  registerCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean | Promise<boolean>): IDisposable;
+  registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean | Promise<boolean>): IDisposable;
+  registerEscHandler(id: IFunctionIdentifier, callback: () => boolean | Promise<boolean>): IDisposable;
+  registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable;
 
   /** C0 BEL */ bell(): void;
   /** C0 LF */ lineFeed(): void;

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -349,7 +349,7 @@ export interface IInputHandler {
   onTitleChange: IEvent<string>;
   onRequestScroll: IEvent<IAttributeData, boolean | void>;
 
-  parse(data: string | Uint8Array): void;
+  parse(data: string | Uint8Array, promiseResult?: boolean): void | Promise<boolean>;
   print(data: Uint32Array, start: number, end: number): void;
   registerCsiHandler(id: IFunctionIdentifier, callback: (params: IParams) => boolean | Promise<boolean>): IDisposable;
   registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: IParams) => boolean | Promise<boolean>): IDisposable;
@@ -430,4 +430,12 @@ export interface IInputHandler {
       ESC }
       ESC ~ */ setgLevel(level: number): void;
   /** ESC # 8 */ screenAlignmentPattern(): void;
+}
+
+interface IParseStack {
+  paused: boolean;
+  cursorStartX: number;
+  cursorStartY: number;
+  decodedLength: number;
+  position: number;
 }

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -167,7 +167,7 @@ export class WriteBuffer {
         // (executed on the same queue, thus properly aligned before continuation happens)
         result.catch(err => {
           qmt(() => {throw err;});
-          return Promise.resolve(true);
+          return Promise.resolve(false);
         }).then(continuation);
         return;
       }

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -37,8 +37,9 @@ export class WriteBuffer {
   private _pendingData = 0;
   private _bufferOffset = 0;
 
-  constructor(private _action: (data: string | Uint8Array) => void) { }
+  constructor(private _action: (data: string | Uint8Array, promiseResult?: boolean) => void | Promise<boolean>) { }
 
+  // FIXME: does not work that way anymore with async handlers!!!
   public writeSync(data: string | Uint8Array): void {
     // force sync processing on pending data chunks to avoid in-band data scrambling
     // does the same as innerWrite but without event loop
@@ -76,16 +77,64 @@ export class WriteBuffer {
     this._callbacks.push(callback);
   }
 
-  protected _innerWrite(): void {
-    const startTime = Date.now();
+  protected _innerWrite(d: number = 0, promiseResult: boolean = true): void {
+    let result: void | Promise<boolean>;
+    const startTime = d || Date.now();
     while (this._writeBuffer.length > this._bufferOffset) {
       const data = this._writeBuffer[this._bufferOffset];
-      const cb = this._callbacks[this._bufferOffset];
-      this._bufferOffset++;
 
-      this._action(data);
-      this._pendingData -= data.length;
+      if (result = this._action(data, promiseResult)) {
+        /**
+         * If we get a promise as return value, we re-schedule the continuation
+         * as thenable on the promise and exit right away.
+         *
+         * The exit here means, that we block input processing at the current active chunk,
+         * the exact execution position within the chunk is preserved by the saved
+         * stack content in InputHandler and EscapeSequenceParser.
+         *
+         * Resuming happens automatically from that saved stack state.
+         * Also the resolved promise value is passed along the callstack to
+         * `EscapeSequenceParser.parse` to correctly resume the stopped handler loop.
+         *
+         * Exceptions on async handlers will be logged to console async, but do not interrupt
+         * the input processing (continues with next handler at the current input position).
+         * FIXME: No clear exception handling rules for sync handlers yet (will exit whole processing?).
+         */
+
+        /**
+         * If a promise takes long to resolve, we should schedule continuation behind setTimeout.
+         * This might already be too late, if our .then enters really late (executor + prev thens took very long).
+         * This cannot be solved here for the handler itself (it is the handlers responsibility to slice hard work),
+         * but we can at least schedule a screen update as we gain control.
+         */
+        const continuation: (r: boolean) => void = (r: boolean) => Date.now() - startTime >= WRITE_TIMEOUT_MS
+          ? setTimeout(() => this._innerWrite(0, r))
+          : this._innerWrite(startTime, r);
+
+        /**
+         * Optimization considerations:
+         * The continuation above favors FPS over throughput by eval'ing `startTime` on resolve.
+         * This might schedule too many screen updates with bad throughput drops (in case a slow
+         * resolving handler sliced its work properly behind setTimeout calls). We cannot spot
+         * this condition here, also the renderer has no way to spot nonsense updates either.
+         * FIXME: A proper fix for this would track the FPS at the renderer entry level separately.
+         *
+         * If favoring of FPS shows bad throughtput impact, use the following instead. It favors
+         * throughput by eval'ing `startTime` upfront pulling at least one more chunk into the
+         * current microtask queue (executed before setTimeout).
+         */
+        // const continuation: (r: boolean) => void = Date.now() - startTime >= WRITE_TIMEOUT_MS
+        //   ? r => setTimeout(() => this._innerWrite(0, r))
+        //   : r => this._innerWrite(startTime, r);
+
+        result.then(continuation, err => { setTimeout(() => { throw err; }); continuation(true); });
+        return;
+      }
+
+      const cb = this._callbacks[this._bufferOffset];
       if (cb) cb();
+      this._bufferOffset++;
+      this._pendingData -= data.length;
 
       if (Date.now() - startTime >= WRITE_TIMEOUT_MS) {
         break;
@@ -99,7 +148,7 @@ export class WriteBuffer {
         this._callbacks = this._callbacks.slice(this._bufferOffset);
         this._bufferOffset = 0;
       }
-      setTimeout(() => this._innerWrite(), 0);
+      setTimeout(() => this._innerWrite());
     } else {
       this._writeBuffer = [];
       this._callbacks = [];

--- a/src/common/parser/DcsParser.ts
+++ b/src/common/parser/DcsParser.ts
@@ -48,9 +48,13 @@ export class DcsParser implements IDcsParser {
   }
 
   public reset(): void {
+    // force cleanup leftover handlers
     if (this._active.length) {
-      this.unhook(false);
+      for (let j = this._stack.paused ? this._stack.loopPosition - 1 : this._active.length - 1; j >= 0; --j) {
+        this._active[j].unhook(false);
+      }
     }
+    this._stack.paused = false;
     this._active = EMPTY_HANDLERS;
     this._ident = 0;
   }

--- a/src/common/parser/DcsParser.ts
+++ b/src/common/parser/DcsParser.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDisposable } from 'common/Types';
-import { IDcsHandler, IParams, IHandlerCollection, IDcsParser, DcsFallbackHandlerType } from 'common/parser/Types';
+import { IDcsHandler, IParams, IHandlerCollection, IDcsParser, DcsFallbackHandlerType, ISubParserStackState } from 'common/parser/Types';
 import { utf32ToString } from 'common/input/TextDecoder';
 import { Params } from 'common/parser/Params';
 import { PAYLOAD_LIMIT } from 'common/parser/Constants';
@@ -16,6 +16,11 @@ export class DcsParser implements IDcsParser {
   private _active: IDcsHandler[] = EMPTY_HANDLERS;
   private _ident: number = 0;
   private _handlerFb: DcsFallbackHandlerType = () => { };
+  private _stack: ISubParserStackState = {
+    paused: false,
+    loopPosition: 0,
+    fallThrough: false
+  };
 
   public dispose(): void {
     this._handlers = Object.create(null);
@@ -83,11 +88,6 @@ export class DcsParser implements IDcsParser {
     }
   }
 
-  private _stack = {
-    paused: false,
-    loopPosition: 0,
-    fallThrough: false
-  };
   public unhook(success: boolean, promiseResult: boolean = true): void | Promise<boolean> {
     if (!this._active.length) {
       this._handlerFb(this._ident, 'UNHOOK', success);

--- a/src/common/parser/EscapeSequenceParser.test.ts
+++ b/src/common/parser/EscapeSequenceParser.test.ts
@@ -1847,7 +1847,9 @@ describe('EscapeSequenceParser - async', () => {
       // keeps being broken for further parse calls (sync and async)
       assert.throws(() => parseSync(parser, 'random'), 'improper continuation due to previous async handler, giving up parsing');
       await throwsAsync(() => parseP(parser, 'foobar'), 'improper continuation due to previous async handler, giving up parsing');
-      // FIXME: come up with a good recovery strategy
+      // reset should lift the error condition
+      parser.reset();
+      await parseP(parser, INPUT); // does not throw anymore
     });
     it('correct result on awaited parse call', async () => {
       await parseP(parser, INPUT);

--- a/src/common/parser/EscapeSequenceParser.test.ts
+++ b/src/common/parser/EscapeSequenceParser.test.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { IParsingState, IParams, ParamsArray, IOscParser, IOscHandler, OscFallbackHandlerType, IFunctionIdentifier } from 'common/parser/Types';
+import { IParsingState, IParams, ParamsArray, IOscParser, IOscHandler, OscFallbackHandlerType, IFunctionIdentifier, IParserStackState, ParserStackType, ResumableHandlersType } from 'common/parser/Types';
 import { EscapeSequenceParser, TransitionTable, VT500_TRANSITION_TABLE } from 'common/parser/EscapeSequenceParser';
 import { assert } from 'chai';
 import { StringToUtf32, stringFromCodePoint, utf32ToString } from 'common/input/TextDecoder';
@@ -24,7 +24,7 @@ function r(a: number, b: number): string[] {
 }
 
 class MockOscPutParser implements IOscParser {
-  private _fallback: OscFallbackHandlerType = () => {};
+  private _fallback: OscFallbackHandlerType = () => { };
   public data = '';
   public reset(): void {
     this.data = '';
@@ -91,6 +91,21 @@ class TestEscapeSequenceParser extends EscapeSequenceParser {
   }
   public identifier(id: IFunctionIdentifier): number {
     return this._identifier(id);
+  }
+  public get parseStack(): IParserStackState {
+    return this._parseStack;
+  }
+  private _trackStack = false;
+  public trackStackSavesOnPause(): void {
+    this._trackStack = true;
+  }
+  public trackedStack: IParserStackState[] = [];
+  public parse(data: Uint32Array, length: number, promiseResult?: boolean): void | Promise<boolean> {
+    const result = super.parse(data, length, promiseResult);
+    if (result && this._trackStack) {
+      this.trackedStack.push({ ...this.parseStack });
+    }
+    return result;
   }
 }
 
@@ -1206,71 +1221,71 @@ describe('EscapeSequenceParser', () => {
       assert.equal(print, '');
     });
     it('ESC handler', () => {
-      parser2.registerEscHandler({intermediates: '%', final: 'G'}, function (): boolean {
+      parser2.registerEscHandler({ intermediates: '%', final: 'G' }, function (): boolean {
         esc.push('%G');
         return true;
       });
-      parser2.registerEscHandler({final: 'E'}, function (): boolean {
+      parser2.registerEscHandler({ final: 'E' }, function (): boolean {
         esc.push('E');
         return true;
       });
       parse(parser2, INPUT);
       assert.deepEqual(esc, ['%G', 'E']);
-      parser2.clearEscHandler({intermediates: '%', final: 'G'});
-      parser2.clearEscHandler({intermediates: '%', final: 'G'}); // should not throw
+      parser2.clearEscHandler({ intermediates: '%', final: 'G' });
+      parser2.clearEscHandler({ intermediates: '%', final: 'G' }); // should not throw
       clearAccu();
       parse(parser2, INPUT);
       assert.deepEqual(esc, ['E']);
-      parser2.clearEscHandler({final: 'E'});
+      parser2.clearEscHandler({ final: 'E' });
       clearAccu();
       parse(parser2, INPUT);
       assert.deepEqual(esc, []);
     });
     describe('ESC custom handlers', () => {
       it('prevent fallback', () => {
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('default - %G'); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('default - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom - %G'); return true; });
         parse(parser2, INPUT);
         assert.deepEqual(esc, ['custom - %G']);
       });
       it('allow fallback', () => {
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('default - %G'); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom - %G'); return false; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('default - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom - %G'); return false; });
         parse(parser2, INPUT);
         assert.deepEqual(esc, ['custom - %G', 'default - %G']);
       });
       it('Multiple custom handlers fallback once', () => {
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('default - %G'); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom - %G'); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom2 - %G'); return false; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('default - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom2 - %G'); return false; });
         parse(parser2, INPUT);
         assert.deepEqual(esc, ['custom2 - %G', 'custom - %G']);
       });
       it('Multiple custom handlers no fallback', () => {
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('default - %G'); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom - %G'); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom2 - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('default - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom2 - %G'); return true; });
         parse(parser2, INPUT);
         assert.deepEqual(esc, ['custom2 - %G']);
       });
       it('Execution order should go from latest handler down to the original', () => {
         const order: number[] = [];
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { order.push(1); return true; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { order.push(2); return false; });
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { order.push(3); return false; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { order.push(1); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { order.push(2); return false; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { order.push(3); return false; });
         parse(parser2, '\x1b%G');
         assert.deepEqual(order, [3, 2, 1]);
       });
       it('Dispose should work', () => {
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('default - %G'); return true; });
-        const dispo = parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('default - %G'); return true; });
+        const dispo = parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom - %G'); return true; });
         dispo.dispose();
         parse(parser2, INPUT);
         assert.deepEqual(esc, ['default - %G']);
       });
       it('Should not corrupt the parser when dispose is called twice', () => {
-        parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('default - %G'); return true; });
-        const dispo = parser2.registerEscHandler({intermediates: '%', final: 'G'}, () => { esc.push('custom - %G'); return true; });
+        parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('default - %G'); return true; });
+        const dispo = parser2.registerEscHandler({ intermediates: '%', final: 'G' }, () => { esc.push('custom - %G'); return true; });
         dispo.dispose();
         dispo.dispose();
         parse(parser2, INPUT);
@@ -1278,14 +1293,14 @@ describe('EscapeSequenceParser', () => {
       });
     });
     it('CSI handler', () => {
-      parser2.registerCsiHandler({final: 'm'}, function (params: IParams): boolean {
+      parser2.registerCsiHandler({ final: 'm' }, function (params: IParams): boolean {
         csi.push(['m', params.toArray(), '']);
         return true;
       });
       parse(parser2, INPUT);
       assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']]);
-      parser2.clearCsiHandler({final: 'm'});
-      parser2.clearCsiHandler({final: 'm'}); // should not throw
+      parser2.clearCsiHandler({ final: 'm' });
+      parser2.clearCsiHandler({ final: 'm' }); // should not throw
       clearAccu();
       parse(parser2, INPUT);
       assert.deepEqual(csi, []);
@@ -1293,16 +1308,16 @@ describe('EscapeSequenceParser', () => {
     describe('CSI custom handlers', () => {
       it('Prevent fallback', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
-        parser2.registerCsiHandler({final: 'm'}, params => { csi.push(['m', params.toArray(), '']); return true; });
-        parser2.registerCsiHandler({final: 'm'}, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csi.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
         parse(parser2, INPUT);
         assert.deepEqual(csi, [], 'Should not fallback to original handler');
         assert.deepEqual(csiCustom, [['m', [1, 31], ''], ['m', [0], '']]);
       });
       it('Allow fallback', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
-        parser2.registerCsiHandler({final: 'm'}, params => { csi.push(['m', params.toArray(), '']); return true; });
-        parser2.registerCsiHandler({final: 'm'}, params => { csiCustom.push(['m', params.toArray(), '']); return false; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csi.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom.push(['m', params.toArray(), '']); return false; });
         parse(parser2, INPUT);
         assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']], 'Should fallback to original handler');
         assert.deepEqual(csiCustom, [['m', [1, 31], ''], ['m', [0], '']]);
@@ -1310,9 +1325,9 @@ describe('EscapeSequenceParser', () => {
       it('Multiple custom handlers fallback once', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
         const csiCustom2: [string, ParamsArray, string][] = [];
-        parser2.registerCsiHandler({final: 'm'}, params => { csi.push(['m', params.toArray(), '']); return true; });
-        parser2.registerCsiHandler({final: 'm'}, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
-        parser2.registerCsiHandler({final: 'm'}, params => { csiCustom2.push(['m', params.toArray(), '']); return false; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csi.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom2.push(['m', params.toArray(), '']); return false; });
         parse(parser2, INPUT);
         assert.deepEqual(csi, [], 'Should not fallback to original handler');
         assert.deepEqual(csiCustom, [['m', [1, 31], ''], ['m', [0], '']]);
@@ -1321,9 +1336,9 @@ describe('EscapeSequenceParser', () => {
       it('Multiple custom handlers no fallback', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
         const csiCustom2: [string, ParamsArray, string][] = [];
-        parser2.registerCsiHandler({final: 'm'}, params => { csi.push(['m', params.toArray(), '']); return true; });
-        parser2.registerCsiHandler({final: 'm'}, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
-        parser2.registerCsiHandler({final: 'm'}, params => { csiCustom2.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csi.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom2.push(['m', params.toArray(), '']); return true; });
         parse(parser2, INPUT);
         assert.deepEqual(csi, [], 'Should not fallback to original handler');
         assert.deepEqual(csiCustom, [], 'Should not fallback once');
@@ -1331,16 +1346,16 @@ describe('EscapeSequenceParser', () => {
       });
       it('Execution order should go from latest handler down to the original', () => {
         const order: number[] = [];
-        parser2.registerCsiHandler({final: 'm'}, () => { order.push(1); return true; });
-        parser2.registerCsiHandler({final: 'm'}, () => { order.push(2); return false; });
-        parser2.registerCsiHandler({final: 'm'}, () => { order.push(3); return false; });
+        parser2.registerCsiHandler({ final: 'm' }, () => { order.push(1); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, () => { order.push(2); return false; });
+        parser2.registerCsiHandler({ final: 'm' }, () => { order.push(3); return false; });
         parse(parser2, '\x1b[0m');
         assert.deepEqual(order, [3, 2, 1]);
       });
       it('Dispose should work', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
-        parser2.registerCsiHandler({final: 'm'}, params => { csi.push(['m', params.toArray(), '']); return true; });
-        const customHandler = parser2.registerCsiHandler({final: 'm'}, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csi.push(['m', params.toArray(), '']); return true; });
+        const customHandler = parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
         customHandler.dispose();
         parse(parser2, INPUT);
         assert.deepEqual(csi, [['m', [1, 31], ''], ['m', [0], '']]);
@@ -1348,8 +1363,8 @@ describe('EscapeSequenceParser', () => {
       });
       it('Should not corrupt the parser when dispose is called twice', () => {
         const csiCustom: [string, ParamsArray, string][] = [];
-        parser2.registerCsiHandler({final: 'm'}, params => { csi.push(['m', params.toArray(), '']); return true; });
-        const customHandler = parser2.registerCsiHandler({final: 'm'}, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
+        parser2.registerCsiHandler({ final: 'm' }, params => { csi.push(['m', params.toArray(), '']); return true; });
+        const customHandler = parser2.registerCsiHandler({ final: 'm' }, params => { csiCustom.push(['m', params.toArray(), '']); return true; });
         customHandler.dispose();
         customHandler.dispose();
         parse(parser2, INPUT);
@@ -1455,7 +1470,7 @@ describe('EscapeSequenceParser', () => {
       });
     });
     it('DCS handler', () => {
-      parser2.registerDcsHandler({intermediates: '+', final: 'p'}, {
+      parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, {
         hook: function (params: IParams): void {
           dcs.push(['hook', '', params.toArray(), 0]);
         },
@@ -1478,8 +1493,8 @@ describe('EscapeSequenceParser', () => {
         ['put', 'abc'], ['put', ';de'],
         ['unhook']
       ]);
-      parser2.clearDcsHandler({intermediates: '+', final: 'p'});
-      parser2.clearDcsHandler({intermediates: '+', final: 'p'}); // should not throw
+      parser2.clearDcsHandler({ intermediates: '+', final: 'p' });
+      parser2.clearDcsHandler({ intermediates: '+', final: 'p' }); // should not throw
       clearAccu();
       parse(parser2, '\x1bP1;2;3+pabc');
       parse(parser2, ';de\x9c');
@@ -1489,54 +1504,54 @@ describe('EscapeSequenceParser', () => {
       const DCS_INPUT = '\x1bP1;2;3+pabc\x1b\\';
       it('Prevent fallback', () => {
         const dcsCustom: [string, (number | number[])[], string][] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
         parse(parser2, DCS_INPUT);
         assert.deepEqual(dcsCustom, [['B', [1, 2, 3], 'abc']]);
       });
       it('Allow fallback', () => {
         const dcsCustom: [string, (number | number[])[], string][] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return false; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return false; }));
         parse(parser2, DCS_INPUT);
         assert.deepEqual(dcsCustom, [['B', [1, 2, 3], 'abc'], ['A', [1, 2, 3], 'abc']]);
       });
       it('Multiple custom handlers fallback once', () => {
         const dcsCustom: [string, (number | number[])[], string][] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['C', params.toArray(), data]); return false; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['C', params.toArray(), data]); return false; }));
         parse(parser2, DCS_INPUT);
         assert.deepEqual(dcsCustom, [['C', [1, 2, 3], 'abc'], ['B', [1, 2, 3], 'abc']]);
       });
       it('Multiple custom handlers no fallback', () => {
         const dcsCustom: [string, (number | number[])[], string][] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['C', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['C', params.toArray(), data]); return true; }));
         parse(parser2, DCS_INPUT);
         assert.deepEqual(dcsCustom, [['C', [1, 2, 3], 'abc']]);
       });
       it('Execution order should go from latest handler down to the original', () => {
         const order: number[] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler(() => { order.push(1); return true; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler(() => { order.push(2); return false; }));
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler(() => { order.push(3); return false; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler(() => { order.push(1); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler(() => { order.push(2); return false; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler(() => { order.push(3); return false; }));
         parse(parser2, DCS_INPUT);
         assert.deepEqual(order, [3, 2, 1]);
       });
       it('Dispose should work', () => {
         const dcsCustom: [string, (number | number[])[], string][] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
-        const dispo = parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
+        const dispo = parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
         dispo.dispose();
         parse(parser2, DCS_INPUT);
         assert.deepEqual(dcsCustom, [['A', [1, 2, 3], 'abc']]);
       });
       it('Should not corrupt the parser when dispose is called twice', () => {
         const dcsCustom: [string, (number | number[])[], string][] = [];
-        parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
-        const dispo = parser2.registerDcsHandler({intermediates: '+', final: 'p'}, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
+        parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['A', params.toArray(), data]); return true; }));
+        const dispo = parser2.registerDcsHandler({ intermediates: '+', final: 'p' }, new DcsHandler((data, params) => { dcsCustom.push(['B', params.toArray(), data]); return true; }));
         dispo.dispose();
         dispo.dispose();
         parse(parser2, DCS_INPUT);
@@ -1570,54 +1585,54 @@ describe('EscapeSequenceParser', () => {
       it('prefix range 0x3c .. 0x3f, one byte', () => {
         for (let i = 0x3c; i <= 0x3f; ++i) {
           const c = String.fromCharCode(i);
-          assert.equal(parser.identToString(parser.identifier({prefix: c, final: 'z'})), c + 'z');
+          assert.equal(parser.identToString(parser.identifier({ prefix: c, final: 'z' })), c + 'z');
         }
-        assert.throws(() => { parser.identifier({prefix: '\x3b', final: 'z'}); }, 'prefix must be in range 0x3c .. 0x3f');
-        assert.throws(() => { parser.identifier({prefix: '\x40', final: 'z'}); }, 'prefix must be in range 0x3c .. 0x3f');
-        assert.throws(() => { parser.identifier({prefix: '??', final: 'z'}); }, 'only one byte as prefix supported');
+        assert.throws(() => { parser.identifier({ prefix: '\x3b', final: 'z' }); }, 'prefix must be in range 0x3c .. 0x3f');
+        assert.throws(() => { parser.identifier({ prefix: '\x40', final: 'z' }); }, 'prefix must be in range 0x3c .. 0x3f');
+        assert.throws(() => { parser.identifier({ prefix: '??', final: 'z' }); }, 'only one byte as prefix supported');
       });
       it('intermediates range 0x20 .. 0x2f, up to two bytes', () => {
         for (let i = 0x20; i <= 0x2f; ++i) {
           const c = String.fromCharCode(i);
-          assert.equal(parser.identToString(parser.identifier({intermediates: c + c, final: 'z'})), c + c + 'z');
+          assert.equal(parser.identToString(parser.identifier({ intermediates: c + c, final: 'z' })), c + c + 'z');
         }
-        assert.throws(() => { parser.identifier({intermediates: '\x1f', final: 'z'}); }, 'intermediate must be in range 0x20 .. 0x2f');
-        assert.throws(() => { parser.identifier({intermediates: '\x30', final: 'z'}); }, 'intermediate must be in range 0x20 .. 0x2f');
-        assert.throws(() => { parser.identifier({intermediates: '!!!', final: 'z'}); }, 'only two bytes as intermediates are supported');
+        assert.throws(() => { parser.identifier({ intermediates: '\x1f', final: 'z' }); }, 'intermediate must be in range 0x20 .. 0x2f');
+        assert.throws(() => { parser.identifier({ intermediates: '\x30', final: 'z' }); }, 'intermediate must be in range 0x20 .. 0x2f');
+        assert.throws(() => { parser.identifier({ intermediates: '!!!', final: 'z' }); }, 'only two bytes as intermediates are supported');
       });
       it('final CSI/DCS range 0x40 .. 0x7e (default), one byte', () => {
         for (let i = 0x40; i <= 0x7e; ++i) {
           const c = String.fromCharCode(i);
-          assert.equal(parser.identToString(parser.identifier({final: c})), c);
+          assert.equal(parser.identToString(parser.identifier({ final: c })), c);
         }
-        assert.throws(() => { parser.identifier({final: '\x3f'}); }, 'final must be in range 64 .. 126');
-        assert.throws(() => { parser.identifier({final: '\x7f'}); }, 'final must be in range 64 .. 126');
-        assert.throws(() => { parser.identifier({final: 'zz'}); }, 'final must be a single byte');
+        assert.throws(() => { parser.identifier({ final: '\x3f' }); }, 'final must be in range 64 .. 126');
+        assert.throws(() => { parser.identifier({ final: '\x7f' }); }, 'final must be in range 64 .. 126');
+        assert.throws(() => { parser.identifier({ final: 'zz' }); }, 'final must be a single byte');
       });
       it('final ESC range 0x30 .. 0x7e, one byte', () => {
         for (let i = 0x30; i <= 0x7e; ++i) {
           const final = String.fromCharCode(i);
           let handler: IDisposable | undefined;
-          assert.doesNotThrow(() => { handler = parser.registerEscHandler({final}, () => true); }, 'final must be in range 48 .. 126');
+          assert.doesNotThrow(() => { handler = parser.registerEscHandler({ final }, () => true); }, 'final must be in range 48 .. 126');
           if (handler) handler.dispose();
         }
-        assert.throws(() => { parser.registerEscHandler({final: '\x2f'}, () => true); }, 'final must be in range 48 .. 126');
-        assert.throws(() => { parser.registerEscHandler({final: '\x7f'}, () => true); }, 'final must be in range 48 .. 126');
+        assert.throws(() => { parser.registerEscHandler({ final: '\x2f' }, () => true); }, 'final must be in range 48 .. 126');
+        assert.throws(() => { parser.registerEscHandler({ final: '\x7f' }, () => true); }, 'final must be in range 48 .. 126');
       });
       it('id calculation - should stacking prefix -> intermediate -> final', () => {
-        assert.equal(parser.identToString(parser.identifier({final: 'z'})), 'z');
-        assert.equal(parser.identToString(parser.identifier({prefix: '?', final: 'z'})), '?z');
-        assert.equal(parser.identToString(parser.identifier({intermediates: '!', final: 'z'})), '!z');
-        assert.equal(parser.identToString(parser.identifier({prefix: '?', intermediates: '!', final: 'z'})), '?!z');
-        assert.equal(parser.identToString(parser.identifier({prefix: '?', intermediates: '!!', final: 'z'})), '?!!z');
+        assert.equal(parser.identToString(parser.identifier({ final: 'z' })), 'z');
+        assert.equal(parser.identToString(parser.identifier({ prefix: '?', final: 'z' })), '?z');
+        assert.equal(parser.identToString(parser.identifier({ intermediates: '!', final: 'z' })), '!z');
+        assert.equal(parser.identToString(parser.identifier({ prefix: '?', intermediates: '!', final: 'z' })), '?!z');
+        assert.equal(parser.identToString(parser.identifier({ prefix: '?', intermediates: '!!', final: 'z' })), '?!!z');
       });
     });
     describe('identifier invocation', () => {
       it('ESC', () => {
         const callstack: string[] = [];
-        const h1 = parser.registerEscHandler({final: 'z'}, () => { callstack.push('z'); return true; });
-        const h2 = parser.registerEscHandler({intermediates: '!', final: 'z'}, () => { callstack.push('!z'); return true; });
-        const h3 = parser.registerEscHandler({intermediates: '!!', final: 'z'}, () => { callstack.push('!!z'); return true; });
+        const h1 = parser.registerEscHandler({ final: 'z' }, () => { callstack.push('z'); return true; });
+        const h2 = parser.registerEscHandler({ intermediates: '!', final: 'z' }, () => { callstack.push('!z'); return true; });
+        const h3 = parser.registerEscHandler({ intermediates: '!!', final: 'z' }, () => { callstack.push('!!z'); return true; });
         parse(parser, '\x1bz\x1b!z\x1b!!z');
         h1.dispose();
         h2.dispose();
@@ -1627,12 +1642,12 @@ describe('EscapeSequenceParser', () => {
       });
       it('CSI', () => {
         const callstack: any[] = [];
-        const h1 = parser.registerCsiHandler({final: 'z'}, params => { callstack.push(['z', params.toArray()]); return true; });
-        const h2 = parser.registerCsiHandler({intermediates: '!', final: 'z'}, params => { callstack.push(['!z', params.toArray()]); return true; });
-        const h3 = parser.registerCsiHandler({intermediates: '!!', final: 'z'}, params => { callstack.push(['!!z', params.toArray()]); return true; });
-        const h4 = parser.registerCsiHandler({prefix: '?', final: 'z'}, params => { callstack.push(['?z', params.toArray()]); return true; });
-        const h5 = parser.registerCsiHandler({prefix: '?', intermediates: '!', final: 'z'}, params => { callstack.push(['?!z', params.toArray()]); return true; });
-        const h6 = parser.registerCsiHandler({prefix: '?', intermediates: '!!', final: 'z'}, params => { callstack.push(['?!!z', params.toArray()]); return true; });
+        const h1 = parser.registerCsiHandler({ final: 'z' }, params => { callstack.push(['z', params.toArray()]); return true; });
+        const h2 = parser.registerCsiHandler({ intermediates: '!', final: 'z' }, params => { callstack.push(['!z', params.toArray()]); return true; });
+        const h3 = parser.registerCsiHandler({ intermediates: '!!', final: 'z' }, params => { callstack.push(['!!z', params.toArray()]); return true; });
+        const h4 = parser.registerCsiHandler({ prefix: '?', final: 'z' }, params => { callstack.push(['?z', params.toArray()]); return true; });
+        const h5 = parser.registerCsiHandler({ prefix: '?', intermediates: '!', final: 'z' }, params => { callstack.push(['?!z', params.toArray()]); return true; });
+        const h6 = parser.registerCsiHandler({ prefix: '?', intermediates: '!!', final: 'z' }, params => { callstack.push(['?!!z', params.toArray()]); return true; });
         parse(parser, '\x1b[1;z\x1b[1;!z\x1b[1;!!z\x1b[?1;z\x1b[?1;!z\x1b[?1;!!z');
         h1.dispose();
         h2.dispose();
@@ -1648,12 +1663,12 @@ describe('EscapeSequenceParser', () => {
       });
       it('DCS', () => {
         const callstack: any[] = [];
-        const h1 = parser.registerDcsHandler({final: 'z'}, new DcsHandler((data, params) => { callstack.push(['z', params.toArray(), data]); return true; }));
-        const h2 = parser.registerDcsHandler({intermediates: '!', final: 'z'}, new DcsHandler((data, params) => { callstack.push(['!z', params.toArray(), data]); return true; }));
-        const h3 = parser.registerDcsHandler({intermediates: '!!', final: 'z'}, new DcsHandler((data, params) => { callstack.push(['!!z', params.toArray(), data]); return true; }));
-        const h4 = parser.registerDcsHandler({prefix: '?', final: 'z'}, new DcsHandler((data, params) => { callstack.push(['?z', params.toArray(), data]); return true; }));
-        const h5 = parser.registerDcsHandler({prefix: '?', intermediates: '!', final: 'z'}, new DcsHandler((data, params) => { callstack.push(['?!z', params.toArray(), data]); return true; }));
-        const h6 = parser.registerDcsHandler({prefix: '?', intermediates: '!!', final: 'z'}, new DcsHandler((data, params) => { callstack.push(['?!!z', params.toArray(), data]); return true; }));
+        const h1 = parser.registerDcsHandler({ final: 'z' }, new DcsHandler((data, params) => { callstack.push(['z', params.toArray(), data]); return true; }));
+        const h2 = parser.registerDcsHandler({ intermediates: '!', final: 'z' }, new DcsHandler((data, params) => { callstack.push(['!z', params.toArray(), data]); return true; }));
+        const h3 = parser.registerDcsHandler({ intermediates: '!!', final: 'z' }, new DcsHandler((data, params) => { callstack.push(['!!z', params.toArray(), data]); return true; }));
+        const h4 = parser.registerDcsHandler({ prefix: '?', final: 'z' }, new DcsHandler((data, params) => { callstack.push(['?z', params.toArray(), data]); return true; }));
+        const h5 = parser.registerDcsHandler({ prefix: '?', intermediates: '!', final: 'z' }, new DcsHandler((data, params) => { callstack.push(['?!z', params.toArray(), data]); return true; }));
+        const h6 = parser.registerDcsHandler({ prefix: '?', intermediates: '!!', final: 'z' }, new DcsHandler((data, params) => { callstack.push(['?!!z', params.toArray(), data]); return true; }));
         parse(parser, '\x1bP1;zAB\x1b\\\x1bP1;!zAB\x1b\\\x1bP1;!!zAB\x1b\\\x1bP?1;zAB\x1b\\\x1bP?1;!zAB\x1b\\\x1bP?1;!!zAB\x1b\\');
         h1.dispose();
         h2.dispose();
@@ -1677,4 +1692,366 @@ describe('EscapeSequenceParser', () => {
     });
   });
   // TODO: error conditions and error recovery (not implemented yet in parser)
+});
+
+
+/**
+ * async handler tests.
+ */
+
+function parseSync(parser: TestEscapeSequenceParser, data: string): void | Promise<boolean> {
+  const container = new Uint32Array(data.length);
+  const decoder = new StringToUtf32();
+  return parser.parse(container, decoder.decode(data, container));
+}
+async function parseP(parser: TestEscapeSequenceParser, data: string): Promise<void> {
+  const container = new Uint32Array(data.length);
+  const decoder = new StringToUtf32();
+  const len = decoder.decode(data, container);
+  let result: void | Promise<boolean>;
+  let prev: boolean | undefined;
+  while (result = parser.parse(container, len, prev)) {
+    prev = await result;
+  }
+}
+function evalStackSaves(stackSaves: IParserStackState[], data: [number, ParserStackType, number][]): void {
+  assert.equal(stackSaves.length, data.length);
+  for (let i = 0; i < data.length; ++i) {
+    assert.equal(stackSaves[i].chunkPos, data[i][0]);
+    assert.equal(stackSaves[i].state, data[i][1]);
+    assert.equal(stackSaves[i].handlerPos, data[i][2]);
+  }
+}
+// helper similiar to assert.throws for async functions
+async function throwsAsync(fn: () => Promise<any>, message?: string | undefined): Promise<void> {
+  let msg: string | undefined;
+  try {
+    await fn();
+  } catch (e) {
+    if (e instanceof Error) {
+      msg = e.message;
+    } else if (typeof e === 'string') {
+      msg = e;
+    }
+    if (typeof message === 'string') {
+      assert.equal(msg, message);
+    }
+    return;
+  }
+  assert.throws(fn, message);
+}
+
+describe('EscapeSequenceParser - async', () => {
+  // sequences: SGR 1;31 | hello SP | ESC %G | wor | ESC E | ld! | SGR 0 | EXE \r\n | $> | OSC 1;foo=bar ST
+  // needed handlers: CSI m, PRINT, ESC %G, ESC E, EXE \r, EXE \n, OSC 1
+  const INPUT = '\x1b[1;31mhello \x1b%Gwor\x1bEld!\x1b[0m\r\n$>\x1b]1;foo=bar\x1b\\';
+  let RESULT: any[];
+  let parser: TestEscapeSequenceParser;
+  const callstack: any[] = [];
+  function clearAccu(): void {
+    callstack.length = 0;
+    parser.trackedStack.length = 0;
+  }
+  beforeEach(() => {
+    RESULT = [
+      ['SGR', [1, 31]],
+      ['PRINT', 'hello '],
+      ['ESC %G'],
+      ['PRINT', 'wor'],
+      ['ESC E'],
+      ['PRINT', 'ld!'],
+      ['SGR', [0]],
+      ['EXE \r'],
+      ['EXE \n'],
+      ['PRINT', '$>'],
+      ['OSC 1', 'foo=bar']
+    ];
+    parser = new TestEscapeSequenceParser();
+    parser.reset();
+    parser.trackStackSavesOnPause();
+    clearAccu();
+  });
+  describe('sync handlers should behave as before', () => {
+    beforeEach(() => {
+      parser.setPrintHandler((data, start, end) => {
+        let result = '';
+        for (let i = start; i < end; ++i) {
+          result += stringFromCodePoint(data[i]);
+        }
+        callstack.push(['PRINT', result]);
+      });
+      parser.registerCsiHandler({ final: 'm' }, params => { callstack.push(['SGR', params.toArray()]); return true; });
+      parser.registerEscHandler({ intermediates: '%', final: 'G' }, () => { callstack.push(['ESC %G']); return true; });
+      parser.registerEscHandler({ final: 'E' }, () => { callstack.push(['ESC E']); return true; });
+      parser.setExecuteHandler('\r', () => { callstack.push(['EXE \r']); return true; });
+      parser.setExecuteHandler('\n', () => { callstack.push(['EXE \n']); return true; });
+      parser.registerOscHandler(1, new OscHandler(data => { callstack.push(['OSC 1', data]); return true; }));
+    });
+
+    it('sync handlers keep parsed in sync mode', () => {
+      // note: if we have only sync handlers, a parse call should never return anything
+      assert.equal(!parseSync(parser, INPUT), true);
+      assert.equal(parser.parseStack.state, ParserStackType.NONE);  // not paused
+      assert.equal(parser.trackedStack.length, 0);                  // never got paused
+    });
+    it('correct result on sync parse call', () => {
+      parseSync(parser, INPUT);
+      assert.deepEqual(callstack, RESULT);
+      assert.equal(parser.trackedStack.length, 0);
+    });
+    it('correct result on async parse call', async () => {
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT);
+      assert.equal(parser.trackedStack.length, 0);
+    });
+  });
+  describe('async handlers', () => {
+    beforeEach(() => {
+      parser.setPrintHandler((data, start, end) => {
+        let result = '';
+        for (let i = start; i < end; ++i) {
+          result += stringFromCodePoint(data[i]);
+        }
+        callstack.push(['PRINT', result]);
+      });
+      parser.registerCsiHandler({ final: 'm' }, async params => { callstack.push(['SGR', params.toArray()]); return true; });
+      parser.registerEscHandler({ intermediates: '%', final: 'G' }, async () => { callstack.push(['ESC %G']); return true; });
+      parser.registerEscHandler({ final: 'E' }, async () => { callstack.push(['ESC E']); return true; });
+      parser.setExecuteHandler('\r', () => { callstack.push(['EXE \r']); return true; });
+      parser.setExecuteHandler('\n', () => { callstack.push(['EXE \n']); return true; });
+      parser.registerOscHandler(1, new OscHandler(data => { callstack.push(['OSC 1', data]); return true; }));
+    });
+
+    it('sync parse call does not work anymore', () => {
+      assert.notEqual(!parseSync(parser, INPUT), true);
+      assert.notDeepEqual(callstack, RESULT);
+      // due to sync calling we should save exactly one saved stack
+      // proper continuation is not possible anymore, as we lost the promise resolve value
+      assert.equal(parser.trackedStack.length, 1);
+    });
+    it('improper continuation should throw', async () => {
+      /**
+       * Explanation:
+       * The first sync call will stop at the first promise returned,
+       * but does not await its resolve value.
+       * The second sync call to parse will fail due to missing `promiseResult`,
+       * which is needed for correct continuation.
+       */
+      assert.notEqual(!parseSync(parser, INPUT), true);
+      assert.notDeepEqual(callstack, RESULT);
+      assert.throws(() => parseSync(parser, INPUT), 'improper continuation due to previous async handler, giving up parsing');
+      // keeps being broken for further parse calls (sync and async)
+      assert.throws(() => parseSync(parser, 'random'), 'improper continuation due to previous async handler, giving up parsing');
+      await throwsAsync(() => parseP(parser, 'foobar'), 'improper continuation due to previous async handler, giving up parsing');
+      // FIXME: come up with a good recovery strategy
+    });
+    it('correct result on awaited parse call', async () => {
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT);
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0], [15, ParserStackType.ESC, 0], [20, ParserStackType.ESC, 0], [27, ParserStackType.CSI, 0]
+      ]);
+    });
+    it('correct result on chunked awaited parse calls', async () => {
+      RESULT = [
+        ['SGR', [1, 31]],
+        ['PRINT', 'h'],  // due to single char input PRINT is split
+        ['PRINT', 'e'],
+        ['PRINT', 'l'],
+        ['PRINT', 'l'],
+        ['PRINT', 'o'],
+        ['PRINT', ' '],
+        ['ESC %G'],
+        ['PRINT', 'w'],
+        ['PRINT', 'o'],
+        ['PRINT', 'r'],
+        ['ESC E'],
+        ['PRINT', 'l'],
+        ['PRINT', 'd'],
+        ['PRINT', '!'],
+        ['SGR', [0]],
+        ['EXE \r'],
+        ['EXE \n'],
+        ['PRINT', '$'],
+        ['PRINT', '>'],
+        ['OSC 1', 'foo=bar']
+      ];
+
+      // split to single char input
+      for (let i = 0; i < INPUT.length; ++i) {
+        // Note: a single fully awaited parse call always ends in sync mode,
+        // which re-enables faster sync processing in the higher up callstack
+        await parseP(parser, INPUT[i]);
+      }
+      assert.deepEqual(callstack, RESULT);
+      evalStackSaves(parser.trackedStack, [
+        [0, ParserStackType.CSI, 0],
+        [0, ParserStackType.ESC, 0],
+        [0, ParserStackType.ESC, 0],
+        [0, ParserStackType.CSI, 0]
+      ]);
+    });
+    it('multiple async SGR handlers', async () => {
+      // register with fallback
+      const SGR2 = parser.registerCsiHandler({ final: 'm' }, async params => { callstack.push(['2# SGR', params.toArray()]); return false; });
+      await parseP(parser, INPUT);
+      // should contain [2# SGR, SGR] call pairs
+      for (let i = 0; i < callstack.length; ++i) {
+        const entry = callstack[i];
+        if (entry[0] === '2# SGR') assert.equal(callstack[i + 1][0], 'SGR', 'Should fallback to original handler');
+      }
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 1],
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 1],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+      // after dispose we should be back to RESULT
+      SGR2.dispose();
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT, 'Should not call custom handler');
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+
+      // register without fallback
+      const SGR22 = parser.registerCsiHandler({ final: 'm' }, async params => { callstack.push(['2# SGR', params.toArray()]); return true; });
+      await parseP(parser, INPUT);
+      // should only contain 2# SGR
+      for (let i = 0; i < callstack.length; ++i) {
+        const entry = callstack[i];
+        if (entry[0] === '2# SGR') assert.notEqual(callstack[i + 1][0], 'SGR', 'Should not fallback to original handler');
+      }
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 1],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 1]
+      ]);
+      clearAccu();
+      // after dispose we should be back to RESULT
+      SGR22.dispose();
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT, 'Should not call custom handler');
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 0]
+      ]);
+    });
+    it('multiple async ESC handlers', async () => {
+      // register with fallback
+      const ESC2 = parser.registerEscHandler({ final: 'E' }, async () => { callstack.push(['2# ESC E']); return false; });
+      await parseP(parser, INPUT);
+      for (let i = 0; i < callstack.length; ++i) {
+        const entry = callstack[i];
+        if (entry[0] === '2# ESC E') assert.equal(callstack[i + 1][0], 'ESC E', 'Should fallback to original handler');
+      }
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 1],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+      // after dispose we should be back to RESULT
+      ESC2.dispose();
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT, 'Should not call custom handler');
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+
+      // register without fallback
+      const ESC22 = parser.registerEscHandler({ final: 'E' }, async () => { callstack.push(['2# ESC E']); return true; });
+      await parseP(parser, INPUT);
+      for (let i = 0; i < callstack.length; ++i) {
+        const entry = callstack[i];
+        if (entry[0] === '2# ESC E') assert.notEqual(callstack[i + 1][0], 'ESC E', 'Should not fallback to original handler');
+      }
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 1],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+      // after dispose we should be back to RESULT
+      ESC22.dispose();
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT, 'Should not call custom handler');
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 0]
+      ]);
+    });
+    it('sync/async SGR mixed', async () => {
+      // sync with fallback
+      const SGR2 = parser.registerCsiHandler({ final: 'm' }, params => { callstack.push(['2# SGR', params.toArray()]); return false; });
+      // async with fallback
+      const SGR3 = parser.registerCsiHandler({ final: 'm' }, async params => { callstack.push(['3# SGR', params.toArray()]); return false; });
+      await parseP(parser, INPUT);
+      // should contain [3# SGR, 2# SGR, SGR] call triples
+      for (let i = 0; i < callstack.length; ++i) {
+        const entry = callstack[i];
+        if (entry[0] === '3# SGR') {
+          assert.equal(callstack[i + 1][0], '2# SGR', 'Should fallback to next handler');
+          assert.equal(callstack[i + 2][0], 'SGR', 'Should fallback to original handler');
+        }
+      }
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 2],
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 2],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+      // dispose SGR2 (sync one)
+      SGR2.dispose();
+      await parseP(parser, INPUT);
+      // should contain [3# SGR, SGR] call pairs
+      for (let i = 0; i < callstack.length; ++i) {
+        const entry = callstack[i];
+        if (entry[0] === '3# SGR') {
+          assert.equal(callstack[i + 1][0], 'SGR', 'Should fallback to original handler');
+        }
+      }
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 1],
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 1],
+        [27, ParserStackType.CSI, 0]
+      ]);
+      clearAccu();
+      // dispose SGR3 (async one)
+      SGR3.dispose();
+      await parseP(parser, INPUT);
+      assert.deepEqual(callstack, RESULT, 'Should not call custom handler');
+      evalStackSaves(parser.trackedStack, [
+        [6, ParserStackType.CSI, 0],
+        [15, ParserStackType.ESC, 0],
+        [20, ParserStackType.ESC, 0],
+        [27, ParserStackType.CSI, 0]
+      ]);
+    });
+  });
 });

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -526,18 +526,17 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
         this._parseStack.state = ParserStackType.FAIL;
         throw new Error('improper continuation due to previous async handler, giving up parsing');
       }
-      let handlerPos = this._parseStack.handlerPos - 1;
 
       // we have to resume the old handler loop if:
       // - return value of the promise was `false`
       // - handlers are not exhausted yet
       // FIXME: removing handlers from within a handler of the same sequence
       //        is not supported atm (also true for sync handlers)!!
-      let handlers: ResumableHandlersType;
+      let handlers = this._parseStack.handlers;
+      let handlerPos = this._parseStack.handlerPos - 1;
       switch (this._parseStack.state) {
         case ParserStackType.CSI:
           if (promiseResult === false && handlerPos > -1) {
-            handlers = this._parseStack.handlers;
             for (; handlerPos >= 0; handlerPos--) {
               if ((handlerResult = (handlers as CsiHandlerType[])[handlerPos](this._params)) !== false) {
                 if (handlerResult instanceof Promise) {
@@ -552,7 +551,6 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
           break;
         case ParserStackType.ESC:
           if (promiseResult === false && handlerPos > -1) {
-            handlers = this._parseStack.handlers;
             for (; handlerPos >= 0; handlerPos--) {
               if ((handlerResult = (handlers as EscHandlerType[])[handlerPos]()) !== false) {
                 if (handlerResult instanceof Promise) {

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -253,6 +253,15 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
   protected _escHandlerFb: EscFallbackHandlerType;
   protected _errorHandlerFb: (state: IParsingState) => IParsingState;
 
+  // parser stack save for async handler support
+  protected _parseStack: IParserStackState = {
+    state: ParserStackType.NONE,
+    handlers: [],
+    handlerPos: 0,
+    transition: 0,
+    chunkPos: 0
+  };
+
   constructor(
     protected readonly _transitions: TransitionTable = VT500_TRANSITION_TABLE
   ) {
@@ -456,13 +465,6 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
   /**
    * Async parse support.
    */
-  protected _parseStack: IParserStackState = {
-    state: ParserStackType.NONE,
-    handlers: [],
-    handlerPos: 0,
-    transition: 0,
-    chunkPos: 0
-  };
   protected _preserveStack(
     state: ParserStackType,
     handlers: ResumableHandlersType,

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -536,7 +536,7 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
       // - handlers are not exhausted yet
       // FIXME: removing handlers from within a handler of the same sequence
       //        is not supported atm (also true for sync handlers)!!
-      let handlers = this._parseStack.handlers;
+      const handlers = this._parseStack.handlers;
       let handlerPos = this._parseStack.handlerPos - 1;
       switch (this._parseStack.state) {
         case ParserStackType.CSI:

--- a/src/common/parser/OscParser.ts
+++ b/src/common/parser/OscParser.ts
@@ -46,10 +46,13 @@ export class OscParser implements IOscParser {
   }
 
   public reset(): void {
-    // cleanup handlers if payload was already sent
+    // force cleanup handlers if payload was already sent
     if (this._state === OscState.PAYLOAD) {
-      this.end(false);
+      for (let j = this._stack.paused ? this._stack.loopPosition - 1 : this._active.length - 1; j >= 0; --j) {
+        this._active[j].end(false);
+      }
     }
+    this._stack.paused = false;
     this._active = EMPTY_HANDLERS;
     this._id = -1;
     this._state = OscState.START;

--- a/src/common/parser/OscParser.ts
+++ b/src/common/parser/OscParser.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { IOscHandler, IHandlerCollection, OscFallbackHandlerType, IOscParser } from 'common/parser/Types';
+import { IOscHandler, IHandlerCollection, OscFallbackHandlerType, IOscParser, ISubParserStackState } from 'common/parser/Types';
 import { OscState, PAYLOAD_LIMIT } from 'common/parser/Constants';
 import { utf32ToString } from 'common/input/TextDecoder';
 import { IDisposable } from 'common/Types';
@@ -16,6 +16,11 @@ export class OscParser implements IOscParser {
   private _id = -1;
   private _handlers: IHandlerCollection<IOscHandler> = Object.create(null);
   private _handlerFb: OscFallbackHandlerType = () => { };
+  private _stack: ISubParserStackState = {
+    paused: false,
+    loopPosition: 0,
+    fallThrough: false
+  };
 
   public registerHandler(ident: number, handler: IOscHandler): IDisposable {
     if (this._handlers[ident] === undefined) {
@@ -118,12 +123,6 @@ export class OscParser implements IOscParser {
       this._put(data, start, end);
     }
   }
-
-  private _stack = {
-    paused: false,
-    loopPosition: 0,
-    fallThrough: false
-  };
 
   /**
    * Indicates end of an OSC command.

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -245,6 +245,7 @@ export interface IHandlerCollection<T> {
 export const enum ParserStackType {
   NONE = 0,
   FAIL,
+  RESET,
   CSI,
   ESC,
   OSC,

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -244,6 +244,7 @@ export interface IHandlerCollection<T> {
  */
 export const enum ParserStackType {
   NONE = 0,
+  FAIL,
   CSI,
   ESC,
   OSC,

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -242,6 +242,8 @@ export interface IHandlerCollection<T> {
 /**
  * Types for async parser support.
  */
+
+// type of saved stack state in parser
 export const enum ParserStackType {
   NONE = 0,
   FAIL,
@@ -251,11 +253,22 @@ export const enum ParserStackType {
   OSC,
   DCS
 }
+
+// aggregate of resumable handler lists
 export type ResumableHandlersType = CsiHandlerType[] | EscHandlerType[];
+
+// saved stack state of the parser
 export interface IParserStackState {
   state: ParserStackType;
   handlers: ResumableHandlersType;
   handlerPos: number;
   transition: number;
   chunkPos: number;
+}
+
+// saved stack state of subparser (OSC and DCS)
+export interface ISubParserStackState {
+  paused: boolean;
+  loopPosition: number;
+  fallThrough: boolean;
 }

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -5,7 +5,7 @@
 
 import { IDisposable } from 'common/Types';
 import { ParserState } from 'common/parser/Constants';
-import { OscParser } from 'common/parser/OscParser';
+
 
 /** sequence params serialized to js arrays */
 export type ParamsArray = (number | number[])[];
@@ -94,7 +94,7 @@ export interface IDcsHandler {
    * execution of the command should depend on `success`.
    * To save memory also cleanup data structures here.
    */
-  unhook(success: boolean): boolean;
+  unhook(success: boolean): boolean | Promise<boolean>;
 }
 export type DcsFallbackHandlerType = (ident: number, action: 'HOOK' | 'PUT' | 'UNHOOK', payload?: any) => void;
 
@@ -219,7 +219,7 @@ export interface IOscParser extends ISubParser<IOscHandler, OscFallbackHandlerTy
 
 export interface IDcsParser extends ISubParser<IDcsHandler, DcsFallbackHandlerType> {
   hook(ident: number, params: IParams): void;
-  unhook(success: boolean): void;
+  unhook(success: boolean, promiseResult?: boolean): void | Promise<boolean>;
 }
 
 /**

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -130,7 +130,7 @@ export interface IOscHandler {
    * execution of the command should depend on `success`.
    * To save memory also cleanup data structures here.
    */
-  end(success: boolean): boolean;
+  end(success: boolean): boolean | Promise<boolean>;
 }
 export type OscFallbackHandlerType = (ident: number, action: 'START' | 'PUT' | 'END', payload?: any) => void;
 
@@ -214,7 +214,7 @@ export interface ISubParser<T, U> extends IDisposable {
 
 export interface IOscParser extends ISubParser<IOscHandler, OscFallbackHandlerType> {
   start(): void;
-  end(success: boolean): void;
+  end(success: boolean, promiseResult?: boolean): void | Promise<boolean>;
 }
 
 export interface IDcsParser extends ISubParser<IDcsHandler, DcsFallbackHandlerType> {

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -5,6 +5,7 @@
 
 import { IDisposable } from 'common/Types';
 import { ParserState } from 'common/parser/Constants';
+import { OscParser } from 'common/parser/OscParser';
 
 /** sequence params serialized to js arrays */
 export type ParamsArray = (number | number[])[];
@@ -236,4 +237,23 @@ export interface IFunctionIdentifier {
 
 export interface IHandlerCollection<T> {
   [key: string]: T[];
+}
+
+/**
+ * Types for async parser support.
+ */
+export const enum ParserStackType {
+  NONE = 0,
+  CSI,
+  ESC,
+  OSC,
+  DCS
+}
+export type ResumableHandlersType = CsiHandlerType[] | EscHandlerType[];
+export interface IParserStackState {
+  state: ParserStackType;
+  handlers: ResumableHandlersType;
+  handlerPos: number;
+  transition: number;
+  chunkPos: number;
 }

--- a/src/common/parser/Types.d.ts
+++ b/src/common/parser/Types.d.ts
@@ -160,7 +160,7 @@ export interface IEscapeSequenceParser extends IDisposable {
    * Parse UTF32 codepoints in `data` up to `length`.
    * @param data The data to parse.
    */
-  parse(data: Uint32Array, length: number): void;
+  parse(data: Uint32Array, length: number, promiseResult?: boolean): void | Promise<boolean>;
 
   /**
    * Get string from numercial function identifier `ident`.

--- a/src/common/services/LogService.ts
+++ b/src/common/services/LogService.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { ILogService, IOptionsService } from 'common/services/Services';
+import { ILogService, IOptionsService, LogLevelEnum } from 'common/services/Services';
 
 type LogType = (message?: any, ...optionalParams: any[]) => void;
 
@@ -19,21 +19,12 @@ interface IConsole {
 // module doesn't depend on them so we need to explicitly declare it.
 declare const console: IConsole;
 
-
-export enum LogLevel {
-  DEBUG = 0,
-  INFO = 1,
-  WARN = 2,
-  ERROR = 3,
-  OFF = 4
-}
-
-const optionsKeyToLogLevel: { [key: string]: LogLevel } = {
-  debug: LogLevel.DEBUG,
-  info: LogLevel.INFO,
-  warn: LogLevel.WARN,
-  error: LogLevel.ERROR,
-  off: LogLevel.OFF
+const optionsKeyToLogLevel: { [key: string]: LogLevelEnum } = {
+  debug: LogLevelEnum.DEBUG,
+  info: LogLevelEnum.INFO,
+  warn: LogLevelEnum.WARN,
+  error: LogLevelEnum.ERROR,
+  off: LogLevelEnum.OFF
 };
 
 const LOG_PREFIX = 'xterm.js: ';
@@ -41,7 +32,7 @@ const LOG_PREFIX = 'xterm.js: ';
 export class LogService implements ILogService {
   public serviceBrand: any;
 
-  private _logLevel!: LogLevel;
+  public logLevel: LogLevelEnum = LogLevelEnum.OFF;
 
   constructor(
     @IOptionsService private readonly _optionsService: IOptionsService
@@ -55,7 +46,7 @@ export class LogService implements ILogService {
   }
 
   private _updateLogLevel(): void {
-    this._logLevel = optionsKeyToLogLevel[this._optionsService.options.logLevel];
+    this.logLevel = optionsKeyToLogLevel[this._optionsService.options.logLevel];
   }
 
   private _evalLazyOptionalParams(optionalParams: any[]): void {
@@ -72,25 +63,25 @@ export class LogService implements ILogService {
   }
 
   public debug(message: string, ...optionalParams: any[]): void {
-    if (this._logLevel <= LogLevel.DEBUG) {
+    if (this.logLevel <= LogLevelEnum.DEBUG) {
       this._log(console.log, message, optionalParams);
     }
   }
 
   public info(message: string, ...optionalParams: any[]): void {
-    if (this._logLevel <= LogLevel.INFO) {
+    if (this.logLevel <= LogLevelEnum.INFO) {
       this._log(console.info, message, optionalParams);
     }
   }
 
   public warn(message: string, ...optionalParams: any[]): void {
-    if (this._logLevel <= LogLevel.WARN) {
+    if (this.logLevel <= LogLevelEnum.WARN) {
       this._log(console.warn, message, optionalParams);
     }
   }
 
   public error(message: string, ...optionalParams: any[]): void {
-    if (this._logLevel <= LogLevel.ERROR) {
+    if (this.logLevel <= LogLevelEnum.ERROR) {
       this._log(console.error, message, optionalParams);
     }
   }

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -161,6 +161,8 @@ export const ILogService = createDecorator<ILogService>('LogService');
 export interface ILogService {
   serviceBrand: undefined;
 
+  logLevel: LogLevelEnum;
+
   debug(message: any, ...optionalParams: any[]): void;
   info(message: any, ...optionalParams: any[]): void;
   warn(message: any, ...optionalParams: any[]): void;
@@ -181,6 +183,13 @@ export interface IOptionsService {
 
 export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' | number;
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
+export enum LogLevelEnum {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  OFF = 4
+}
 export type RendererType = 'dom' | 'canvas';
 
 export interface IPartialTerminalOptions {

--- a/test/api/Parser.api.ts
+++ b/test/api/Parser.api.ts
@@ -14,8 +14,8 @@ let page: Page;
 const width = 800;
 const height = 600;
 
-describe('Parser Integration Tests', function(): void {
-  before(async function(): Promise<any> {
+describe('Parser Integration Tests', function (): void {
+  before(async function (): Promise<any> {
     const browserType = getBrowserType();
     browser = await browserType.launch({
       headless: process.argv.indexOf('--headless') !== -1
@@ -39,7 +39,35 @@ describe('Parser Integration Tests', function(): void {
         }, '');
       `);
       await writeSync(page, '\x1b[38;5;123mparams\x1b[38:2::50:100:150msubparams');
-      assert.deepEqual(await page.evaluate(`(() => window._customCsiHandlerParams)();`), [[38, 5, 123], [38, [2, -1, 50, 100, 150]]]);
+      assert.deepEqual(await page.evaluate(`window._customCsiHandlerParams`), [
+        [38, 5, 123],
+        [38, [2, -1, 50, 100, 150]]
+      ]);
+    });
+    it('async', async () => {
+      await page.evaluate(`
+        window.term.reset();
+        window._customCsiHandlerCallStack = [];
+        const _customCsiHandlerA = window.term.parser.registerCsiHandler({intermediates:'+', final: 'Z'}, params => {
+          window._customCsiHandlerCallStack.push(['A', params]);
+          return false;
+        });
+        const _customCsiHandlerB = window.term.parser.registerCsiHandler({intermediates:'+', final: 'Z'}, async params => {
+          await new Promise(res => setTimeout(res, 50));
+          window._customCsiHandlerCallStack.push(['B', params]);
+          return false;
+        });
+        const _customCsiHandlerC = window.term.parser.registerCsiHandler({intermediates:'+', final: 'Z'}, params => {
+          window._customCsiHandlerCallStack.push(['C', params]);
+          return false;
+        });
+      `);
+      await writeSync(page, '\x1b[1;2+Z');
+      assert.deepEqual(await page.evaluate(`window._customCsiHandlerCallStack`), [
+        ['C', [1, 2]],
+        ['B', [1, 2]],
+        ['A', [1, 2]]
+      ]);
     });
   });
   describe('registerDcsHandler', () => {
@@ -61,7 +89,35 @@ describe('Parser Integration Tests', function(): void {
         });
       `);
       await writeSync(page, '\x1bP1;2+psome data\x1b\\\\');
-      assert.deepEqual(await page.evaluate(`(() => window._customDcsHandlerCallStack)();`), [['C', [1, 2], 'some data'], ['B', [1, 2], 'some data']]);
+      assert.deepEqual(await page.evaluate(`window._customDcsHandlerCallStack`), [
+        ['C', [1, 2], 'some data'],
+        ['B', [1, 2], 'some data']
+      ]);
+    });
+    it('async', async () => {
+      await page.evaluate(`
+        window.term.reset();
+        window._customDcsHandlerCallStack = [];
+        const _customDcsHandlerA = window.term.parser.registerDcsHandler({intermediates:'+', final: 'q'}, (data, params) => {
+          window._customDcsHandlerCallStack.push(['A', params, data]);
+          return false;
+        });
+        const _customDcsHandlerB = window.term.parser.registerDcsHandler({intermediates:'+', final: 'q'}, async (data, params) => {
+          await new Promise(res => setTimeout(res, 50));
+          window._customDcsHandlerCallStack.push(['B', params, data]);
+          return false;
+        });
+        const _customDcsHandlerC = window.term.parser.registerDcsHandler({intermediates:'+', final: 'q'}, (data, params) => {
+          window._customDcsHandlerCallStack.push(['C', params, data]);
+          return false;
+        });
+      `);
+      await writeSync(page, '\x1bP1;2+qsome data\x1b\\\\');
+      assert.deepEqual(await page.evaluate(`window._customDcsHandlerCallStack`), [
+        ['C', [1, 2], 'some data'],
+        ['B', [1, 2], 'some data'],
+        ['A', [1, 2], 'some data']
+      ]);
     });
   });
   describe('registerEscHandler', () => {
@@ -83,7 +139,28 @@ describe('Parser Integration Tests', function(): void {
         });
       `);
       await writeSync(page, '\x1b(B');
-      assert.deepEqual(await page.evaluate(`(() => window._customEscHandlerCallStack)();`), ['C', 'B']);
+      assert.deepEqual(await page.evaluate(`window._customEscHandlerCallStack`), ['C', 'B']);
+    });
+    it('async', async () => {
+      await page.evaluate(`
+        window.term.reset();
+        window._customEscHandlerCallStack = [];
+        const _customEscHandlerA = window.term.parser.registerEscHandler({intermediates:'(', final: 'Z'}, () => {
+          window._customEscHandlerCallStack.push('A');
+          return false;
+        });
+        const _customEscHandlerB = window.term.parser.registerEscHandler({intermediates:'(', final: 'Z'}, async () => {
+          await new Promise(res => setTimeout(res, 50));
+          window._customEscHandlerCallStack.push('B');
+          return false;
+        });
+        const _customEscHandlerC = window.term.parser.registerEscHandler({intermediates:'(', final: 'Z'}, () => {
+          window._customEscHandlerCallStack.push('C');
+          return false;
+        });
+      `);
+      await writeSync(page, '\x1b(Z');
+      assert.deepEqual(await page.evaluate(`window._customEscHandlerCallStack`), ['C', 'B', 'A']);
     });
   });
   describe('registerOscHandler', () => {
@@ -105,7 +182,35 @@ describe('Parser Integration Tests', function(): void {
         });
       `);
       await writeSync(page, '\x1b]1234;some data\x07');
-      assert.deepEqual(await page.evaluate(`(() => window._customOscHandlerCallStack)();`), [['C', 'some data'], ['B', 'some data']]);
+      assert.deepEqual(await page.evaluate(`window._customOscHandlerCallStack`), [
+        ['C', 'some data'],
+        ['B', 'some data']
+      ]);
+    });
+    it('async', async () => {
+      await page.evaluate(`
+        window.term.reset();
+        window._customOscHandlerCallStack = [];
+        const _customOscHandlerA = window.term.parser.registerOscHandler(666, data => {
+          window._customOscHandlerCallStack.push(['A', data]);
+          return false;
+        });
+        const _customOscHandlerB = window.term.parser.registerOscHandler(666, async data => {
+          await new Promise(res => setTimeout(res, 50));
+          window._customOscHandlerCallStack.push(['B', data]);
+          return false;
+        });
+        const _customOscHandlerC = window.term.parser.registerOscHandler(666, data => {
+          window._customOscHandlerCallStack.push(['C', data]);
+          return false;
+        });
+      `);
+      await writeSync(page, '\x1b]666;some data\x07');
+      assert.deepEqual(await page.evaluate(`window._customOscHandlerCallStack`), [
+        ['C', 'some data'],
+        ['B', 'some data'],
+        ['A', 'some data']
+      ]);
     });
   });
 });

--- a/test/api/Parser.api.ts
+++ b/test/api/Parser.api.ts
@@ -28,12 +28,12 @@ describe('Parser Integration Tests', function(): void {
 
   after(async () => browser.close());
 
-  describe('addCsiHandler', () => {
+  describe('registerCsiHandler', () => {
     it('should call custom CSI handler with js array params', async () => {
       await page.evaluate(`
         window.term.reset();
         window._customCsiHandlerParams = [];
-        const _customCsiHandler = window.term.parser.addCsiHandler({final: 'm'}, (params, collect) => {
+        const _customCsiHandler = window.term.parser.registerCsiHandler({final: 'm'}, (params, collect) => {
           window._customCsiHandlerParams.push(params);
           return false;
         }, '');
@@ -42,20 +42,20 @@ describe('Parser Integration Tests', function(): void {
       assert.deepEqual(await page.evaluate(`(() => window._customCsiHandlerParams)();`), [[38, 5, 123], [38, [2, -1, 50, 100, 150]]]);
     });
   });
-  describe('addDcsHandler', () => {
+  describe('registerDcsHandler', () => {
     it('should respects return value', async () => {
       await page.evaluate(`
         window.term.reset();
         window._customDcsHandlerCallStack = [];
-        const _customDcsHandlerA = window.term.parser.addDcsHandler({intermediates:'+', final: 'p'}, (data, params) => {
+        const _customDcsHandlerA = window.term.parser.registerDcsHandler({intermediates:'+', final: 'p'}, (data, params) => {
           window._customDcsHandlerCallStack.push(['A', params, data]);
           return false;
         });
-        const _customDcsHandlerB = window.term.parser.addDcsHandler({intermediates:'+', final: 'p'}, (data, params) => {
+        const _customDcsHandlerB = window.term.parser.registerDcsHandler({intermediates:'+', final: 'p'}, (data, params) => {
           window._customDcsHandlerCallStack.push(['B', params, data]);
           return true;
         });
-        const _customDcsHandlerC = window.term.parser.addDcsHandler({intermediates:'+', final: 'p'}, (data, params) => {
+        const _customDcsHandlerC = window.term.parser.registerDcsHandler({intermediates:'+', final: 'p'}, (data, params) => {
           window._customDcsHandlerCallStack.push(['C', params, data]);
           return false;
         });
@@ -64,20 +64,20 @@ describe('Parser Integration Tests', function(): void {
       assert.deepEqual(await page.evaluate(`(() => window._customDcsHandlerCallStack)();`), [['C', [1, 2], 'some data'], ['B', [1, 2], 'some data']]);
     });
   });
-  describe('addEscHandler', () => {
+  describe('registerEscHandler', () => {
     it('should respects return value', async () => {
       await page.evaluate(`
         window.term.reset();
         window._customEscHandlerCallStack = [];
-        const _customEscHandlerA = window.term.parser.addEscHandler({intermediates:'(', final: 'B'}, () => {
+        const _customEscHandlerA = window.term.parser.registerEscHandler({intermediates:'(', final: 'B'}, () => {
           window._customEscHandlerCallStack.push('A');
           return false;
         });
-        const _customEscHandlerB = window.term.parser.addEscHandler({intermediates:'(', final: 'B'}, () => {
+        const _customEscHandlerB = window.term.parser.registerEscHandler({intermediates:'(', final: 'B'}, () => {
           window._customEscHandlerCallStack.push('B');
           return true;
         });
-        const _customEscHandlerC = window.term.parser.addEscHandler({intermediates:'(', final: 'B'}, () => {
+        const _customEscHandlerC = window.term.parser.registerEscHandler({intermediates:'(', final: 'B'}, () => {
           window._customEscHandlerCallStack.push('C');
           return false;
         });
@@ -86,20 +86,20 @@ describe('Parser Integration Tests', function(): void {
       assert.deepEqual(await page.evaluate(`(() => window._customEscHandlerCallStack)();`), ['C', 'B']);
     });
   });
-  describe('addOscHandler', () => {
+  describe('registerOscHandler', () => {
     it('should respects return value', async () => {
       await page.evaluate(`
         window.term.reset();
         window._customOscHandlerCallStack = [];
-        const _customOscHandlerA = window.term.parser.addOscHandler(1234, data => {
+        const _customOscHandlerA = window.term.parser.registerOscHandler(1234, data => {
           window._customOscHandlerCallStack.push(['A', data]);
           return false;
         });
-        const _customOscHandlerB = window.term.parser.addOscHandler(1234, data => {
+        const _customOscHandlerB = window.term.parser.registerOscHandler(1234, data => {
           window._customOscHandlerCallStack.push(['B', data]);
           return true;
         });
-        const _customOscHandlerC = window.term.parser.addOscHandler(1234, data => {
+        const _customOscHandlerC = window.term.parser.registerOscHandler(1234, data => {
           window._customOscHandlerCallStack.push(['C', data]);
           return false;
         });

--- a/test/benchmark/Terminal.benchmark.ts
+++ b/test/benchmark/Terminal.benchmark.ts
@@ -29,7 +29,7 @@ perfContext('Terminal: ls -lR /usr/lib', () => {
       chunks.push(data as unknown as Buffer);
       length += data.length;
     });
-    await new Promise(resolve => p.on('exit', () => resolve()));
+    await new Promise<void>(resolve => p.on('exit', () => resolve()));
     contentUtf8 = Buffer.concat(chunks, length);
     // translate to content string
     const buffer = new Uint32Array(contentUtf8.length);
@@ -44,24 +44,46 @@ perfContext('Terminal: ls -lR /usr/lib', () => {
     }
   });
 
-  perfContext('write', () => {
+  // perfContext('write/string/sync', () => {
+  //   let terminal: Terminal;
+  //   before(() => {
+  //     terminal = new Terminal({cols: 80, rows: 25, scrollback: 1000});
+  //   });
+  //   new ThroughputRuntimeCase('', () => {
+  //     terminal.writeSync(content);
+  //     return {payloadSize: contentUtf8.length};
+  //   }, {fork: false}).showAverageThroughput();
+  // });
+  //
+  // perfContext('write/Utf8/sync', () => {
+  //   let terminal: Terminal;
+  //   before(() => {
+  //     terminal = new Terminal({cols: 80, rows: 25, scrollback: 1000});
+  //   });
+  //   new ThroughputRuntimeCase('', () => {
+  //     terminal.writeSync(content);
+  //     return {payloadSize: contentUtf8.length};
+  //   }, {fork: false}).showAverageThroughput();
+  // });
+
+  perfContext('write/string/async', () => {
     let terminal: Terminal;
     before(() => {
       terminal = new Terminal({cols: 80, rows: 25, scrollback: 1000});
     });
-    new ThroughputRuntimeCase('', () => {
-      terminal.writeSync(content);
+    new ThroughputRuntimeCase('', async () => {
+      await new Promise<void>(res => terminal.write(content, res));
       return {payloadSize: contentUtf8.length};
     }, {fork: false}).showAverageThroughput();
   });
 
-  perfContext('writeUtf8', () => {
+  perfContext('write/Utf8/async', () => {
     let terminal: Terminal;
     before(() => {
       terminal = new Terminal({cols: 80, rows: 25, scrollback: 1000});
     });
-    new ThroughputRuntimeCase('', () => {
-      terminal.writeSync(content);
+    new ThroughputRuntimeCase('', async () => {
+      await new Promise<void>(res => terminal.write(content, res));
       return {payloadSize: contentUtf8.length};
     }, {fork: false}).showAverageThroughput();
   });

--- a/test/benchmark/Terminal.benchmark.ts
+++ b/test/benchmark/Terminal.benchmark.ts
@@ -44,28 +44,6 @@ perfContext('Terminal: ls -lR /usr/lib', () => {
     }
   });
 
-  // perfContext('write/string/sync', () => {
-  //   let terminal: Terminal;
-  //   before(() => {
-  //     terminal = new Terminal({cols: 80, rows: 25, scrollback: 1000});
-  //   });
-  //   new ThroughputRuntimeCase('', () => {
-  //     terminal.writeSync(content);
-  //     return {payloadSize: contentUtf8.length};
-  //   }, {fork: false}).showAverageThroughput();
-  // });
-  //
-  // perfContext('write/Utf8/sync', () => {
-  //   let terminal: Terminal;
-  //   before(() => {
-  //     terminal = new Terminal({cols: 80, rows: 25, scrollback: 1000});
-  //   });
-  //   new ThroughputRuntimeCase('', () => {
-  //     terminal.writeSync(content);
-  //     return {payloadSize: contentUtf8.length};
-  //   }, {fork: false}).showAverageThroughput();
-  // });
-
   perfContext('write/string/async', () => {
     let terminal: Terminal;
     before(() => {

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -1515,7 +1515,7 @@ declare module 'xterm' {
      * The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
-    registerCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean): IDisposable;
+    registerCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean | Promise<boolean>): IDisposable;
 
     /**
      * Adds a handler for DCS escape sequences.
@@ -1534,7 +1534,7 @@ declare module 'xterm' {
      * The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
-    registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean): IDisposable;
+    registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean | Promise<boolean>): IDisposable;
 
     /**
      * Adds a handler for ESC escape sequences.
@@ -1547,7 +1547,7 @@ declare module 'xterm' {
      * The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
-    registerEscHandler(id: IFunctionIdentifier, handler: () => boolean): IDisposable;
+    registerEscHandler(id: IFunctionIdentifier, handler: () => boolean | Promise<boolean>): IDisposable;
 
     /**
      * Adds a handler for OSC escape sequences.
@@ -1565,7 +1565,7 @@ declare module 'xterm' {
      * The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
-    registerOscHandler(ident: number, callback: (data: string) => boolean): IDisposable;
+    registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable;
   }
 
   /**

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -1501,6 +1501,23 @@ declare module 'xterm' {
 
   /**
    * Allows hooking into the parser for custom handling of escape sequences.
+   *
+   * Note on sync vs. async handlers:
+   * xterm.js implements all parser actions with synchronous handlers.
+   * In general custom handlers should also operate in sync mode wherever
+   * possible to keep the parser fast.
+   * Still the exposed interfaces allow to register async handlers by returning
+   * a `Promise<boolean>`. Here the parser will pause input processing until
+   * the promise got resolved or rejected (in-band blocking). This "full stop"
+   * on the input chain allows to implement backpressure from a certain async
+   * action while the terminal state will not progress any further from input.
+   * It does not mean that the terminal state will not change at all in between,
+   * as user actions like resize or reset are still processed immediately.
+   * It is an error to assume a stable terminal state while giving back control
+   * in between, e.g. by multiple chained `then` calls.
+   * Downside of an async handler is a rather bad throughput performance,
+   * thus use async handlers only as a last resort or for actions that have
+   * to rely on async interfaces itself.
    */
   export interface IParser {
     /**
@@ -1510,9 +1527,8 @@ declare module 'xterm' {
      * @param callback The function to handle the sequence. The callback is
      * called with the numerical params. If the sequence has subparams the
      * array will contain subarrays with their numercial values.
-     * Return true if the sequence was handled; false if we should try
-     * a previous handler (set by addCsiHandler or setCsiHandler).
-     * The most recently added handler is tried first.
+     * Return `true` if the sequence was handled, `false` if the parser should try
+     * a previous handler. The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
     registerCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean | Promise<boolean>): IDisposable;
@@ -1529,9 +1545,8 @@ declare module 'xterm' {
      * big payloads. Currently xterm.js limits DCS payload to 10 MB
      * which should give enough room for most use cases.
      * The function gets the payload and numerical parameters as arguments.
-     * Return true if the sequence was handled; false if we should try
-     * a previous handler (set by addDcsHandler or setDcsHandler).
-     * The most recently added handler is tried first.
+     * Return `true` if the sequence was handled, `false` if the parser should try
+     * a previous handler. The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
     registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean | Promise<boolean>): IDisposable;
@@ -1542,9 +1557,8 @@ declare module 'xterm' {
      * gets registered, e.g. {intermediates: '%' final: 'G'} for
      * default charset selection.
      * @param callback The function to handle the sequence.
-     * Return true if the sequence was handled; false if we should try
-     * a previous handler (set by addEscHandler or setEscHandler).
-     * The most recently added handler is tried first.
+     * Return `true` if the sequence was handled, `false` if the parser should try
+     * a previous handler. The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
     registerEscHandler(id: IFunctionIdentifier, handler: () => boolean | Promise<boolean>): IDisposable;
@@ -1560,9 +1574,8 @@ declare module 'xterm' {
      * big payloads. Currently xterm.js limits OSC payload to 10 MB
      * which should give enough room for most use cases.
      * The callback is called with OSC data string.
-     * Return true if the sequence was handled; false if we should try
-     * a previous handler (set by addOscHandler or setOscHandler).
-     * The most recently added handler is tried first.
+     * Return `true` if the sequence was handled, `false` if the parser should try
+     * a previous handler. The most recently added handler is tried first.
      * @return An IDisposable you can call to remove this handler.
      */
     registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable;


### PR DESCRIPTION
Not being able to use async functions in parser handlers is an unfortunate limitation of the current parser implementation. This PR tries to come up with a solution to enable async support while keeping the parser performant.

TODO:
- [x] async parser support for:
  - [x] CSI handler
    - [x] basic impl
    - [x] test cases
  - [x] ESC handler
    - [x] basic impl
    - [x] test cases
  - [x] OSC handler
    - [x] basic impl
    - [x] test cases
  - [x] DCS handler
    - [x] basic impl
    - [x] test cases
- [x] async/sync mixed test cases on inputhandler
- [x] high level API tests with async handlers
- [x] deprecate/remove `writeSync` (refactor core tests) - needs note in release doc
- [x] proper `reset` handling on parser
- [x] simplify/cleanup handler interface mess of the parser (see #3223)
- [x] cleanup async codebase
- [x] update parser hooks docs --> created https://github.com/xtermjs/xtermjs.org/issues/136

Shall fix #3218.