### PR TITLE
Change textBaseline from "ideographic" to "bottom"

### DIFF
--- a/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
+++ b/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
@@ -365,7 +365,7 @@ export class WebglCharAtlas implements IDisposable {
     const fontStyle = italic ? 'italic' : '';
     this._tmpCtx.font =
       `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
-    this._tmpCtx.textBaseline = 'ideographic';
+    this._tmpCtx.textBaseline = 'bottom';
 
     this._tmpCtx.fillStyle = this._getForegroundCss(bg, bgColorMode, bgColor, fg, fgColorMode, fgColor, inverse, bold);
 

--- a/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
@@ -224,7 +224,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
    */
   protected _fillCharTrueColor(terminal: Terminal, cell: CellData, x: number, y: number): void {
     this._ctx.font = this._getFont(terminal, false, false);
-    this._ctx.textBaseline = 'ideographic';
+    this._ctx.textBaseline = 'bottom';
     this._clipRow(terminal, y);
     this._ctx.fillText(
       cell.getChars(),

--- a/src/browser/renderer/BaseRenderLayer.ts
+++ b/src/browser/renderer/BaseRenderLayer.ts
@@ -242,7 +242,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
    */
   protected _fillCharTrueColor(cell: CellData, x: number, y: number): void {
     this._ctx.font = this._getFont(false, false);
-    this._ctx.textBaseline = 'ideographic';
+    this._ctx.textBaseline = 'bottom';
     this._clipRow(y);
     this._ctx.fillText(
       cell.getChars(),
@@ -320,7 +320,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
   private _drawUncachedChars(cell: ICellData, x: number, y: number, fgOverride?: IColor): void {
     this._ctx.save();
     this._ctx.font = this._getFont(!!cell.isBold(), !!cell.isItalic());
-    this._ctx.textBaseline = 'ideographic';
+    this._ctx.textBaseline = 'bottom';
 
     if (cell.isInverse()) {
       if (fgOverride) {

--- a/src/browser/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/browser/renderer/atlas/DynamicCharAtlas.ts
@@ -256,7 +256,7 @@ export class DynamicCharAtlas extends BaseCharAtlas {
     const fontStyle = glyph.italic ? 'italic' : '';
     this._tmpCtx.font =
       `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
-    this._tmpCtx.textBaseline = 'ideographic';
+    this._tmpCtx.textBaseline = 'bottom';
 
     this._tmpCtx.fillStyle = this._getForegroundColor(glyph).css;
 


### PR DESCRIPTION
This changes the `textBaseline` from `ideographic` to `bottom` to resolve Issue #3353. I made changes in all places where `middle` was changed to `ideographic` as part of PR #3279.

In my testing, the update worked as expected. However, I don't know whether there are assumptions elsewhere that this would break. Any feedback would be appreciated if there is further testing I should conduct and/or additional changes that should be made.

I tried using the code in https://github.com/xtermjs/xterm.js/wiki/Powerline-fonts to test whether powerline fonts continue to work as expected, but the fonts were not supported by my browser, either with or without the change in this PR. I tried on Chrome as well with no success. I also tried on Windows instead of Ubuntu, and encountered the same issue.

![fonts_not_supported](https://user-images.githubusercontent.com/541289/120088298-0595fe00-c0bd-11eb-94fd-ec9acaf43de9.png)


