### PR TITLE
Don't start npm start until watch is done

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,51 +1,70 @@
 {
-	"version": "2.0.0",
-	"presentation": {
-		"echo": false,
-		"reveal": "always",
-		"focus": false,
-		"panel": "dedicated",
-		"showReuseMessage": true
-	},
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "test",
-			"group": "test",
-			"problemMatcher": []
-		},
-		{
-			"type": "npm",
-			"script": "watch",
-			"group": "build",
-			"isBackground": true,
-			"problemMatcher": [],
-			"presentation": {
-				"group": "vscode"
-			}
-		},
-		{
-			"type": "npm",
-			"script": "start",
-			"group": "build",
-			"isBackground": true,
-			"problemMatcher": [],
-			"presentation": {
-				"group": "vscode"
-			}
-		},
-		{
-			"label": "Start demo",
-			"dependsOn": ["npm: watch", "npm: start"],
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"isBackground": true,
-			"problemMatcher": [],
-			"presentation": {
-				"group": "vscode"
-			}
-		}
-	]
+  "version": "2.0.0",
+  "presentation": {
+    "echo": false,
+    "reveal": "always",
+    "focus": false,
+    "panel": "dedicated",
+    "showReuseMessage": true
+  },
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "test",
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "type": "npm",
+      "script": "watch",
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "group": "vscode"
+      }
+    },
+    {
+      "type": "npm",
+      "script": "start",
+      "dependsOn": "npm: watch",
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "group": "vscode"
+      }
+    },
+    {
+      "label": "Start demo",
+      "dependsOn": "npm: start",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
+        ],
+        "pattern": [
+          {
+            "regexp": "^([^\\\\s].*)\\\\((\\\\d+,\\\\d+)\\\\):\\\\s*(.*)$",
+            "file": 1,
+            "location": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "beginsPattern": "assets by",
+          "endsPattern": "webpack \\d+\\.\\d+\\.\\d+ compiled successfully"
+        }
+      },
+      "presentation": {
+        "group": "vscode"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Instead of starting both `npm watch` and `npm start` at the same time, this will wait for `npm watch` to finish compiling before starting `npm start` (webpack). This should improve the initial compile somewhat since webpack isn't watching file and reacting to changes while tsc is doing its thing.