### PR TITLE
Handle 'cmd + .' on macOS

### DIFF
--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -359,6 +359,8 @@ export function evaluateKeyboardEvent(
       } else if (isMac && !ev.altKey && !ev.ctrlKey && !ev.shiftKey && ev.metaKey) {
         if (ev.keyCode === 65) { // cmd + a
           result.type = KeyboardResultType.SELECT_ALL;
+        } else if (ev.keyCode === 190) { // cmd + . (same as ^C)
+          result.key = C0.ETX;
         }
       } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 48 && ev.key.length === 1) {
         // Include only keys that that result in a _single_ character; don't include num lock, volume up, etc.


### PR DESCRIPTION
- treat it as 'ctrl + C', as like in macOS Terminal
- checked the expected behavior manually:
  - in xterm demo page
  - in VS Code integrated terminal, using a customized local xterm lib
- fix #3400 