### PR TITLE
Visual marker at end of the selection and selectionStyle option to Terminal

### DIFF
--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -174,7 +174,7 @@ export class Terminal implements ITerminalApi {
   public paste(data: string): void {
     this._core.paste(data);
   }
-  public getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'logLevel' | 'rendererType' | 'termName' | 'wordSeparator'): string;
+  public getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'logLevel' | 'selectionStyle' | 'rendererType' | 'termName' | 'wordSeparator'): string;
   public getOption(key: 'allowTransparency' | 'altClickMovesCursor' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'disableStdin' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'visualBell'): boolean;
   public getOption(key: 'cols' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;
   public getOption(key: 'fontWeight' | 'fontWeightBold'): FontWeight;
@@ -191,6 +191,7 @@ export class Terminal implements ITerminalApi {
   public setOption(key: 'fontSize' | 'letterSpacing' | 'lineHeight' | 'tabStopWidth' | 'scrollback', value: number): void;
   public setOption(key: 'theme', value: ITheme): void;
   public setOption(key: 'cols' | 'rows', value: number): void;
+  public setOption(key: 'selectionStyle', value: 'plain' | 'mark-start' | 'mark-end'): void;
   public setOption(key: string, value: any): void;
   public setOption(key: any, value: any): void {
     this._core.optionsService.setOption(key, value);

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -53,7 +53,8 @@ export const DEFAULT_OPTIONS: ITerminalOptions = Object.freeze({
   altClickMovesCursor: true,
   convertEol: false,
   termName: 'xterm',
-  cancelEvents: false
+  cancelEvents: false,
+  selectionStyle: 'plain'
 });
 
 const FONT_WEIGHT_OPTIONS: Extract<FontWeight, string>[] = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -258,6 +258,7 @@ export interface ITerminalOptions {
   screenReaderMode: boolean;
   scrollback: number;
   scrollSensitivity: number;
+  selectionStyle: 'plain' | 'mark-start' | 'mark-end';
   tabStopWidth: number;
   theme: ITheme;
   windowsMode: boolean;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -226,6 +226,12 @@ declare module 'xterm' {
     scrollSensitivity?: number;
 
     /**
+     * Styling for the text selection shade - plain shading, 
+     *   or add a marker at the start/end of the shade
+     */
+    selectionStyle?: 'plain' | 'mark-start' | 'mark-end';
+
+    /**
      * The size of tab stops in the terminal.
      */
     tabStopWidth?: number;
@@ -946,7 +952,7 @@ declare module 'xterm' {
      * Retrieves an option's value from the terminal.
      * @param key The option key.
      */
-    getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'logLevel' | 'rendererType' | 'termName' | 'wordSeparator'): string;
+    getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'logLevel' | 'selectionStyle' | 'rendererType' | 'termName' | 'wordSeparator'): string;
     /**
      * Retrieves an option's value from the terminal.
      * @param key The option key.
@@ -1022,6 +1028,12 @@ declare module 'xterm' {
      * @param value The option value.
      */
     setOption(key: 'cols' | 'rows', value: number): void;
+    /**
+     * Sets an option on the terminal.
+     * @param key The option key.
+     * @param value The option value.
+     */
+    setOption(key: 'selectionStyle', value: 'plain' | 'mark-start' | 'mark-end'): void;
     /**
      * Sets an option on the terminal.
      * @param key The option key.


### PR DESCRIPTION
We introduce a new configuration option - `selectionStyle` - used to style the text selection layer.
It has three 'modes': `plain` (the current default), `mark-end` (add a marker to the end) and `mark-start` (add a marker to the beginning of the selection range). The styling of the marker is taken from the theme itself.

The use case here is when integrating with applications that need to allow manipulating either end of the selection range via keyboard, and we need a way to show the user the currently 'selected' end.

mark-start:    <img width="128" alt="Screen Shot 2021-03-31 at 18 43 09" src="https://user-images.githubusercontent.com/265333/113172327-0216ff80-9251-11eb-871f-204e436eac86.png">

mark-end:     <img width="126" alt="Screen Shot 2021-03-31 at 18 43 17" src="https://user-images.githubusercontent.com/265333/113172324-00e5d280-9251-11eb-8e41-28c33a057919.png">

