### PR TITLE
Update local fonts query

### DIFF
--- a/addons/xterm-addon-ligatures/src/font.ts
+++ b/addons/xterm-addon-ligatures/src/font.ts
@@ -44,8 +44,8 @@ export default async function load(fontFamily: string, cacheSize: number): Promi
       }
       const fonts: Record<string, IFontMetadata[]> = {};
       try {
-        const fontsIterator: AsyncIterableIterator<IFontMetadata> = (navigator as any).fonts.query();
-        for await (const metadata of fontsIterator) {
+        const fontsIterator: IFontMetadata[] = await (navigator as any).fonts.query();
+        for (const metadata of fontsIterator) {
           if (!fonts.hasOwnProperty(metadata.family)) {
             fonts[metadata.family] = [];
           }

--- a/addons/xterm-addon-ligatures/src/font.ts
+++ b/addons/xterm-addon-ligatures/src/font.ts
@@ -15,6 +15,15 @@ interface IFontMetadata {
   blob: () => Promise<Blob>;
 }
 
+interface IFontAccessNavigator {
+  fonts: {
+    query: () => Promise<IFontMetadata[]>;
+  };
+  permissions: {
+    request?: (permission: { name: string }) => Promise<{state: string}>;
+  };
+}
+
 let fontsPromise: Promise<FontList | Record<string, IFontMetadata[]>> | undefined = undefined;
 
 /**
@@ -28,7 +37,7 @@ export default async function load(fontFamily: string, cacheSize: number): Promi
     // Web environment that supports font access API
     if (typeof navigator !== 'undefined' && 'fonts' in navigator) {
       try {
-        const status = await (navigator as any).permissions.request?.({
+        const status = await (navigator as IFontAccessNavigator).permissions.request?.({
           name: 'local-fonts'
         });
         if (status && status.state !== 'granted') {
@@ -44,7 +53,7 @@ export default async function load(fontFamily: string, cacheSize: number): Promi
       }
       const fonts: Record<string, IFontMetadata[]> = {};
       try {
-        const fontsIterator: IFontMetadata[] = await (navigator as any).fonts.query();
+        const fontsIterator = await (navigator as IFontAccessNavigator).fonts.query();
         for (const metadata of fontsIterator) {
           if (!fonts.hasOwnProperty(metadata.family)) {
             fonts[metadata.family] = [];


### PR DESCRIPTION
The local fonts api has changed a bit
`navigator.fonts.query()` now returns a Promise for Array of font metadata instead of async iterator
See https://github.com/WICG/local-font-access#enumerating-local-fonts