### PR TITLE
Add hover and leave callbacks for linkprovider

### DIFF
--- a/addons/xterm-addon-web-links/src/WebLinkProvider.ts
+++ b/addons/xterm-addon-web-links/src/WebLinkProvider.ts
@@ -3,7 +3,12 @@
  * @license MIT
  */
 
-import { ILinkProvider, ILink, Terminal, IViewportRange, ILinkProviderOptions } from 'xterm';
+import { ILinkProvider, ILink, Terminal, IViewportRange } from 'xterm';
+
+interface ILinkProviderOptions {
+  hover?(event: MouseEvent, text: string, location: IViewportRange): void;
+  leave?(event: MouseEvent, text: string): void;
+}
 
 export class WebLinkProvider implements ILinkProvider {
 

--- a/addons/xterm-addon-web-links/src/WebLinkProvider.ts
+++ b/addons/xterm-addon-web-links/src/WebLinkProvider.ts
@@ -3,20 +3,35 @@
  * @license MIT
  */
 
-import { ILinkProvider, IBufferCellPosition, ILink, Terminal } from 'xterm';
+import { ILinkProvider, ILink, Terminal, IViewportRange, ILinkProviderOptions } from 'xterm';
 
 export class WebLinkProvider implements ILinkProvider {
 
   constructor(
     private readonly _terminal: Terminal,
     private readonly _regex: RegExp,
-    private readonly _handler: (event: MouseEvent, uri: string) => void
+    private readonly _handler: (event: MouseEvent, uri: string) => void,
+    private readonly _options: ILinkProviderOptions = {}
   ) {
 
   }
 
   public provideLinks(y: number, callback: (links: ILink[] | undefined) => void): void {
-    callback(LinkComputer.computeLink(y, this._regex, this._terminal, this._handler));
+    const links = LinkComputer.computeLink(y, this._regex, this._terminal, this._handler);
+    callback(this._addCallbacks(links));
+  }
+
+  private _addCallbacks(links: ILink[]): ILink[] {
+    return links.map(link => {
+      link.leave = this._options.leave;
+      link.hover = (event: MouseEvent, uri: string): void => {
+        if (this._options.hover) {
+          const { range } = link;
+          this._options.hover(event, uri, range);
+        }
+      };
+      return link;
+    });
   }
 }
 

--- a/addons/xterm-addon-web-links/src/WebLinksAddon.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { Terminal, ILinkMatcherOptions, ITerminalAddon, IDisposable, ILinkProviderOptions } from 'xterm';
+import { Terminal, ILinkMatcherOptions, ITerminalAddon, IDisposable, IViewportRange } from 'xterm';
 import { WebLinkProvider } from './WebLinkProvider';
 
 const protocolClause = '(https?:\\/\\/)';
@@ -36,6 +36,11 @@ function handleLink(event: MouseEvent, uri: string): void {
   }
 }
 
