### PR TITLE
Patch document role for terminal output accessibility: Move tabindex from xterm to accessibility tree root

### DIFF
--- a/src/browser/AccessibilityManager.ts
+++ b/src/browser/AccessibilityManager.ts
@@ -53,6 +53,7 @@ export class AccessibilityManager extends Disposable {
   ) {
     super();
     this._accessibilityTreeRoot = document.createElement('div');
+    this._accessibilityTreeRoot.setAttribute('tabindex', '0');
     this._accessibilityTreeRoot.setAttribute('role', 'document');
     this._accessibilityTreeRoot.classList.add('xterm-accessibility');
 

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -423,7 +423,6 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this.element.dir = 'ltr';   // xterm.css assumes LTR
     this.element.classList.add('terminal');
     this.element.classList.add('xterm');
-    this.element.setAttribute('tabindex', '0');
     parent.appendChild(this.element);
 
     // Performance: Use a document fragment to build the terminal


### PR DESCRIPTION
CC @Tyriar @meganrogge @isidorn 

This is a follow-up PR to patch [xtermjs/xterm.js#3483](https://github.com/xtermjs/xterm.js/pull/3483) to correctly address [microsoft/vscode#98918](https://github.com/microsoft/vscode/issues/98918).

I tested the recent PR (#3483) using JAWS and NVDA in the dev xterm.js with the screenreader mode, and found that it doesn't trigger document role correctly. This is because the focusable tabindex has not been placed in the same level as the document role. Moving down the tabindex 0 from xterm to xterm accessibility tree root resolves this issue (confirmed with JAWS and NVDA testing).