### PR TITLE
Fix bug of some IMEs cannot input in terminal

### DIFF
--- a/css/xterm.css
+++ b/css/xterm.css
@@ -59,7 +59,7 @@
 }
 
 .xterm .xterm-helper-textarea {
-/*     padding: 0; */
+    padding: 0;
     border: 0;
     margin: 0;
     /* Move textarea out of the screen to the far left, so that the cursor is not visible */

--- a/css/xterm.css
+++ b/css/xterm.css
@@ -59,7 +59,7 @@
 }
 
 .xterm .xterm-helper-textarea {
-    padding: 0;
+/*     padding: 0; */
     border: 0;
     margin: 0;
     /* Move textarea out of the screen to the far left, so that the cursor is not visible */

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -225,8 +225,6 @@ export class CompositionHelper {
       // Ensure the text area is at least 1x1, otherwise certain IMEs may break
       this._textarea.style.width = Math.max(compositionViewBounds.width, 1) + 'px';
       this._textarea.style.height = Math.max(compositionViewBounds.height, 1) + 'px';
-      this._textarea.style.width = compositionViewBounds.width + 'px';
-      this._textarea.style.height = compositionViewBounds.height + 'px';
       this._textarea.style.lineHeight = compositionViewBounds.height + 'px';
     }
 

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -222,6 +222,9 @@ export class CompositionHelper {
       const compositionViewBounds = this._compositionView.getBoundingClientRect();
       this._textarea.style.left = cursorLeft + 'px';
       this._textarea.style.top = cursorTop + 'px';
+      // Ensure the text area is at least 1x1, otherwise certain IMEs may break
+      this._textarea.style.width = Math.max(compositionViewBounds.width, 1) + 'px';
+      this._textarea.style.height = Math.max(compositionViewBounds.height, 1) + 'px';
       this._textarea.style.width = compositionViewBounds.width + 'px';
       this._textarea.style.height = compositionViewBounds.height + 'px';
       this._textarea.style.lineHeight = compositionViewBounds.height + 'px';


### PR DESCRIPTION
Fix bug of QQ pinyin and Rime IME cannot input characters in VS Code's terminal.
microsoft/vscode#115814
This bug behaves like this https://github.com/microsoft/vscode/issues/115814#issuecomment-774930701
Here we found the reason https://github.com/microsoft/vscode/issues/115814#issuecomment-792250478
Here we found a solution https://github.com/microsoft/vscode/issues/115814#issuecomment-792257321
The css `padding: 0` caused this bug.
Thanks to @ccloli and @ZhyMC