### PR TITLE
Force char size measurement when devicePixelRatio changes

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -174,6 +174,10 @@ export class RenderService extends Disposable implements IRenderService {
   }
 
   public onDevicePixelRatioChange(): void {
+    // Force char size measurement as DomMeasureStrategy(getBoundingClientRect) is not stable
+    // when devicePixelRatio changes
+    this._charSizeService.measure();
+
     this._renderer.onDevicePixelRatioChange();
     this.refreshRows(0, this._rowCount - 1);
   }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/102194

Note that `this._charSizeService.measure()` could trigger a call to `this._renderer.onCharSizeChanged()` which uses the same logic as `this._renderer.onDevicePixelRatioChange()` underneath