### PR TITLE
Issue #3425 (Terminal controls shifted to the right of the demo)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -15,42 +15,69 @@
   </head>
   <body>
     <h1 style="color: #2D2E2C">xterm.js: A terminal for the <em style="color: #5DA5D5">web</em></h1>
-    <div id="terminal-container"></div>
-    <div>
-      <h3>Options</h3>
-      <p>These options can be set in the <code>Terminal</code> constructor or by using the <code>Terminal.setOption</code> function.</p>
-      <div id="options-container"></div>
-    </div>
-    <div>
-      <h3>Addons</h3>
-      <p>Addons can be loaded and unloaded on a particular terminal to extend its functionality.</p>
-      <div id="addons-container"></div>
-      <h3>Addons Control</h3>
-      <h4>SearchAddon</h4>
-      <p>
-        <label>Find next <input id="find-next"/></label>
-        <label>Find previous <input id="find-previous"/></label>
-        <label>Use regex<input type="checkbox" id="regex"/></label>
-        <label>Case sensitive<input type="checkbox" id="case-sensitive"/></label>
-        <label>Whole word<input type="checkbox" id="whole-word"/></label>
-      </p>
-      <h4>SerializeAddon</h4>
-      <p>
-        <button id="serialize">Serialize the content of terminal</button>
-        <label><input type="checkbox" id="write-to-terminal">Write back to terminal</label>
-        <div><pre id="serialize-output"></pre></div>
-      </p>
-    </div>
-    <div>
-      <h3>Style</h3>
-      <div style="display: inline-block; margin-right: 16px;">
-        <label for="padding">Padding</label>
-        <input type="number" id="padding" />
+    <div id="container">
+      <div id="grid">
+        <div id="terminal-container"></div>
+      </div>
+      <div id="grid">
+        <div class="tab">
+          <button class="tabLinks active" onclick="openSection(event, 'options')">Options</button>
+          <button class="tabLinks" onclick="openSection(event, 'addons')">Add Ons</button>
+          <button class="tabLinks" onclick="openSection(event, 'style')">Style</button>
+        </div>
+        <div id="options" class="tabContent">
+          <h3>Options</h3>
+          <p>These options can be set in the <code>Terminal</code> constructor or by using the <code>Terminal.setOption</code> function.</p>
+          <div id="options-container"></div>
+        </div>
+        <div id="addons" class="tabContent">
+          <h3>Addons</h3>
+          <p>Addons can be loaded and unloaded on a particular terminal to extend its functionality.</p>
+          <div id="addons-container"></div>
+          <h3>Addons Control</h3>
+          <h4>SearchAddon</h4>
+          <p>
+            <label>Find next <input id="find-next"/></label>
+            <label>Find previous <input id="find-previous"/></label>
+            <label>Use regex<input type="checkbox" id="regex"/></label>
+            <label>Case sensitive<input type="checkbox" id="case-sensitive"/></label>
+            <label>Whole word<input type="checkbox" id="whole-word"/></label>
+          </p>
+          <h4>SerializeAddon</h4>
+          <p>
+            <button id="serialize">Serialize the content of terminal</button>
+            <label><input type="checkbox" id="write-to-terminal">Write back to terminal</label>
+            <div><pre id="serialize-output"></pre></div>
+          </p>
+        </div>
+        <div id="style" class="tabContent">
+          <h3>Style</h3>
+          <div style="display: inline-block; margin-right: 16px;">
+            <label for="padding">Padding</label>
+            <input type="number" id="padding" />
+          </div>
+        </div>
       </div>
     </div>
-    <hr/>
-    <button id="dispose" title="This is used to testing memory leaks">Dispose terminal</button>
-    <button id="custom-glyph" title="Write custom box drawing and block element characters to the terminal">Test custom glyphs</button>
-    <script src="dist/client-bundle.js" defer ></script>
-  </body>
+      <hr/>
+      <button id="dispose" title="This is used to testing memory leaks">Dispose terminal</button>
+      <button id="custom-glyph" title="Write custom box drawing and block element characters to the terminal">Test custom glyphs</button>
+      <script src="dist/client-bundle.js" defer ></script>
+      <script>
+        function openSection(event, section) {
+          const tabContent = document.getElementsByClassName("tabContent");
+          let itr;
+          for (itr = 0; itr < tabContent.length; itr+=1) {
+            tabContent[itr].style.display = "none";
+          }
+          const tabLinks = document.getElementsByClassName("tabLinks");
+          for (itr = 0; itr < tabLinks.length; itr+=1) {
+            tabLinks[itr].className = tabLinks[itr].className.replace(" active", "");
+          }
+          document.getElementById(section).style.display = "block";
+          event.currentTarget.className += " active";
+        }
+        document.getElementById("options").style.display = "block";
+      </script>
+    </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -37,19 +37,19 @@
           <div id="addons-container"></div>
           <h3>Addons Control</h3>
           <h4>SearchAddon</h4>
-          <p style= "display:flex; flex-direction:column;">
+          <div style= "display:flex; flex-direction:column;">
             <label>Find next <input id="find-next"/></label>
             <label>Find previous <input id="find-previous"/></label>
-            <label>Use regex<input type="checkbox" id="regex"/></label>
-            <label>Case sensitive<input type="checkbox" id="case-sensitive"/></label>
-            <label>Whole word<input type="checkbox" id="whole-word"/></label>
-          </p>
+            <label><input type="checkbox" id="regex"/>Use regex</label>
+            <label><input type="checkbox" id="case-sensitive"/>Case sensitive</label>
+            <label><input type="checkbox" id="whole-word"/>Whole word</label>
+          </div>
           <h4>SerializeAddon</h4>
