### PR TITLE
input: handle dead keys

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -94,6 +94,13 @@ export class Terminal extends CoreTerminal implements ITerminal {
    */
   private _keyDownHandled: boolean = false;
 
+  /**
+   * Records whether there has been a keydown event for a dead key without a corresponding keydown
+   * event for the composed/alternative character. If we cancel the keydown event for the dead key,
+   * no events will be emitted for the final character.
+   */
+  private _unprocessedDeadKey: boolean = false;
+
   public linkifier: ILinkifier;
   public linkifier2: ILinkifier2;
   public viewport: IViewport | undefined;
@@ -1025,6 +1032,10 @@ export class Terminal extends CoreTerminal implements ITerminal {
       return false;
     }
 
+    if (event.key === 'Dead') {
+      this._unprocessedDeadKey = true;
+    }
+
     const result = evaluateKeyboardEvent(event, this.coreService.decPrivateModes.applicationCursorKeys, this.browser.isMac, this.options.macOptionIsMeta);
 
     this.updateCursorStyle(event);
@@ -1049,6 +1060,11 @@ export class Terminal extends CoreTerminal implements ITerminal {
     }
 
     if (!result.key) {
+      return true;
+    }
+
+    if (this._unprocessedDeadKey) {
+      this._unprocessedDeadKey = false;
       return true;
     }
 


### PR DESCRIPTION
Fixes #2151
This adds extra handling to avoid canceling `keydown` events dead keys, since canceling a dead key's own `keydown` will cancel the future `keydown` for the combined character.

The typical event flow for e.g. `Swedish Tilde` + `Forward Slash` is: 

* While canceling keydown (current):
![image](https://user-images.githubusercontent.com/161476/130360736-d0c2eb17-bd47-45e6-bd5c-ec4290d52217.png)
 
* Without canceling keydown (fixed):
![image](https://user-images.githubusercontent.com/161476/130360712-2a317a63-0fee-4b5d-9b52-c4e61d907b15.png)

For clarity, we want to let through the next `keydown` event that is responsible for a future `keypress`/`input` (so not just the "next" one since it might be a modifier key), hence the order of the checks.