### PR TITLE
Add initial decorations API

### DIFF
--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -204,6 +204,10 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._onRequestRedraw.fire({ start: 0, end: this._terminal.rows - 1 });
   }
 
+  public onDecorationsChanged(): void {
+    // TBD
+  }
+
   public onCursorMove(): void {
     for (const l of this._renderLayers) {
       l.onCursorMove(this._terminal);

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -52,6 +52,7 @@ let protocol;
 let socketURL;
 let socket;
 let pid;
+let decorationHandle;
 
 type AddonType = 'attach' | 'fit' | 'search' | 'serialize' | 'unicode11' | 'web-links' | 'webgl' | 'ligatures';
 
@@ -147,6 +148,7 @@ if (document.location.pathname === '/test') {
   createTerminal();
   document.getElementById('dispose').addEventListener('click', disposeRecreateButtonHandler);
   document.getElementById('serialize').addEventListener('click', serializeButtonHandler);
+  document.getElementById('decorations').addEventListener('click', decorationsButtonHandler);
 }
 
 function createTerminal(): void {
@@ -429,5 +431,19 @@ function serializeButtonHandler(): void {
   if ((document.getElementById('write-to-terminal') as HTMLInputElement).checked) {
     term.reset();
     term.write(output);
+  }
+}
+
+function decorationsButtonHandler(): void {
+  if (decorationHandle) {
+    term.removeDeoration(decorationHandle);
+    decorationHandle = null;
+  } else {
+    decorationHandle = term.addDecoration({
+      startColumn: 3, endColumn: 13,
+      startRow: 3, endRow: 8,
+      fillStyle: 'rgba(255, 0, 0, 0.7)',
+      strokeStyle: 'rgba(0, 0, 255, 0.7)',
+    });
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,6 +22,7 @@
       <div id="options-container"></div>
     </div>
     <div>
+      <button id="decorations">Toggle decorations</button>
       <h3>Addons</h3>
       <p>Addons can be loaded and unloaded on a particular terminal to extend its functionality.</p>
       <div id="addons-container"></div>

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -458,6 +458,9 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this._characterJoinerService = this._instantiationService.createInstance(CharacterJoinerService);
     this._instantiationService.setService(ICharacterJoinerService, this._characterJoinerService);
 
+    this._decorationService = this.register(this._instantiationService.createInstance(DecorationService));
+    this._instantiationService.setService(IDecorationService, this._decorationService);
+
     const renderer = this._createRenderer();
     this._renderService = this.register(this._instantiationService.createInstance(RenderService, renderer, this.rows, this.screenElement));
     this._instantiationService.setService(IRenderService, this._renderService);
@@ -517,11 +520,10 @@ export class Terminal extends CoreTerminal implements ITerminal {
         this.viewport!.syncScrollArea();
       }
       this._selectionService!.refresh();
+      console.log('SCROLL');
+      this._renderService!.onDecorationsChanged();
     }));
     this.register(addDisposableDomListener(this._viewportElement, 'scroll', () => this._selectionService!.refresh()));
-
-    this._decorationService = this.register(this._instantiationService.createInstance(DecorationService));
-    this._instantiationService.setService(IDecorationService, this._decorationService);
 
     this._mouseZoneManager = this._instantiationService.createInstance(MouseZoneManager, this.element, this.screenElement);
     this.register(this._mouseZoneManager);
@@ -1287,13 +1289,19 @@ export class Terminal extends CoreTerminal implements ITerminal {
   }
 
   public addDecoration(element: IDecorationElement): IDecorationHandle | undefined{
-    return this._decorationService?.addDecoration(element);
+    const ret = this._decorationService?.addDecoration(element);
+    this._renderService?.onDecorationsChanged();
+    return ret;
   }
   public removeDeoration(handle: IDecorationHandle): boolean {
-    return !!(this._decorationService?.removeDeoration(handle));
+    const ret = !!(this._decorationService?.removeDeoration(handle));
+    this._renderService?.onDecorationsChanged();
+    return ret;
   }
   public clearDecorations(): number {
-    return this._decorationService?.clearDecorations() || 0;
+    const ret = this._decorationService?.clearDecorations() || 0;
+    this._renderService?.onDecorationsChanged();
+    return ret;
   }
 }
 

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -520,7 +520,6 @@ export class Terminal extends CoreTerminal implements ITerminal {
         this.viewport!.syncScrollArea();
       }
       this._selectionService!.refresh();
-      console.log('SCROLL');
       this._renderService!.onDecorationsChanged();
     }));
     this.register(addDisposableDomListener(this._viewportElement, 'scroll', () => this._selectionService!.refresh()));

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -412,6 +412,9 @@ export class MockRenderService implements IRenderService {
   public onSelectionChanged(start: [number, number], end: [number, number], columnSelectMode: boolean): void {
     throw new Error('Method not implemented.');
   }
+  public onDecorationsChanged(): void {
+    throw new Error('Method not implemented.');
+  }
   public onCursorMove(): void {
     throw new Error('Method not implemented.');
   }

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -9,7 +9,7 @@ import { ICharacterJoinerService, ICharSizeService, IMouseService, IRenderServic
 import { IRenderDimensions, IRenderer, IRequestRedrawEvent } from 'browser/renderer/Types';
 import { IColorSet, ILinkMatcherOptions, ITerminal, ILinkifier, ILinkifier2, IBrowser, IViewport, IColorManager, ICompositionHelper, CharacterJoinerHandler } from 'browser/Types';
 import { IBuffer, IBufferStringIterator, IBufferSet } from 'common/buffer/Types';
-import { IBufferLine, ICellData, IAttributeData, ICircularList, XtermListener, ICharset, ITerminalOptions } from 'common/Types';
+import { IBufferLine, ICellData, IAttributeData, ICircularList, XtermListener, ICharset, ITerminalOptions, IDecorationElement } from 'common/Types';
 import { Buffer } from 'common/buffer/Buffer';
 import * as Browser from 'common/Platform';
 import { Terminal } from 'browser/Terminal';
@@ -198,6 +198,15 @@ export class MockTerminal implements ITerminal {
   }
   public registerCharacterJoiner(handler: CharacterJoinerHandler): number { return 0; }
   public deregisterCharacterJoiner(joinerId: number): void { }
+  public addDecoration(element: IDecorationElement): number | undefined {
+    throw new Error('Method not implemented.');
+  }
+  public removeDeoration(handle: number): boolean {
+    throw new Error('Method not implemented.');
+  }
+  public clearDecorations(): number {
+    throw new Error('Method not implemented.');
+  }
 }
 
 export class MockBuffer implements IBuffer {
@@ -280,6 +289,7 @@ export class MockRenderer implements IRenderer {
   public onBlur(): void { }
   public onFocus(): void { }
   public onSelectionChanged(start: [number, number], end: [number, number]): void { }
+  public onDecorationsChanged(): void { }
   public onCursorMove(): void { }
   public onOptionsChanged(): void { }
   public onDevicePixelRatioChange(): void { }

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -5,7 +5,7 @@
 
 import { IDisposable, IMarker, ISelectionPosition } from 'xterm';
 import { IEvent } from 'common/EventEmitter';
-import { ICoreTerminal, CharData, ITerminalOptions } from 'common/Types';
+import { ICoreTerminal, CharData, ITerminalOptions, IDecorationElement, IDecorationHandle } from 'common/Types';
 import { IMouseService, IRenderService } from './services/Services';
 import { IBuffer, IBufferSet } from 'common/buffer/Types';
 import { IFunctionIdentifier, IParams } from 'common/parser/Types';
@@ -81,6 +81,9 @@ export interface IPublicTerminal extends IDisposable {
   paste(data: string): void;
   refresh(start: number, end: number): void;
   reset(): void;
+  addDecoration(element: IDecorationElement): IDecorationHandle | undefined;
+  removeDeoration(handle: IDecorationHandle): boolean;
+  clearDecorations(): number;
 }
 
 export type CustomKeyEventHandler = (event: KeyboardEvent) => boolean;

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -5,7 +5,7 @@
 
 import { Terminal as ITerminalApi, ITerminalOptions, IMarker, IDisposable, ILinkMatcherOptions, ITheme, ILocalizableStrings, ITerminalAddon, ISelectionPosition, IBuffer as IBufferApi, IBufferNamespace as IBufferNamespaceApi, IBufferLine as IBufferLineApi, IBufferCell as IBufferCellApi, IParser, IFunctionIdentifier, ILinkProvider, IUnicodeHandling, IUnicodeVersionProvider, FontWeight } from 'xterm';
 import { ITerminal } from 'browser/Types';
-import { IBufferLine, ICellData } from 'common/Types';
+import { IBufferLine, ICellData, IDecorationElement, IDecorationHandle } from 'common/Types';
 import { IBuffer, IBufferSet } from 'common/buffer/Types';
 import { CellData } from 'common/buffer/CellData';
 import { Terminal as TerminalCore } from '../Terminal';
@@ -175,6 +175,16 @@ export class Terminal implements ITerminalApi {
   public paste(data: string): void {
     this._core.paste(data);
   }
+  public addDecoration(element: IDecorationElement): IDecorationHandle | undefined {
+    return this._core.addDecoration(element);
+  }
+  public removeDeoration(handle: IDecorationHandle): boolean {
+    return this._core.removeDeoration(handle);
+  }
+  public clearDecorations(): number {
+    return this._core.clearDecorations();
+  }
+
   public getOption(key: 'bellSound' | 'bellStyle' | 'cursorStyle' | 'fontFamily' | 'logLevel' | 'rendererType' | 'termName' | 'wordSeparator'): string;
   public getOption(key: 'allowTransparency' | 'altClickMovesCursor' | 'cancelEvents' | 'convertEol' | 'cursorBlink' | 'disableStdin' | 'macOptionIsMeta' | 'rightClickSelectsWord' | 'popOnBell' | 'visualBell'): boolean;
   public getOption(key: 'cols' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'rows' | 'tabStopWidth' | 'scrollback'): number;

--- a/src/browser/renderer/BaseRenderLayer.ts
+++ b/src/browser/renderer/BaseRenderLayer.ts
@@ -79,6 +79,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
   public onCursorMove(): void {}
   public onGridChanged(startRow: number, endRow: number): void {}
   public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {}
+  public onDecorationsChanged(): void {}
 
   public setColors(colorSet: IColorSet): void {
     this._refreshCharAtlas(colorSet);

--- a/src/browser/renderer/DecorationRenderLayer.ts
+++ b/src/browser/renderer/DecorationRenderLayer.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { IRenderDimensions } from 'browser/renderer/Types';
+import { BaseRenderLayer } from 'browser/renderer/BaseRenderLayer';
+import { IColorSet } from 'browser/Types';
+import { IBufferService, IOptionsService } from 'common/services/Services';
+import { IDecorationService } from 'browser/services/Services';
+
+
+export class DecorationRenderLayer extends BaseRenderLayer {
+
+  private _decorationService: IDecorationService;
+
+  constructor(
+    container: HTMLElement,
+    zIndex: number,
+    colors: IColorSet,
+    rendererId: number,
+    @IDecorationService decorationService: IDecorationService,
+    @IBufferService bufferService: IBufferService,
+    @IOptionsService optionsService: IOptionsService,
+  ) {
+    super(container, 'decorations', zIndex, true, colors, rendererId, bufferService, optionsService);
+    this._decorationService = decorationService;
+  }
+
+  public reset(): void {
+    this._clearAll();
+  }
+
+  public onDecorationsChanged(): void {
+    // Remove all decorations
+    this._clearAll();
+
+    this._decorationService.forEachDecoration((element) => {
+      // Translate from buffer position to viewport position
+      const viewportStartRow = element.startRow - this._bufferService.buffer.ydisp;
+      const viewportEndRow = element.endRow - this._bufferService.buffer.ydisp;
+      const viewportCappedStartRow = Math.max(viewportStartRow, 0);
+      const viewportCappedEndRow = Math.min(viewportEndRow, this._bufferService.rows - 1);
+      const width = element.endColumn - element.startColumn;
+      const height = viewportCappedEndRow - viewportCappedStartRow + 1;
+      if (viewportStartRow <= viewportEndRow) {
+        if (element.fillStyle) {
+          this._ctx.fillStyle = element.fillStyle;
+          this._fillCells(element.startColumn, viewportCappedStartRow, width, height);
+        }
+        if (element.strokeStyle) {
+          this._ctx.strokeStyle = element.strokeStyle;
+          this._strokeRectAtCell(element.startColumn, viewportCappedStartRow, width, height);
+        }
+      }
+      return false;
+    });
+  }
+
+}

--- a/src/browser/renderer/Renderer.ts
+++ b/src/browser/renderer/Renderer.ts
@@ -14,6 +14,7 @@ import { ICharSizeService, ICoreBrowserService } from 'browser/services/Services
 import { IBufferService, IOptionsService, ICoreService, IInstantiationService } from 'common/services/Services';
 import { removeTerminalFromCache } from 'browser/renderer/atlas/CharAtlasCache';
 import { EventEmitter, IEvent } from 'common/EventEmitter';
+import { DecorationRenderLayer } from 'browser/renderer/DecorationRenderLayer';
 
 let nextRendererId = 1;
 
@@ -36,7 +37,7 @@ export class Renderer extends Disposable implements IRenderer {
     @IInstantiationService instantiationService: IInstantiationService,
     @IBufferService private readonly _bufferService: IBufferService,
     @ICharSizeService private readonly _charSizeService: ICharSizeService,
-    @IOptionsService private readonly _optionsService: IOptionsService
+    @IOptionsService private readonly _optionsService: IOptionsService,
   ) {
     super();
     const allowTransparency = this._optionsService.options.allowTransparency;
@@ -44,7 +45,8 @@ export class Renderer extends Disposable implements IRenderer {
       instantiationService.createInstance(TextRenderLayer, this._screenElement, 0, this._colors, allowTransparency, this._id),
       instantiationService.createInstance(SelectionRenderLayer, this._screenElement, 1, this._colors, this._id),
       instantiationService.createInstance(LinkRenderLayer, this._screenElement, 2, this._colors, this._id, linkifier, linkifier2),
-      instantiationService.createInstance(CursorRenderLayer, this._screenElement, 3, this._colors, this._id, this._onRequestRedraw)
+      instantiationService.createInstance(DecorationRenderLayer, this._screenElement, 3, this._colors, this._id),
+      instantiationService.createInstance(CursorRenderLayer, this._screenElement, 4, this._colors, this._id, this._onRequestRedraw),
     ];
     this.dimensions = {
       scaledCharWidth: 0,
@@ -119,6 +121,10 @@ export class Renderer extends Disposable implements IRenderer {
 
   public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {
     this._runOperation(l => l.onSelectionChanged(start, end, columnSelectMode));
+  }
+
+  public onDecorationsChanged(): void {
+    this._runOperation(l => l.onDecorationsChanged());
   }
 
   public onCursorMove(): void {

--- a/src/browser/renderer/Types.d.ts
+++ b/src/browser/renderer/Types.d.ts
@@ -48,6 +48,7 @@ export interface IRenderer extends IDisposable {
   onBlur(): void;
   onFocus(): void;
   onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  onDecorationsChanged(): void;
   onCursorMove(): void;
   onOptionsChanged(): void;
   clear(): void;
@@ -90,6 +91,11 @@ export interface IRenderLayer extends IDisposable {
    * Calls when the selection changes.
    */
   onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+
+  /**
+   * Called when decorations change
+   */
+  onDecorationsChanged(): void;
 
   /**
    * Resize the render layer.

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -337,6 +337,10 @@ export class DomRenderer extends Disposable implements IRenderer {
     return element;
   }
 
+  public onDecorationsChanged(): void {
+    // TBD
+  }
+
   public onCursorMove(): void {
     // No-op, the cursor is drawn when rows are drawn
   }

--- a/src/browser/services/DecorationService.ts
+++ b/src/browser/services/DecorationService.ts
@@ -3,15 +3,8 @@
  * @license MIT
  */
 
-import { IRenderer, IRenderDimensions, CharacterJoinerHandler } from 'browser/renderer/Types';
-import { RenderDebouncer } from 'browser/RenderDebouncer';
-import { EventEmitter, IEvent } from 'common/EventEmitter';
 import { Disposable } from 'common/Lifecycle';
-import { ScreenDprMonitor } from 'browser/ScreenDprMonitor';
-import { addDisposableDomListener } from 'browser/Lifecycle';
-import { IColorSet } from 'browser/Types';
-import { IOptionsService, IBufferService } from 'common/services/Services';
-import { ICharSizeService, IDecorationService } from 'browser/services/Services';
+import { IDecorationService } from 'browser/services/Services';
 import { IDecorationElement, IDecorationHandle } from 'common/Types';
 
 interface IDecorationRegistration {
@@ -22,6 +15,7 @@ interface IDecorationRegistration {
 
 export class DecorationService extends Disposable implements IDecorationService {
   public serviceBrand: undefined;
+  private _handle = 0;
 
   private _activeDecorations: IDecorationRegistration[] = [];
 
@@ -30,12 +24,13 @@ export class DecorationService extends Disposable implements IDecorationService 
   }
 
   public addDecoration(element: IDecorationElement): number {
+    this._handle += 1;
     const registration: IDecorationRegistration = {
-      handle: this._activeDecorations.length,
+      handle: this._handle,
       element: element
     };
-    this._activeDecorations[registration.handle] = registration;
-    return registration.handle;
+    this._activeDecorations.push(registration);
+    return this._handle;
   }
 
   public removeDeoration(handle: IDecorationHandle): boolean {

--- a/src/browser/services/DecorationService.ts
+++ b/src/browser/services/DecorationService.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { IRenderer, IRenderDimensions, CharacterJoinerHandler } from 'browser/renderer/Types';
+import { RenderDebouncer } from 'browser/RenderDebouncer';
+import { EventEmitter, IEvent } from 'common/EventEmitter';
+import { Disposable } from 'common/Lifecycle';
+import { ScreenDprMonitor } from 'browser/ScreenDprMonitor';
+import { addDisposableDomListener } from 'browser/Lifecycle';
+import { IColorSet } from 'browser/Types';
+import { IOptionsService, IBufferService } from 'common/services/Services';
+import { ICharSizeService, IDecorationService } from 'browser/services/Services';
+import { IDecorationElement, IDecorationHandle } from 'common/Types';
+
+interface IDecorationRegistration {
+  handle: IDecorationHandle;
+  element: IDecorationElement;
+}
+
+
+export class DecorationService extends Disposable implements IDecorationService {
+  public serviceBrand: undefined;
+
+  private _activeDecorations: IDecorationRegistration[] = [];
+
+  constructor() {
+    super();
+  }
+
+  public addDecoration(element: IDecorationElement): number {
+    const registration: IDecorationRegistration = {
+      handle: this._activeDecorations.length,
+      element: element
+    };
+    this._activeDecorations[registration.handle] = registration;
+    return registration.handle;
+  }
+
+  public removeDeoration(handle: IDecorationHandle): boolean {
+    for (let index = 0 ; index < this._activeDecorations.length ; index++) {
+      const reg = this._activeDecorations[index];
+      if (reg.handle === handle) {
+        this._activeDecorations.splice(index, 1);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public forEachDecoration(callback: (decoration: IDecorationElement) => boolean): void {
+    for (const reg of this._activeDecorations) {
+      if (callback(reg.element)) {
+        return;
+      }
+    }
+  }
+
+  public clearDecorations(): number {
+    const count = this._activeDecorations.length;
+    this._activeDecorations = [];
+    return count;
+  }
+}

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -118,6 +118,7 @@ export class RenderService extends Disposable implements IRenderService {
       this._renderer.onSelectionChanged(this._selectionState.start, this._selectionState.end, this._selectionState.columnSelectMode);
       this._needsSelectionRefresh = false;
     }
+    this._renderer.onDecorationsChanged();
 
     // Fire render event only if it was not a redraw
     if (!this._isNextRenderRedrawOnly) {

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -207,6 +207,10 @@ export class RenderService extends Disposable implements IRenderService {
     this._renderer.onSelectionChanged(start, end, columnSelectMode);
   }
 
+  public onDecorationsChanged(): void {
+    this._renderer.onDecorationsChanged();
+  }
+
   public onCursorMove(): void {
     this._renderer.onCursorMove();
   }

--- a/src/browser/services/Services.ts
+++ b/src/browser/services/Services.ts
@@ -64,6 +64,7 @@ export interface IRenderService extends IDisposable {
   onBlur(): void;
   onFocus(): void;
   onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  onDecorationsChanged(): void;
   onCursorMove(): void;
   clear(): void;
 }

--- a/src/browser/services/Services.ts
+++ b/src/browser/services/Services.ts
@@ -8,7 +8,7 @@ import { IRenderDimensions, IRenderer } from 'browser/renderer/Types';
 import { IColorSet } from 'browser/Types';
 import { ISelectionRedrawRequestEvent as ISelectionRequestRedrawEvent, ISelectionRequestScrollLinesEvent } from 'browser/selection/Types';
 import { createDecorator } from 'common/services/ServiceRegistry';
-import { IDisposable } from 'common/Types';
+import { IDecorationHandle, IDecorationElement, IDisposable } from 'common/Types';
 
 export const ICharSizeService = createDecorator<ICharSizeService>('CharSizeService');
 export interface ICharSizeService {
@@ -103,7 +103,6 @@ export interface ISoundService {
   playBellSound(): void;
 }
 
-
 export const ICharacterJoinerService = createDecorator<ICharacterJoinerService>('CharacterJoinerService');
 export interface ICharacterJoinerService {
   serviceBrand: undefined;
@@ -111,4 +110,14 @@ export interface ICharacterJoinerService {
   register(handler: (text: string) => [number, number][]): number;
   deregister(joinerId: number): boolean;
   getJoinedCharacters(row: number): [number, number][];
+}
+
+export const IDecorationService = createDecorator<IDecorationService>('DecorationService');
+export interface IDecorationService {
+  serviceBrand: undefined;
+
+  addDecoration(element: IDecorationElement): IDecorationHandle;
+  removeDeoration(handle: IDecorationHandle): boolean;
+  forEachDecoration(callback: (decoration: IDecorationElement) => boolean) : void;
+  clearDecorations(): number;
 }

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -448,3 +448,13 @@ interface IParseStack {
   decodedLength: number;
   position: number;
 }
+
+export type IDecorationHandle = number;
+interface IDecorationElement {
+  startColumn: number;
+  endColumn: number;
+  startRow: number;
+  endRow: number;
+  fillStyle: string | CanvasGradient | CanvasPattern;
+  strokeStyle: string | CanvasGradient | CanvasPattern;
+}


### PR DESCRIPTION
Following the discussion in https://github.com/xtermjs/xterm.js/pull/3274

Here's a simple decorations API which adds the ability to add custom 'decorations' on top of the terminal layers, without interfering with the buffer, selections or the cursor.

API is as follows:
```typescript
export interface IDecorationService {
  serviceBrand: undefined;

  addDecoration(element: IDecorationElement): IDecorationHandle;
  removeDeoration(handle: IDecorationHandle): boolean;
  forEachDecoration(callback: (decoration: IDecorationElement) => boolean) : void;
  clearDecorations(): number;
}

export type IDecorationHandle = number;
interface IDecorationElement {
  startColumn: number;
  endColumn: number;
  startRow: number;
  endRow: number;
  fillStyle: string | CanvasGradient | CanvasPattern;
  strokeStyle: string | CanvasGradient | CanvasPattern;
}
```

This is my first contribution to this code base so please review carefully :) 