### PR TITLE
Set text baseline conditionally by browser.

### DIFF
--- a/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
+++ b/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
@@ -4,7 +4,7 @@
  */
 
 import { ICharAtlasConfig } from './Types';
-import { DIM_OPACITY } from 'browser/renderer/atlas/Constants';
+import { DIM_OPACITY, TEXT_BASELINE } from 'browser/renderer/atlas/Constants';
 import { IRasterizedGlyph, IBoundingBox, IRasterizedGlyphSet } from '../Types';
 import { DEFAULT_COLOR, Attributes } from 'common/buffer/Constants';
 import { throwIfFalsy } from '../WebglUtils';
@@ -365,7 +365,7 @@ export class WebglCharAtlas implements IDisposable {
     const fontStyle = italic ? 'italic' : '';
     this._tmpCtx.font =
       `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
-    this._tmpCtx.textBaseline = 'ideographic';
+    this._tmpCtx.textBaseline = TEXT_BASELINE;
 
     this._tmpCtx.fillStyle = this._getForegroundCss(bg, bgColorMode, bgColor, fg, fgColorMode, fgColor, inverse, bold);
 

--- a/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
@@ -7,6 +7,7 @@ import { IRenderLayer } from './Types';
 import { acquireCharAtlas } from '../atlas/CharAtlasCache';
 import { Terminal } from 'xterm';
 import { IColorSet } from 'browser/Types';
+import { TEXT_BASELINE } from 'browser/renderer/atlas/Constants';
 import { IRenderDimensions } from 'browser/renderer/Types';
 import { CellData } from 'common/buffer/CellData';
 import { WebglCharAtlas } from 'atlas/WebglCharAtlas';
@@ -224,7 +225,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
    */
   protected _fillCharTrueColor(terminal: Terminal, cell: CellData, x: number, y: number): void {
     this._ctx.font = this._getFont(terminal, false, false);
-    this._ctx.textBaseline = 'ideographic';
+    this._ctx.textBaseline = TEXT_BASELINE;
     this._clipRow(terminal, y);
     this._ctx.fillText(
       cell.getChars(),

--- a/src/browser/renderer/BaseRenderLayer.ts
+++ b/src/browser/renderer/BaseRenderLayer.ts
@@ -7,7 +7,7 @@ import { IRenderDimensions, IRenderLayer } from 'browser/renderer/Types';
 import { ICellData } from 'common/Types';
 import { DEFAULT_COLOR, WHITESPACE_CELL_CHAR, WHITESPACE_CELL_CODE, Attributes } from 'common/buffer/Constants';
 import { IGlyphIdentifier } from 'browser/renderer/atlas/Types';
-import { DIM_OPACITY, INVERTED_DEFAULT_COLOR } from 'browser/renderer/atlas/Constants';
+import { DIM_OPACITY, INVERTED_DEFAULT_COLOR, TEXT_BASELINE } from 'browser/renderer/atlas/Constants';
 import { BaseCharAtlas } from 'browser/renderer/atlas/BaseCharAtlas';
 import { acquireCharAtlas } from 'browser/renderer/atlas/CharAtlasCache';
 import { AttributeData } from 'common/buffer/AttributeData';
@@ -242,7 +242,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
    */
   protected _fillCharTrueColor(cell: CellData, x: number, y: number): void {
     this._ctx.font = this._getFont(false, false);
-    this._ctx.textBaseline = 'ideographic';
+    this._ctx.textBaseline = TEXT_BASELINE;
     this._clipRow(y);
     this._ctx.fillText(
       cell.getChars(),
@@ -320,7 +320,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
   private _drawUncachedChars(cell: ICellData, x: number, y: number, fgOverride?: IColor): void {
     this._ctx.save();
     this._ctx.font = this._getFont(!!cell.isBold(), !!cell.isItalic());
-    this._ctx.textBaseline = 'ideographic';
+    this._ctx.textBaseline = TEXT_BASELINE;
 
     if (cell.isInverse()) {
       if (fgOverride) {

--- a/src/browser/renderer/atlas/Constants.ts
+++ b/src/browser/renderer/atlas/Constants.ts
@@ -3,7 +3,13 @@
  * @license MIT
  */
 
+import { isFirefox } from 'common/Platform';
+
 export const INVERTED_DEFAULT_COLOR = 257;
 export const DIM_OPACITY = 0.5;
+// The text baseline is set conditionally by browser. Using 'ideographic' for Firefox would
+// result in truncated text (Issue 3353). Using 'bottom' for Chrome would result in slightly
+// unaligned Powerline fonts (PR 3356#issuecomment-850928179).
+export const TEXT_BASELINE: CanvasTextBaseline = isFirefox ? 'bottom' : 'ideographic';
 
 export const CHAR_ATLAS_CELL_SPACING = 1;

--- a/src/browser/renderer/atlas/DynamicCharAtlas.ts
+++ b/src/browser/renderer/atlas/DynamicCharAtlas.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { DIM_OPACITY, INVERTED_DEFAULT_COLOR } from 'browser/renderer/atlas/Constants';
+import { DIM_OPACITY, INVERTED_DEFAULT_COLOR, TEXT_BASELINE } from 'browser/renderer/atlas/Constants';
 import { IGlyphIdentifier, ICharAtlasConfig } from 'browser/renderer/atlas/Types';
 import { BaseCharAtlas } from 'browser/renderer/atlas/BaseCharAtlas';
 import { DEFAULT_ANSI_COLORS } from 'browser/ColorManager';
@@ -256,7 +256,7 @@ export class DynamicCharAtlas extends BaseCharAtlas {
     const fontStyle = glyph.italic ? 'italic' : '';
     this._tmpCtx.font =
       `${fontStyle} ${fontWeight} ${this._config.fontSize * this._config.devicePixelRatio}px ${this._config.fontFamily}`;
-    this._tmpCtx.textBaseline = 'ideographic';
+    this._tmpCtx.textBaseline = TEXT_BASELINE;
 
     this._tmpCtx.fillStyle = this._getForegroundColor(glyph).css;
 


### PR DESCRIPTION
This changes the `textBaseline` from `ideographic` to `bottom` for Firefox, to resolve Issue #3353. I made changes in all places where `middle` was changed to `ideographic` as part of PR #3279. The change was not made for Chrome, to avoid Powerline fonts from becoming [slightly unaligned](https://github.com/xtermjs/xterm.js/pull/3356#issuecomment-850928179). On Firefox, it appears the Poweline text is slightly high when I set the font to `monospace` and slightly low when I set it to `DejaVu Sans Mono`, but in both cases an improvement versus the low text when using `ideographic` for `textBaseline` prior to this PR's update.

**Firefox `fontFamily=monospace` `textBaseline=ideographic`** (before this PR's update)

<img src="https://user-images.githubusercontent.com/541289/122309323-18da0380-cedc-11eb-8401-3ec1d8f415bc.png?raw=true" width="600"/>

**Firefox `fontFamily=monospace` `textBaseline=bottom`** (after this PR's update)

<img src="https://user-images.githubusercontent.com/541289/122308984-73bf2b00-cedb-11eb-9f37-242a387f59cd.png?raw=true" width="600"/>

**Firefox `fontFamily=DejaVu Sans Mono` `textBaseline=ideographic`** (before this PR's update)

<img src="https://user-images.githubusercontent.com/541289/122308995-791c7580-cedb-11eb-97c7-4361dc6b933f.png?raw=true" width="600"/>

**Firefox `fontFamily=DejaVu Sans Mono` `textBaseline=bottom`** (after this PR's update)

<img src="https://user-images.githubusercontent.com/541289/122309008-7d489300-cedb-11eb-8d0e-25d59000273f.png?raw=true" width="600"/>

In my testing, the update worked as expected (other than the possible slight Powerline alignment issue mentioned above). However, I don't know whether there are assumptions elsewhere that this would break, and I wasn't sure where in the code would be an appropriate place for defining `TEXT_BASELINE`, which is currently in `browser/renderer/atlas/Constants.ts`.

Any feedback would be appreciated if this is a sufficient way to address Issue #3353 and there is further testing I should conduct and/or additional changes that should be made.