### PR TITLE
fix: disable pointer-events on a11y overlay

### DIFF
--- a/css/xterm.css
+++ b/css/xterm.css
@@ -142,6 +142,10 @@
     cursor: crosshair;
 }
 
+.xterm .xterm-accessibility {
+    pointer-events: none;
+}
+
 .xterm .xterm-accessibility,
 .xterm .xterm-message {
     position: absolute;


### PR DESCRIPTION
closes #1931 

Looking for feedback here, not sure this is the best approach to fix this issue. It's something I'm willing to ship in another product, as turning on `screenReaderMode` has removed the ability to copy and paste.

From what I can tell, there shouldn't be any detrimental effect of removing pointer events in the `.xterm-accessibility` div, as the div and children aren't meant to be interacted with via pointers. 

Happy to work on this more to fit a11y needs, but I'm not aware of what problems a change like this could be creating. 