### PR TITLE
Ensure all viewport scroll events are handled by buffer

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -476,7 +476,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this._instantiationService.setService(IMouseService, this._mouseService);
 
     this.viewport = this._instantiationService.createInstance(Viewport,
-      (amount: number) => this.scrollLines(amount, false, ScrollSource.VIEWPORT),
+      (amount: number) => this.scrollLines(amount, true, ScrollSource.VIEWPORT),
       this._viewportElement,
       this._viewportScrollArea
     );
@@ -511,9 +511,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       this.textarea!.select();
     }));
     this.register(this._onScroll.event(ev => {
-      if (ev.source !== ScrollSource.VIEWPORT) {
-        this.viewport!.syncScrollArea();
-      }
+      this.viewport!.syncScrollArea();
       this._selectionService!.refresh();
     }));
     this.register(addDisposableDomListener(this._viewportElement, 'scroll', () => this._selectionService!.refresh()));


### PR DESCRIPTION
Some scroll events were never making it to the buffer service when using a trackpad.

See microsoft/vscode#121017
Fixes #3311