-          <p>
+          <div>
             <button id="serialize">Serialize the content of terminal</button>
             <label><input type="checkbox" id="write-to-terminal">Write back to terminal</label>
             <div><pre id="serialize-output"></pre></div>
-          </p>
+          </div>
         </div>
         <div id="style" class="tabContent">
           <h3>Style</h3>

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,9 +21,10 @@
       </div>
       <div id="grid">
         <div class="tab">
-          <button class="tabLinks active" onclick="openSection(event, 'options')">Options</button>
-          <button class="tabLinks" onclick="openSection(event, 'addons')">Add Ons</button>
-          <button class="tabLinks" onclick="openSection(event, 'style')">Style</button>
+          <button id= "optionsbutton" class="tabLinks" onclick="openSection(event, 'options')">Options</button>
+          <button id= "addonsbutton" class="tabLinks" onclick="openSection(event, 'addons')">Add Ons</button>
+          <button id= "stylebutton" class="tabLinks" onclick="openSection(event, 'style')">Style</button>
+          <button id= "testbutton" class="tabLinks" onclick="openSection(event, 'test')">Test</button>
         </div>
         <div id="options" class="tabContent">
           <h3>Options</h3>
@@ -36,7 +37,7 @@
           <div id="addons-container"></div>
           <h3>Addons Control</h3>
           <h4>SearchAddon</h4>
-          <p>
+          <p style= "display:flex; flex-direction:column;">
             <label>Find next <input id="find-next"/></label>
             <label>Find previous <input id="find-previous"/></label>
             <label>Use regex<input type="checkbox" id="regex"/></label>
@@ -57,13 +58,32 @@
             <input type="number" id="padding" />
           </div>
         </div>
+        <div id="test" class="tabContent">
+          <h3>Test</h3>
+          <div style="display: inline-block; margin-right: 16px;">
+            <button id="dispose" title="This is used to testing memory leaks">Dispose terminal</button>
+            <button id="custom-glyph" title="Write custom box drawing and block element characters to the terminal">Test custom glyphs</button>
+          </div>
+        </div>
       </div>
     </div>
-      <hr/>
-      <button id="dispose" title="This is used to testing memory leaks">Dispose terminal</button>
-      <button id="custom-glyph" title="Write custom box drawing and block element characters to the terminal">Test custom glyphs</button>
       <script src="dist/client-bundle.js" defer ></script>
       <script>
+      var tab = localStorage.getItem("tab");
+
+        if(tab === null){
+            document.getElementById("options").style.display = "block";
+            document.getElementById("optionsbutton").classList.add("active");
+        }
+        else {
+          const tabContent = document.getElementsByClassName("tabContent");
+          let itr;
+          for (itr = 0; itr < tabContent.length; itr+=1) {
+            tabContent[itr].style.display = "none";
+          }
+          document.getElementById(""+tab+"").style.display = "block";
+          document.getElementById(""+tab+"button").classList.add("active");
+        }
         function openSection(event, section) {
           const tabContent = document.getElementsByClassName("tabContent");
           let itr;
@@ -75,9 +95,10 @@
             tabLinks[itr].className = tabLinks[itr].className.replace(" active", "");
           }
           document.getElementById(section).style.display = "block";
+          localStorage.setItem("tab", section);
           event.currentTarget.className += " active";
         }
-        document.getElementById("options").style.display = "block";
+
       </script>
     </body>
 </html>

--- a/demo/style.css
+++ b/demo/style.css
@@ -87,6 +87,6 @@ pre {
     padding: 6px 12px;
     border: 1px solid #ccc;
     border-top: none;
-    max-height: 67.7vh;
+    max-height: 100vh;
     overflow-y: auto;
 }

--- a/demo/style.css
+++ b/demo/style.css
@@ -41,3 +41,52 @@ pre {
     word-wrap: break-word;
     white-space: pre-wrap;
 }
+
+
+#container {
+    display: flex;
+    height: 75vh;
+}
+#grid {
+    flex: 1;
+    /* max-height: 80vh;
+    overflow-y: auto; */
+    width: 100%;
+}
+.tab {
+    overflow: hidden;
+    border: 1px solid #ccc;
+    background-color: #f1f1f1;
+}
+
+/* Style the buttons inside the tab */
+.tab button {
+    background-color: inherit;
+    float: left;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    padding: 14px 16px;
+    transition: 0.3s;
+    font-size: 17px;
+}
+
+/* Change background color of buttons on hover */
+.tab button:hover {
+    background-color: #ddd;
+}
+
+/* Create an active/current tablink class */
+.tab button.active {
+    background-color: #ccc;
+  }
+
+/* Style the tab content */
+.tabContent {
+    display: none;
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-top: none;
+    max-height: 67.7vh;
+    overflow-y: auto;
+}


### PR DESCRIPTION
Issue: #3425

All the terminal controls have been shifted to the side of the demo with a toggling tab bar for Options, AddOns, and Style. The screenshots of the modified UI have been attached for reference. Hope this would help to resolve issue #3425
![Capture_Options](https://user-images.githubusercontent.com/64780093/131321377-a9517f87-ae27-4c6f-9c2c-4d785a80d02c.PNG)
![Capture_Add0ns](https://user-images.githubusercontent.com/64780093/131321373-9eb5b9ab-cdb9-4e7e-af47-6c2383b6b08c.PNG)
![Capture_Style](https://user-images.githubusercontent.com/64780093/131321371-e9eb2c07-eefd-487e-92a1-8114b88ea3c8.PNG)


