### PR TITLE
writeSync callstack fix

### DIFF
--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -137,12 +137,12 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
    *
    * @deprecated Unreliable, will be removed soon.
    */
-  public writeSync(data: string | Uint8Array): void {
+  public writeSync(data: string | Uint8Array, maxSubsequentCalls?: number): void {
     if (this._logService.logLevel <= LogLevelEnum.WARN && !hasWriteSyncWarnHappened) {
       this._logService.warn('writeSync is unreliable and will be removed soon.');
       hasWriteSyncWarnHappened = true;
     }
-    this._writeBuffer.writeSync(data);
+    this._writeBuffer.writeSync(data, maxSubsequentCalls);
   }
 
   public resize(x: number, y: number): void {

--- a/src/common/input/WriteBuffer.test.ts
+++ b/src/common/input/WriteBuffer.test.ts
@@ -85,5 +85,26 @@ describe('WriteBuffer', () => {
         done();
       });
     });
+    it('writeSync called from action does not overflow callstack - issue #3265', () => {
+      wb = new WriteBuffer(data => {
+        const num = parseInt(data as string);
+        if (num < 1000000) {
+          wb.writeSync('' + (num + 1));
+        }
+      });
+      wb.writeSync('1');
+    });
+    it('writeSync maxSubsequentCalls argument', () => {
+      let last: string = '';
+      wb = new WriteBuffer(data => {
+        last = data as string;
+        const num = parseInt(data as string);
+        if (num < 1000000) {
+          wb.writeSync('' + (num + 1), 10);
+        }
+      });
+      wb.writeSync('1', 10);
+      assert.equal(last, '11'); // 1 + 10 sub calls = 11
+    });
   });
 });


### PR DESCRIPTION
Fixes #3265.

@Tyriar
The fix introduces another optional argument `maxSubsequentCalls` to limit further `writeSync` subcalls. Usage:
- undefined: Will loop forever, if subsequent `writeSync` calls add chunks. Imho thats the correct behavior, as your caller code asked for that. This time without any overflow. :smile_cat: 
- 0: Run once, any subsequent call will exit early discarding the actual chunk.
- 1: Allow one subcall. And so on...

Note that the last chunk is always lost if you have to use `maxSubsequentCalls` (should not contain important data).