### PR TITLE
Terminal.open: support WebComponent when checking DOM Node

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -386,7 +386,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       throw new Error('Terminal requires a parent element.');
     }
 
-    if (!document.body.contains(parent)) {
+    if (!parent.isConnected) {
       this._logService.debug('Terminal.open was called on an element that was not attached to the DOM');
     }
 


### PR DESCRIPTION
Close #2642

First contribution.

I've replicated the issue and debugged. 

## Debug

- Before:

  ![before](https://user-images.githubusercontent.com/11912225/106371620-c8458c00-63ba-11eb-9752-879eddfe2acf.jpg)

- After:

  ![after](https://user-images.githubusercontent.com/11912225/106371622-c976b900-63ba-11eb-860c-9259f5ef6835.jpg)

## Replicate Issue

In `demo/client.ts`, find the `if (document.location.pathname === "/test")` block and put the code inside the `DEBUG START/END` comment blocks below into it. Go to `http://localhost:3000/test` to check.

```typescript
if (document.location.pathname === "/test") {
  window.Terminal = Terminal;
  window.AttachAddon = AttachAddon;
  window.FitAddon = FitAddon;
  window.SearchAddon = SearchAddon;
  window.SerializeAddon = SerializeAddon;
  window.Unicode11Addon = Unicode11Addon;
  window.WebLinksAddon = WebLinksAddon;
  window.WebglAddon = WebglAddon;

  // ====================
  // DEBUG start
  // ====================

  class DemoWebComponent extends HTMLDivElement {
    constructor() {
      super();

      this.attachShadow({ mode: "open" });
    }
  }

  window.customElements.define("demo-webcomponent", DemoWebComponent, { extends: "div" });

  const appContainer = document.createElement("demo-webcomponent");
  terminalContainer.appendChild(appContainer);

  const shadowRoot = appContainer.attachShadow({ mode: "open" });

  const xtermContainer = document.createElement("div");
  xtermContainer.id = "xterm-container";
  shadowRoot.appendChild(xtermContainer);

  console.group("debug");
  console.log(xtermContainer.isConnected); // true
  console.log(document.body.contains(xtermContainer)); // false
  console.groupEnd();

  const term = new Terminal();
  // log to browser console
  term.setOption("logLevel", "debug");
  window.term = term;

  term.open(xtermContainer);
  term.write("Hello xTerm");

  // ====================
  // DEBUG END
  // ====================
}
```