### PR TITLE
hotfix on 4.12 - chore(types): use IEvent from xterm

### DIFF
--- a/addons/xterm-addon-webgl/typings/xterm-addon-webgl.d.ts
+++ b/addons/xterm-addon-webgl/typings/xterm-addon-webgl.d.ts
@@ -3,8 +3,7 @@
  * @license MIT
  */
 
-import { IEvent } from 'node-pty';
-import { Terminal, ITerminalAddon } from 'xterm';
+import { Terminal, ITerminalAddon, IEvent } from 'xterm';
 
 declare module 'xterm-addon-webgl' {
   /**


### PR DESCRIPTION
(cherry picked from commit 7a0b462e7eedbf8824652409bce325afd19f16c2)