### PR TITLE
feat: Improve ligatures addon

### DIFF
--- a/addons/xterm-addon-ligatures/src/LigaturesAddon.ts
+++ b/addons/xterm-addon-ligatures/src/LigaturesAddon.ts
@@ -11,11 +11,15 @@ export interface ITerminalAddon {
   dispose(): void;
 }
 
+export interface ILigaturesOptions {
+  protocol?: string;
+}
+
 export class LigaturesAddon implements ITerminalAddon {
   constructor() {}
 
-  public activate(terminal: Terminal): void {
-    enableLigatures(terminal);
+  public activate(terminal: Terminal, options?: ILigaturesOptions): void {
+    enableLigatures(terminal, options);
   }
 
   public dispose(): void {}

--- a/addons/xterm-addon-ligatures/src/LigaturesAddon.ts
+++ b/addons/xterm-addon-ligatures/src/LigaturesAddon.ts
@@ -16,10 +16,13 @@ export interface ILigaturesOptions {
 }
 
 export class LigaturesAddon implements ITerminalAddon {
-  constructor() {}
+  constructor(
+    private _options?: ILigaturesOptions
+  ) {
+  }
 
-  public activate(terminal: Terminal, options?: ILigaturesOptions): void {
-    enableLigatures(terminal, options);
+  public activate(terminal: Terminal): void {
+    enableLigatures(terminal, this._options);
   }
 
   public dispose(): void {}

--- a/addons/xterm-addon-ligatures/src/font.ts
+++ b/addons/xterm-addon-ligatures/src/font.ts
@@ -6,6 +6,7 @@
 import * as fontFinder from 'font-finder';
 import * as fontLigatures from 'font-ligatures';
 
+import { ILigaturesOptions } from './LigaturesAddon';
 import parse from './parse';
 
 let fontsPromise: Promise<fontFinder.FontList> | undefined = undefined;
@@ -15,8 +16,9 @@ let fontsPromise: Promise<fontFinder.FontList> | undefined = undefined;
  * resolved, throwing if it is unable to find a suitable match.
  * @param fontFamily The CSS font family definition to resolve
  * @param cacheSize The size of the ligature cache to maintain if the font is resolved
+ * @param options The options to use
  */
-export default async function load(fontFamily: string, cacheSize: number): Promise<fontLigatures.Font | undefined> {
+export default async function load(fontFamily: string, cacheSize: number, options?: ILigaturesOptions): Promise<fontLigatures.Font | undefined> {
   if (!fontsPromise) {
     fontsPromise = fontFinder.list();
   }
@@ -31,7 +33,9 @@ export default async function load(fontFamily: string, cacheSize: number): Promi
     }
 
     if (fonts.hasOwnProperty(family) && fonts[family].length > 0) {
-      return await fontLigatures.loadFile(fonts[family][0].path, { cacheSize });
+      const { path } = fonts[family][0];
+      // Allow the use of a custom file protocol
+      return await fontLigatures.loadFile(options?.protocol + path, { cacheSize });
     }
   }
 

--- a/addons/xterm-addon-ligatures/src/index.ts
+++ b/addons/xterm-addon-ligatures/src/index.ts
@@ -7,6 +7,7 @@ import { Terminal } from 'xterm';
 import { Font } from 'font-ligatures';
 
 import load from './font';
+import { ILigaturesOptions } from './LigaturesAddon';
 
 const enum LoadingState {
   UNLOADED,
@@ -25,8 +26,9 @@ const CACHE_SIZE = 100000;
  * the font currently in use supports ligatures, the terminal will automatically
  * start to render them.
  * @param term Terminal instance from xterm.js
+ * @param options Optionnal options to use
  */
-export function enableLigatures(term: Terminal): void {
+export function enableLigatures(term: Terminal, options?: ILigaturesOptions): void {
   let currentFontName: string | undefined = undefined;
   let font: Font | undefined = undefined;
   let loadingState: LoadingState = LoadingState.UNLOADED;
@@ -44,7 +46,7 @@ export function enableLigatures(term: Terminal): void {
       currentFontName = termFont;
       const currentCallFontName = currentFontName;
 
-      load(currentCallFontName, CACHE_SIZE)
+      load(currentCallFontName, CACHE_SIZE, options)
         .then(f => {
           // Another request may have come in while we were waiting, so make
           // sure our font is still vaild.

--- a/addons/xterm-addon-ligatures/src/parse.ts
+++ b/addons/xterm-addon-ligatures/src/parse.ts
@@ -53,6 +53,11 @@ export default function parse(family: string): string[] {
     }
   }
 
+  // Register the found family if no other ones exists
+  if(families.length === 0 && currentFamily) {
+    families.push(currentFamily)
+  }
+
   return families;
 }
 

--- a/addons/xterm-addon-ligatures/typings/xterm-addon-ligatures.d.ts
+++ b/addons/xterm-addon-ligatures/typings/xterm-addon-ligatures.d.ts
@@ -28,15 +28,15 @@ declare module 'xterm-addon-ligatures' {
   export class LigaturesAddon implements ITerminalAddon {
     /**
      * Creates a new ligatures addon.
+     * @param options The optionnal options
      */
-    constructor();
+    constructor(options: ILigaturesOptions);
 
     /**
      * Activates the addon
      * @param terminal The terminal the addon is being loaded in.
-     * @param options Optionnal options to use.
      */
-    public activate(terminal: Terminal, options?: ILigaturesOptions): void;
+    public activate(terminal: Terminal): void;
 
     /**
      * Disposes the addon.

--- a/addons/xterm-addon-ligatures/typings/xterm-addon-ligatures.d.ts
+++ b/addons/xterm-addon-ligatures/typings/xterm-addon-ligatures.d.ts
@@ -12,6 +12,17 @@ import { Terminal, ITerminalAddon } from 'xterm';
 
 declare module 'xterm-addon-ligatures' {
   /**
+   * Options for the ligatures addon.
+   */
+  export interface ILigaturesOptions {
+    /**
+     * A custom file protocol to use when loading the fonts
+     * in the computer.
+     */
+    protocol?: string;
+  }
+
+  /**
    * An xterm.js addon that enables web links.
    */
   export class LigaturesAddon implements ITerminalAddon {
@@ -23,8 +34,9 @@ declare module 'xterm-addon-ligatures' {
     /**
      * Activates the addon
      * @param terminal The terminal the addon is being loaded in.
+     * @param options Optionnal options to use.
      */
-    public activate(terminal: Terminal): void;
+    public activate(terminal: Terminal, options?: ILigaturesOptions): void;
 
     /**
      * Disposes the addon.


### PR DESCRIPTION
This PR adds a new `ILigaturesOptions` to specify a custom file protocol, used to load the fonts on the computer.

The commit https://github.com/xtermjs/xterm.js/commit/e23153635d51f7fd704a9ed116617f90c289e5fe also fixes a bug in the `parse` function:
- If you use only one font with single or double-quotes, the font is only parsed but not pushed to the `families` array:
Example:
```js
parse('"FiraCode Nerd Font"')
```
returns an empty array, where
```js
parse('"FiraCode Nerd Font", monospace')
```
returns an array with both `FiraCode Nerd Font` and `monospace`.
- This issue is fixed here, we push a font if one was found but wasn't added to the array: https://github.com/xtermjs/xterm.js/blob/e23153635d51f7fd704a9ed116617f90c289e5fe/addons/xterm-addon-ligatures/src/parse.ts#L56-L59