### PR TITLE
Update npmignore files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,10 +2,6 @@
 *
 !*/
 
-# Whitelist - entries to be included must be negated with "!"
-!*.js
-!*.json
-
 # Whitelist - css/
 !css/**/*.css
 
@@ -23,34 +19,9 @@
 
 !lib/**/*.css
 
-# Whitelist - src/
-!src/**/*.ts
-!src/**/*.d.ts
-
-!src/**/*.js
-!src/**/*.js.map
-
-!src/**/*.css
-
 # Whitelist - typings/
 !typings/*.d.ts
 
 # Blacklist - (normal behavior) these will override any whitelist
-*.d.ts.map
-*.test.ts
-*.test.d.ts
-*.test.js
-*.test.js.map
-lib/test/
-webpack.config.js
-
-docs/
-/.idea/
-.vscode/
-bin/
-build/
-fixtures/
-demo/
-.devcontainer/
-out/
-addons/
+headless/
+typings/xterm-headless.d.ts

--- a/addons/xterm-addon-attach/.npmignore
+++ b/addons/xterm-addon-attach/.npmignore
@@ -1,5 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/addons/xterm-addon-fit/.npmignore
+++ b/addons/xterm-addon-fit/.npmignore
@@ -1,5 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/addons/xterm-addon-ligatures/.npmignore
+++ b/addons/xterm-addon-ligatures/.npmignore
@@ -2,47 +2,13 @@
 *
 !*/
 
-# Whitelist - entries to be included must be negated with "!"
-!*.js
-!*.json
-
 # Whitelist - lib/
 !lib/**/*.d.ts
 
 !lib/**/*.js
 !lib/**/*.js.map
 
-# Whitelist - out/
-!out/**/*.d.ts
-
-!out/**/*.js
-!out/**/*.js.map
-
-# Whitelist - src/
-!src/**/*.ts
-!src/**/*.d.ts
-
-!src/**/*.js
-!src/**/*.js.map
+!lib/**/*.css
 
 # Whitelist - typings/
-!typings/**/*.d.ts
-
-# Blacklist - (normal behavior) these will override any whitelist
-*.test.ts
-*.test.d.ts
-*.test.js
-*.test.js.map
-
-docs/
-/.idea/
-.vscode/
-coverage/
-.nyc_output/
-fonts/
-
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+!typings/*.d.ts

--- a/addons/xterm-addon-search/.npmignore
+++ b/addons/xterm-addon-search/.npmignore
@@ -1,5 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/addons/xterm-addon-serialize/.npmignore
+++ b/addons/xterm-addon-serialize/.npmignore
@@ -1,5 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/addons/xterm-addon-unicode11/.npmignore
+++ b/addons/xterm-addon-unicode11/.npmignore
@@ -1,5 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/addons/xterm-addon-web-links/.npmignore
+++ b/addons/xterm-addon-web-links/.npmignore
@@ -1,5 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/addons/xterm-addon-webgl/.npmignore
+++ b/addons/xterm-addon-webgl/.npmignore
@@ -1,7 +1,14 @@
-**/*.api.js
-**/*.api.ts
-tsconfig.json
-.yarnrc
-webpack.config.js
-out-test/
-test/
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
+
+# Whitelist - lib/
+!lib/**/*.d.ts
+
+!lib/**/*.js
+!lib/**/*.js.map
+
+!lib/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts

--- a/headless/.npmignore
+++ b/headless/.npmignore
@@ -1,6 +1,14 @@
-# Include
-!typings/*.d.ts
-!lib-headless/
+# Blacklist - exclude everything except npm defaults such as LICENSE, etc
+*
+!*/
 
-# Exclude
-test/
+# Whitelist - lib-headless/
+!lib-headless/**/*.d.ts
+
+!lib-headless/**/*.js
+!lib-headless/**/*.js.map
+
+!lib-headless/**/*.css
+
+# Whitelist - typings/
+!typings/*.d.ts


### PR DESCRIPTION
This PR cleans up the npm ignore files across the repository. 
Source files have been excluded since the source mapping is available in the library folder.
Headless files have been removed from xterm since they are included in xterm-headless. 

Fixes #3137, #3138