### PR TITLE
devcontainer: upgrade to node v14.x

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Upgrade the devcontainer setup from node v10 to node v14. Since some devdependencies require at least node v12, it was no longer possible to run `yarn` successfully with node v10.  