### PR TITLE
input: treat AltGraph as a dead key

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1032,7 +1032,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       return false;
     }
 
-    if (event.key === 'Dead') {
+    if (event.key === 'Dead' || event.key === 'AltGraph') {
       this._unprocessedDeadKey = true;
     }
 


### PR DESCRIPTION
This solves the issue of `RightAlt-SpanishTilde` + `q` producing a `qq` instead of `~q` on Windows