### PR TITLE
Add Mocha Test Explorer to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
   "appPort": 3000,
   "extensions": [
     "dbaeumer.vscode-eslint",
-    "editorconfig.editorconfig"
+    "editorconfig.editorconfig",
+    "hbenl.vscode-mocha-test-adapter"
   ]
 }


### PR DESCRIPTION
Install Mocha Test Explorer extension in the devcontainer by default. 
The test explorer works since #3445 and it does also work when a devcontainer is used.  