+interface ILinkProviderOptions {
+  hover?(event: MouseEvent, text: string, location: IViewportRange): void;
+  leave?(event: MouseEvent, text: string): void;
+}
+
 export class WebLinksAddon implements ITerminalAddon {
   private _linkMatcherId: number | undefined;
   private _terminal: Terminal | undefined;
@@ -43,24 +48,22 @@ export class WebLinksAddon implements ITerminalAddon {
 
   constructor(
     private _handler: (event: MouseEvent, uri: string) => void = handleLink,
-    private _options: ILinkMatcherOptions = {},
+    private _options: ILinkMatcherOptions | ILinkProviderOptions = {},
     private _useLinkProvider: boolean = false
   ) {
-    this._options.matchIndex = 1;
   }
 
   public activate(terminal: Terminal): void {
     this._terminal = terminal;
 
     if (this._useLinkProvider && 'registerLinkProvider' in this._terminal) {
-      const options = {
-        hover: this._options.tooltipCallback,
-        leave: this._options.leaveCallback
-      };
+      const options = this._options as ILinkProviderOptions;
       this._linkProvider = this._terminal.registerLinkProvider(new WebLinkProvider(this._terminal, strictUrlRegex, this._handler, options));
     } else {
       // TODO: This should be removed eventually
-      this._linkMatcherId = (this._terminal as Terminal).registerLinkMatcher(strictUrlRegex, this._handler, this._options);
+      const options = this._options as ILinkMatcherOptions;
+      options.matchIndex = 1;
+      this._linkMatcherId = (this._terminal as Terminal).registerLinkMatcher(strictUrlRegex, this._handler, options);
     }
   }
 

--- a/addons/xterm-addon-web-links/src/WebLinksAddon.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { Terminal, ILinkMatcherOptions, ITerminalAddon, IDisposable } from 'xterm';
+import { Terminal, ILinkMatcherOptions, ITerminalAddon, IDisposable, ILinkProviderOptions } from 'xterm';
 import { WebLinkProvider } from './WebLinkProvider';
 
 const protocolClause = '(https?:\\/\\/)';
@@ -53,7 +53,11 @@ export class WebLinksAddon implements ITerminalAddon {
     this._terminal = terminal;
 
     if (this._useLinkProvider && 'registerLinkProvider' in this._terminal) {
-      this._linkProvider = this._terminal.registerLinkProvider(new WebLinkProvider(this._terminal, strictUrlRegex, this._handler));
+      const options = {
+        hover: this._options.tooltipCallback,
+        leave: this._options.leaveCallback
+      };
+      this._linkProvider = this._terminal.registerLinkProvider(new WebLinkProvider(this._terminal, strictUrlRegex, this._handler, options));
     } else {
       // TODO: This should be removed eventually
       this._linkMatcherId = (this._terminal as Terminal).registerLinkMatcher(strictUrlRegex, this._handler, this._options);

--- a/addons/xterm-addon-web-links/typings/xterm-addon-web-links.d.ts
+++ b/addons/xterm-addon-web-links/typings/xterm-addon-web-links.d.ts
@@ -4,7 +4,7 @@
  */
 
 
-import { Terminal, ILinkMatcherOptions, ITerminalAddon } from 'xterm';
+import { Terminal, ILinkMatcherOptions, ITerminalAddon, IViewportRange } from 'xterm';
 
 declare module 'xterm-addon-web-links' {
   /**
@@ -20,7 +20,7 @@ declare module 'xterm-addon-web-links' {
      * link provider (new) may cause issues. Link provider will eventually be
      * the default and only option.
      */
-    constructor(handler?: (event: MouseEvent, uri: string) => void, options?: ILinkMatcherOptions, useLinkProvider?: boolean);
+    constructor(handler?: (event: MouseEvent, uri: string) => void, options?: ILinkMatcherOptions | ILinkProviderOptions, useLinkProvider?: boolean);
 
     /**
      * Activates the addon
@@ -32,5 +32,22 @@ declare module 'xterm-addon-web-links' {
      * Disposes the addon.
      */
     public dispose(): void;
+  }
+
+  /**
+   * An object containing options for a link provider.
+   */
+  export interface ILinkProviderOptions {
+    /**
+     * A callback that fires when the mouse hovers over a link for a period of
+     * time (defined by {@link ITerminalOptions.linkTooltipHoverDuration}).
+     */
+    hover?(event: MouseEvent, text: string, location: IViewportRange): void;
+
+    /**
+     * A callback that fires when the mouse leaves a link. Note that this can
+     * happen even when tooltipCallback hasn't fired for the link yet.
+     */
+    leave?(event: MouseEvent, text: string): void;
   }
 }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -353,6 +353,23 @@ declare module 'xterm' {
   }
 
   /**
+   * An object containing options for a link provider.
+   */
+  export interface ILinkProviderOptions {
+    /**
+     * A callback that fires when the mouse hovers over a link for a period of
+     * time (defined by {@link ITerminalOptions.linkTooltipHoverDuration}).
+     */
+    hover?(event: MouseEvent, text: string, location: IViewportRange): void;
+
+    /**
+     * A callback that fires when the mouse leaves a link. Note that this can
+     * happen even when tooltipCallback hasn't fired for the link yet.
+     */
+    leave?(event: MouseEvent, text: string): void;
+  }
+
+  /**
    * An object that can be disposed via a dispose function.
    */
   export interface IDisposable {

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -353,23 +353,6 @@ declare module 'xterm' {
   }
 
   /**
-   * An object containing options for a link provider.
-   */
-  export interface ILinkProviderOptions {
-    /**
-     * A callback that fires when the mouse hovers over a link for a period of
-     * time (defined by {@link ITerminalOptions.linkTooltipHoverDuration}).
-     */
-    hover?(event: MouseEvent, text: string, location: IViewportRange): void;
-
-    /**
-     * A callback that fires when the mouse leaves a link. Note that this can
-     * happen even when tooltipCallback hasn't fired for the link yet.
-     */
-    leave?(event: MouseEvent, text: string): void;
-  }
-
-  /**
    * An object that can be disposed via a dispose function.
    */
   export interface IDisposable {


### PR DESCRIPTION
Fixes #3056.

I guess this needs another breaking change when LinkMatchers are removed, to replace the `ILinkMatcherOptions` argument to the `WebLinksAddon` constructor with something not referring to LinkMatchers..