### PR TITLE
Use linkifier2 to double click select links

### DIFF
--- a/src/browser/Linkifier2.ts
+++ b/src/browser/Linkifier2.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { ILinkifier2, ILinkProvider, IBufferCellPosition, ILink, ILinkifierEvent, ILinkDecorations } from 'browser/Types';
+import { ILinkifier2, ILinkProvider, IBufferCellPosition, ILink, ILinkifierEvent, ILinkDecorations, ILinkWithState } from 'browser/Types';
 import { IDisposable } from 'common/Types';
 import { IMouseService, IRenderService } from './services/Services';
 import { IBufferService } from 'common/services/Services';
@@ -11,21 +11,12 @@ import { EventEmitter, IEvent } from 'common/EventEmitter';
 import { Disposable, getDisposeArrayDisposable, disposeArray } from 'common/Lifecycle';
 import { addDisposableDomListener } from 'browser/Lifecycle';
 
-interface ILinkState {
-  decorations: ILinkDecorations;
-  isHovered: boolean;
-}
-
-interface ILinkWithState {
-  link: ILink;
-  state?: ILinkState;
-}
-
 export class Linkifier2 extends Disposable implements ILinkifier2 {
   private _element: HTMLElement | undefined;
   private _mouseService: IMouseService | undefined;
   private _renderService: IRenderService | undefined;
   private _linkProviders: ILinkProvider[] = [];
+  public get currentLink(): ILinkWithState | undefined { return this._currentLink; }
   protected _currentLink: ILinkWithState | undefined;
   private _lastMouseEvent: MouseEvent | undefined;
   private _linkCacheDisposables: IDisposable[] = [];

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -482,7 +482,9 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
     this._selectionService = this.register(this._instantiationService.createInstance(SelectionService,
       this.element,
-      this.screenElement));
+      this.screenElement,
+      this.linkifier2
+    ));
     this._instantiationService.setService(ISelectionService, this._selectionService);
     this.register(this._selectionService.onRequestScrollLines(e => this.scrollLines(e.amount, e.suppressScrollEvent)));
     this.register(this._selectionService.onSelectionChange(() => this._onSelectionChange.fire()));

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -205,9 +205,19 @@ export interface ILinkifier {
   deregisterLinkMatcher(matcherId: number): boolean;
 }
 
