### PR TITLE
Fix #2714 - Start demo server before running integration tests

### DIFF
--- a/addons/xterm-addon-attach/test/AttachAddon.api.ts
+++ b/addons/xterm-addon-attach/test/AttachAddon.api.ts
@@ -7,7 +7,7 @@ import WebSocket = require('ws');
 import { openTerminal, pollFor, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/addons/xterm-addon-fit/test/FitAddon.api.ts
+++ b/addons/xterm-addon-fit/test/FitAddon.api.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { openTerminal, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/addons/xterm-addon-search/test/SearchAddon.api.ts
+++ b/addons/xterm-addon-search/test/SearchAddon.api.ts
@@ -9,7 +9,7 @@ import { resolve } from 'path';
 import { openTerminal, writeSync, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/addons/xterm-addon-serialize/test/SerializeAddon.api.ts
+++ b/addons/xterm-addon-serialize/test/SerializeAddon.api.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { openTerminal, writeSync, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/addons/xterm-addon-unicode11/test/Unicode11Addon.api.ts
+++ b/addons/xterm-addon-unicode11/test/Unicode11Addon.api.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { openTerminal, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/addons/xterm-addon-web-links/test/WebLinksAddon.api.ts
+++ b/addons/xterm-addon-web-links/test/WebLinksAddon.api.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { openTerminal, pollFor, writeSync, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/addons/xterm-addon-webgl/test/WebglRenderer.api.ts
+++ b/addons/xterm-addon-webgl/test/WebglRenderer.api.ts
@@ -9,7 +9,7 @@ import { assert } from 'chai';
 import { openTerminal, pollFor, writeSync, getBrowserType } from '../../../out-test/api/TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,10 +100,6 @@ jobs:
     displayName: 'Install Yarn'
   - script: yarn --frozen-lockfile
     displayName: 'Install dependencies and build'
-  - script: |
-      yarn start &
-      sleep 10
-    displayName: 'Start test server'
   - script: yarn test-api-chromium --headless --forbid-only
     displayName: 'Integration tests (Chromium)'
   - script: xvfb-run --auto-servernum -- bash -c "yarn test-api-firefox --headless --forbid-only"
@@ -119,10 +115,6 @@ jobs:
     displayName: 'Install Node.js'
   - script: yarn --frozen-lockfile
     displayName: 'Install dependencies and build'
-  - script: |
-      yarn start &
-      sleep 10
-    displayName: 'Start test server'
   - script: yarn test-api-chromium --headless --forbid-only
     displayName: 'Integration tests (Chromium)'
   - script: yarn test-api-firefox --headless --forbid-only

--- a/bin/test_api.js
+++ b/bin/test_api.js
@@ -34,6 +34,13 @@ if (process.argv.length > 2) {
 
 
 env.DEBUG = flagArgs.indexOf('--debug') >= 0 ? 'debug' : '';
+env.PORT = 3001;
+
+const server = cp.spawn('node', ['demo/start'], {
+  cwd: path.resolve(__dirname, '..'),
+  env,
+  stdio: 'inherit'
+})
 
 const run = cp.spawnSync(
   npmBinScript('mocha'),

--- a/test/api/CharWidth.api.ts
+++ b/test/api/CharWidth.api.ts
@@ -6,7 +6,7 @@
 import { pollFor, openTerminal, getBrowserType } from './TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/test/api/InputHandler.api.ts
+++ b/test/api/InputHandler.api.ts
@@ -8,7 +8,7 @@ import { pollFor, openTerminal, getBrowserType } from './TestUtils';
 import { Browser, Page } from 'playwright';
 import { IRenderDimensions } from 'browser/renderer/Types';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/test/api/MouseTracking.api.ts
+++ b/test/api/MouseTracking.api.ts
@@ -6,7 +6,7 @@
 import { pollFor, writeSync, openTerminal, getBrowserType } from './TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/test/api/Parser.api.ts
+++ b/test/api/Parser.api.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { writeSync, openTerminal, getBrowserType } from './TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;

--- a/test/api/Terminal.api.ts
+++ b/test/api/Terminal.api.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { pollFor, timeout, writeSync, openTerminal, getBrowserType } from './TestUtils';
 import { Browser, Page } from 'playwright';
 
-const APP = 'http://127.0.0.1:3000/test';
+const APP = 'http://127.0.0.1:3001/test';
 
 let browser: Browser;
 let page: Page;


### PR DESCRIPTION
Fixes #2714 
- Start demo server before running integration tests
- Use port 3001 instead of  3000 to not conflict with the demo