+interface ILinkState {
+  decorations: ILinkDecorations;
+  isHovered: boolean;
+}
+export interface ILinkWithState {
+  link: ILink;
+  state?: ILinkState;
+}
+
 export interface ILinkifier2 {
   onShowLinkUnderline: IEvent<ILinkifierEvent>;
   onHideLinkUnderline: IEvent<ILinkifierEvent>;
+  currentLink: ILinkWithState | undefined;
 
   attachToDom(element: HTMLElement, mouseService: IMouseService, renderService: IRenderService): void;
   registerLinkProvider(linkProvider: ILinkProvider): IDisposable;

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -217,7 +217,7 @@ export interface ILinkWithState {
 export interface ILinkifier2 {
   onShowLinkUnderline: IEvent<ILinkifierEvent>;
   onHideLinkUnderline: IEvent<ILinkifierEvent>;
-  currentLink: ILinkWithState | undefined;
+  readonly currentLink: ILinkWithState | undefined;
 
   attachToDom(element: HTMLElement, mouseService: IMouseService, renderService: IRenderService): void;
   registerLinkProvider(linkProvider: ILinkProvider): IDisposable;

--- a/src/browser/services/SelectionService.test.ts
+++ b/src/browser/services/SelectionService.test.ts
@@ -21,7 +21,7 @@ class TestSelectionService extends SelectionService {
     optionsService: IOptionsService,
     renderService: IRenderService
   ) {
-    super(null!, null!, bufferService, new MockCoreService(), new MockMouseService(), optionsService, renderService);
+    super(null!, null!, null!, bufferService, new MockCoreService(), new MockMouseService(), optionsService, renderService);
   }
 
   public get model(): SelectionModel { return this._model; }

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -321,9 +321,8 @@ export class SelectionService extends Disposable implements ISelectionService {
   private _selectWordAtCursor(event: MouseEvent, allowWhitespaceOnlySelection: boolean): boolean {
     const range = this._linkifier.currentLink?.link?.range;
     if (range) {
-      const scrollOffset = this._bufferService.buffer.ydisp;
-      this._model.selectionStart = [range.start.x - 1, range.start.y - scrollOffset - 1];
-      this._model.selectionEnd = [range.end.x, range.end.y - scrollOffset - 1];
+      this._model.selectionStart = [range.start.x - 1, range.start.y - 1];
+      this._model.selectionEnd = [range.end.x, range.end.y - 1];
       return true;
     }
 

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -319,6 +319,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * @param event The mouse event.
    */
   private _selectWordAtCursor(event: MouseEvent, allowWhitespaceOnlySelection: boolean): boolean {
+    // Check if there is a link under the cursor first and select that if so
     const range = this._linkifier.currentLink?.link?.range;
     if (range) {
       this._model.selectionStart = [range.start.x - 1, range.start.y - 1];

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -11,6 +11,7 @@ import { SelectionModel } from 'browser/selection/SelectionModel';
 import { CellData } from 'common/buffer/CellData';
 import { EventEmitter, IEvent } from 'common/EventEmitter';
 import { ICharSizeService, IMouseService, ISelectionService, IRenderService } from 'browser/services/Services';
+import { ILinkifier2 } from 'browser/Types';
 import { IBufferService, IOptionsService, ICoreService } from 'common/services/Services';
 import { getCoordsRelativeToElement } from 'browser/input/Mouse';
 import { moveToCellSequence } from 'browser/input/MoveToCell';
@@ -121,6 +122,7 @@ export class SelectionService extends Disposable implements ISelectionService {
   constructor(
     private readonly _element: HTMLElement,
     private readonly _screenElement: HTMLElement,
+    private readonly _linkifier: ILinkifier2,
     @IBufferService private readonly _bufferService: IBufferService,
     @ICoreService private readonly _coreService: ICoreService,
     @IMouseService private readonly _mouseService: IMouseService,
@@ -316,13 +318,22 @@ export class SelectionService extends Disposable implements ISelectionService {
    * Selects word at the current mouse event coordinates.
    * @param event The mouse event.
    */
-  private _selectWordAtCursor(event: MouseEvent): void {
+  private _selectWordAtCursor(event: MouseEvent, allowWhitespaceOnlySelection: boolean): boolean {
+    const range = this._linkifier.currentLink?.link?.range;
+    if (range) {
+      const scrollOffset = this._bufferService.buffer.ydisp;
+      this._model.selectionStart = [range.start.x - 1, range.start.y - scrollOffset - 1];
+      this._model.selectionEnd = [range.end.x, range.end.y - scrollOffset - 1];
+      return true;
+    }
+
     const coords = this._getMouseBufferCoords(event);
     if (coords) {
-      this._selectWordAt(coords, false);
+      this._selectWordAt(coords, allowWhitespaceOnlySelection);
       this._model.selectionEnd = undefined;
-      this.refresh(true);
+      return true;
     }
+    return false;
   }
 
   /**
@@ -527,14 +538,12 @@ export class SelectionService extends Disposable implements ISelectionService {
   }
 
   /**
-   * Performs a double click, selecting the current work.
+   * Performs a double click, selecting the current word.
    * @param event The mouse event.
    */
   private _onDoubleClick(event: MouseEvent): void {
-    const coords = this._getMouseBufferCoords(event);
-    if (coords) {
+    if (this._selectWordAtCursor(event, true)) {
       this._activeSelectionMode = SelectionMode.WORD;
-      this._selectWordAt(coords, true);
     }
   }
 
@@ -764,7 +773,9 @@ export class SelectionService extends Disposable implements ISelectionService {
 
   public rightClickSelect(ev: MouseEvent): void {
     if (!this._isClickInSelection(ev)) {
-      this._selectWordAtCursor(ev);
+      if (this._selectWordAtCursor(ev, false)) {
+        this.refresh(true);
+      }
       this._fireEventIfSelectionChanged();
     }
   }


### PR DESCRIPTION
Also works with right click select.
Fixes #682.

This relies on the fact that before a user (double/right)-clicks a link, the cursor will hover the link, triggering the asynchronous link provider(s). By the time the click event fires, the link provider "should" have done its thing, and the link is used.
If not, this falls back to the old behavior.
This seemed good enough to me. If it is not, one probably would have to expose some inner state of the linkifier to provide some way to check if there are currently link providers resolving and to wait for them to finish before selecting.

I feel a bit bad about duplicating the magic "-1"s (on both x and y for start, only on y for end) from `Linkifier2._fireUnderlineEvent`, but I couldn't think of a good way to extract that logic.
It seems to me to produce the correct results.