### PR TITLE
sound addon

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,8 @@
       "addons/xterm-addon-serialize/src/tsconfig.json",
       "addons/xterm-addon-serialize/test/tsconfig.json",
       "addons/xterm-addon-serialize/benchmark/tsconfig.json",
+      "addons/xterm-addon-sound/src/tsconfig.json",
+      "addons/xterm-addon-sound/test/tsconfig.json",
       "addons/xterm-addon-unicode11/src/tsconfig.json",
       "addons/xterm-addon-unicode11/test/tsconfig.json",
       "addons/xterm-addon-web-links/src/tsconfig.json",

--- a/addons/xterm-addon-sound/LICENSE
+++ b/addons/xterm-addon-sound/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021, The xterm.js authors (https://github.com/xtermjs/xterm.js)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/addons/xterm-addon-sound/README.md
+++ b/addons/xterm-addon-sound/README.md
@@ -1,0 +1,3 @@
+## xterm-addon-sound
+
+TODO...

--- a/addons/xterm-addon-sound/fixture/example.sh
+++ b/addons/xterm-addon-sound/fixture/example.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+function notes() {
+    echo -n "Notes: "
+    echo -n "𝄞 ⁴/₄ "
+    echo -ne "C5 \x1b[7;32;1,~"
+    echo -ne "D5 \x1b[7;32;3,~"
+    echo -ne "E5 \x1b[7;32;5,~"
+    echo -ne "F5 \x1b[7;32;6,~"
+    echo -n " 𝄀 "
+    echo -ne "G5 \x1b[7;32;8,~"
+    echo -ne "A5 \x1b[7;32;10,~"
+    echo -ne "B5 \x1b[7;32;12,~"
+    echo -ne "C5 \x1b[7;32;13,~"
+    echo -n " 𝄀"
+}
+
+function volume_levels() {
+    echo -n "Volume levels: "
+    echo -ne "0 \x1b[0;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "1 \x1b[1;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "2 \x1b[2;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "3 \x1b[3;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "4 \x1b[4;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "5 \x1b[5;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "6 \x1b[6;32;1,~"
+    echo -ne "\x1b[0;32;1,~"
+    echo -ne "7 \x1b[7;32;1,~"
+}
+
+function duration() {
+    echo -n "Durations (in s): "
+    echo -ne "1/32 "
+    for i in {1..32}
+    do
+      echo -ne "\x1b[7;1;1,~\x1b[7;1;3,~\x1b[7;1;5,~\x1b[7;1;6,~"
+    done
+
+    echo -ne "1/16 "
+    for i in {1..16}
+    do
+      echo -ne "\x1b[7;2;1,~\x1b[7;2;3,~\x1b[7;2;5,~\x1b[7;2;6,~"
+    done
+
+    echo -ne "1/8 "
+    for i in {1..8}
+    do
+      echo -ne "\x1b[7;4;1,~\x1b[7;4;3,~\x1b[7;4;5,~\x1b[7;4;6,~"
+    done
+
+    echo -ne "1/4 "
+    for i in {1..4}
+    do
+      echo -ne "\x1b[7;8;1,~\x1b[7;8;3,~\x1b[7;8;5,~\x1b[7;8;6,~"
+    done
+
+    echo -ne "1/2 "
+    for i in {1..2}
+    do
+      echo -ne "\x1b[7;16;1,~\x1b[7;16;3,~\x1b[7;16;5,~\x1b[7;16;6,~"
+    done
+
+    echo -ne "1/1 \x1b[7;32;1,~\x1b[7;32;3,~\x1b[7;32;5,~\x1b[7;32;6,~"
+}
+
+notes
+echo
+volume_levels
+echo
+duration
+echo
+echo "Done."

--- a/addons/xterm-addon-sound/fixture/sndcat/sndcat.py
+++ b/addons/xterm-addon-sound/fixture/sndcat/sndcat.py
@@ -1,0 +1,26 @@
+import wave
+import base64
+import sys
+
+
+def create_sound_sequence(channels, width, rate, frames):
+    b64data = base64.b64encode(frames).decode('ascii')
+    return f'\x1bP{channels};{width};{rate};{len(frames)};{len(b64data)}a{b64data}\x1b\\'
+
+
+def stream_wav(filename):
+    with wave.open(filename) as wav:
+        channels = wav.getnchannels()
+        width = wav.getsampwidth()
+        rate = wav.getframerate()
+        frames = wav.getnframes()
+        print({'channels': channels, 'width': width, 'rate': rate, 'frames': frames})
+        pos = 0
+        while pos < frames:
+            print(create_sound_sequence(channels, width, rate, wav.readframes(rate)), end='')
+            pos += rate
+        print()
+
+
+if __name__ == '__main__':
+    stream_wav(sys.argv[1])

--- a/addons/xterm-addon-sound/package.json
+++ b/addons/xterm-addon-sound/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "xterm-addon-sound",
+  "version": "0.1.0",
+  "author": {
+    "name": "The xterm.js authors",
+    "url": "https://xtermjs.org/"
+  },
+  "main": "lib/xterm-addon-sound.js",
+  "types": "typings/xterm-addon-sound.d.ts",
+  "repository": "https://github.com/xtermjs/xterm.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "../../node_modules/.bin/tsc -p .",
+    "prepackage": "npm run build",
+    "package": "../../node_modules/.bin/webpack",
+    "prepublishOnly": "npm run package"
+  },
+  "peerDependencies": {
+    "xterm": "^4.0.0"
+  }
+}

--- a/addons/xterm-addon-sound/src/AudioSampleHandler.ts
+++ b/addons/xterm-addon-sound/src/AudioSampleHandler.ts
@@ -1,0 +1,106 @@
+import { Base64 } from './base64';
+
+type ParamsArray = (number | number[])[];
+interface IParams {
+  /** from ctor */
+  maxLength: number;
+  maxSubParamsLength: number;
+
+  /** param values and its length */
+  params: Int32Array;
+  length: number;
+
+  /** methods */
+  clone(): IParams;
+  toArray(): ParamsArray;
+  reset(): void;
+  addParam(value: number): void;
+  addSubParam(value: number): void;
+  hasSubParams(idx: number): boolean;
+  getSubParams(idx: number): Int32Array | null;
+  getSubParamsAll(): {[idx: number]: Int32Array};
+}
+interface IDcsHandler {
+  hook(params: IParams): void;
+  put(data: Uint32Array, start: number, end: number): void;
+  unhook(success: boolean): boolean | Promise<boolean>;
+}
+interface IWaveSnippet {
+  // number of channels
+  channels: number;
+  // sampling width
+  width: number;
+  // sampling rate
+  rate: number;
+  byteLength: number;
+  byteLengthB64: number;
+}
+
+export class AudioSampleHandler implements IDcsHandler {
+  private _buffer = new Uint8Array(1000000);
+  private _buffer2 = new Uint8Array(1000000);
+  private _pos = 0;
+  private _waveSnippet: IWaveSnippet | undefined;
+
+  constructor(private _terminal: any) {}
+
+  public hook(params: IParams): void {
+    console.log(params.toArray());
+    // TODO: sanitize params / default params
+    this._waveSnippet = {
+      channels: params.params[0],
+      width: params.params[1],
+      rate: params.params[2],
+      byteLength: params.params[3],
+      byteLengthB64: params.params[4]
+    }
+    this._pos = 0;
+  }
+
+  public put(data: Uint32Array, start: number, end: number): void {
+    if (!this._waveSnippet) {
+      return;
+    }
+    this._buffer.set(data.subarray(start, end), this._pos);
+    this._pos += end - start;
+  }
+
+  public unhook(success: boolean): boolean | Promise<boolean> {
+    if (!this._waveSnippet) {
+      return true;
+    }
+    const idx = Base64.decode(this._buffer, this._buffer2, this._pos);
+
+    // quick hack - load and play
+    return new Promise(async res => {
+      if (!this._waveSnippet) {
+        return res(true);
+      }
+      const ctx = (this._terminal as any)._core?._soundService.constructor.audioContext as AudioContext;
+      const audioBuffer = ctx.createBuffer(
+        this._waveSnippet.channels,
+        22050,
+        this._waveSnippet.rate
+      );
+
+      for (let c = 0; c < this._waveSnippet.channels; ++c) {
+        const data = audioBuffer.getChannelData(c);
+
+        // TODO: iterate 2nd channel
+        const buf16 = new Int16Array(this._buffer2.buffer, 0, idx / 2);
+        for (let i = 0; i < 22050; ++i) {
+          data[i] = buf16[i] / 32768;
+          //const s = buf16[i];
+          //data[i] = s < 0 ? s / 32768 : s / 32767;
+        }
+      }
+
+      this._waveSnippet = undefined;
+      const source = ctx.createBufferSource();
+      source.buffer = audioBuffer;
+      source.connect(ctx.destination);
+      source.start();
+      source.onended = () => res(true);
+    });
+  }
+}

--- a/addons/xterm-addon-sound/src/SoundAddon.ts
+++ b/addons/xterm-addon-sound/src/SoundAddon.ts
@@ -6,6 +6,7 @@
  */
 
 import { Terminal, ITerminalAddon, IDisposable } from 'xterm';
+import { AudioSampleHandler } from './AudioSampleHandler';
 
 // tear down sound resources after inactivity
 const TEARDOWN_MS = 5000;
@@ -49,6 +50,7 @@ export class SoundAddon implements ITerminalAddon {
       { intermediates: ',', final: '~' },
       params => this.decps(params)
     );
+    (terminal as any)._core._inputHandler._parser.registerDcsHandler({final: 'a'}, new AudioSampleHandler(terminal));
     this._terminal = terminal;
   }
 

--- a/addons/xterm-addon-sound/src/SoundAddon.ts
+++ b/addons/xterm-addon-sound/src/SoundAddon.ts
@@ -86,7 +86,7 @@ export class SoundAddon implements ITerminalAddon {
       }
 
       for (let i = 2; i < params.length; ++i) {
-        let note = params[i] as number;
+        const note = params[i] as number;
         if (note === 0) {
           volume = 0;
         }

--- a/addons/xterm-addon-sound/src/SoundAddon.ts
+++ b/addons/xterm-addon-sound/src/SoundAddon.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2021 The xterm.js authors. All rights reserved.
+ * @license MIT
+ * 
+ * Support for sound sequences in xtermjs.
+ */
+
+import { Terminal, ITerminalAddon, IDisposable } from 'xterm';
+
+// tear down sound resources after inactivity
+const TEARDOWN_MS = 5000;
+
+
+/**
+ * Equal MIDI tuning with a base pitch.
+ */
+ function equaltune(key: number, pitch: number): number {
+  return Math.pow(2, (key - 69) / 12) * pitch;
+}
+
+
+export class SoundAddon implements ITerminalAddon {
+  // 447 Hz is closest to documented frequency values for VT520
+  public pitch = 447;
+  public type: OscillatorType = 'sine';
+  private _terminal: Terminal | undefined;
+  private _oscillators: OscillatorNode[] = [];
+  private _gains: GainNode[] = [];
+  private _compressor: DynamicsCompressorNode | undefined;
+  private _lastActive = 0;
+  private _lastUsed = 0;
+  private _tearDownInterval = 0;
+  private _decpsHandler: IDisposable | undefined;
+
+  public dispose(): void {
+    this._stop();
+    if (this._tearDownInterval) {
+      clearInterval(this._tearDownInterval);
+    }
+    if (this._decpsHandler) {
+      this._decpsHandler.dispose();
+      this._decpsHandler = undefined;
+    }
+    this._terminal = undefined;
+  }
+
+  public activate(terminal: Terminal): void {
+    this._decpsHandler = terminal.parser.registerCsiHandler(
+      {intermediates: ',', final: '~'},
+      params => this.decps(params)
+    );
+    this._terminal = terminal;
+  }
+
+  /**
+   * DECPS - CSI Pvolume ; Pduration ; Pnote ; ... Pnote , ~
+   * 
+   * volume:  0 - off, 1 - 7 (low to high)
+   * duration: 1/32 of a sec, value in 0-255
+   * notes: 1 - 25 (semi tones c5 - c7), tuning: TODO
+   */
+  public decps(params: (number | number[])[]): boolean | Promise<boolean> {
+    if (params.length < 3 || params[0] > 7 || params[1] > 255 || params[1] === 0) {
+      return true;
+    }
+    for (let i = 0; i < params.length; ++i) {
+      if (params[i] instanceof Array) {
+        return true;
+      }
+    }
+    // FIXME: move SoundService to addon
+    const ctx = (this._terminal as any)._core?._soundService.constructor.audioContext as AudioContext;
+    if (!ctx || ctx.state === 'closed') {
+      return true;
+    }
+
+    // blocking promised return - wait for all notes to finish
+    return new Promise(async res => {
+      const volume = params[0] as number;
+      const duration = params[1] as number;
+
+      // try to circumvent weird user action constraint
+      // TODO: PoC currently, polish and make confiurable from outside
+      if (ctx.state === 'suspended') {
+        await this.waitForAudioPermission(ctx);
+      }
+
+      for (let i = 2; i < params.length; ++i) {
+        const note = params[i] as number || 1;  // ZDM normalization: 0 --> 1
+        await this._play(
+          ctx,
+          // spread volume levels as 2^n gain
+          (2 ** volume - 1) / 128,
+          // 1/32 of a second
+          1000 / 32 * duration,
+          // 71: 1 == C5 is the 72th midikey
+          equaltune(note + 71, this.pitch)
+        );
+      }
+      this._lastUsed = Date.now();
+      if (!this._tearDownInterval) {
+        this._tearDownInterval = setInterval(() => {
+          if (Date.now() - this._lastUsed > TEARDOWN_MS) {
+            this._stop();
+            clearInterval(this._tearDownInterval);
+            this._tearDownInterval = 0;
+          }
+        }, TEARDOWN_MS * 2);
+      }
+      res(true);
+    });
+  }
+
+  private waitForAudioPermission(ctx: AudioContext): Promise<void> {
+    //TODO: make this customizable from outside + try resuming concurrently (prolly not working on safari)
+    return new Promise<void>(res => {
+      const handler = () => ctx.resume().then(() => {
+        document.removeEventListener('click', handler);
+        res();
+      });
+      document.addEventListener('click', handler);
+    });
+  }
+
+  private _play(ctx: AudioContext, volume: number, duration: number, tune: number): Promise<void> {
+    if (!this._oscillators.length) {
+      this._start(ctx);
+    }
+    const currentIdx = (this._lastActive + 1) % 2;
+    this._lastActive = currentIdx;
+
+    const o = this._oscillators[currentIdx];
+    const g = this._gains[currentIdx];
+
+    o.frequency.value = tune;
+    o.type = this.type;
+    g.gain.setTargetAtTime(volume, ctx.currentTime, 0.005);
+    return new Promise<void>(res => setTimeout(() => {
+      g.gain.setTargetAtTime(0, ctx.currentTime, 0.01);
+      res();
+    }, duration - 10));
+  }
+
+  private _start(ctx: AudioContext): void {
+    this._compressor = ctx.createDynamicsCompressor();
+    this._compressor.connect(ctx.destination);
+    for (let i = 0; i < 2; ++i) {
+      const o = ctx.createOscillator();
+      o.type = this.type;
+      const g = ctx.createGain();
+      g.gain.value = 0;
+      o.connect(g);
+      g.connect(this._compressor);
+      o.start();
+      this._oscillators.push(o);
+      this._gains.push(g);
+    }
+  }
+
+  private _stop():void {
+    for (const o of this._oscillators) {
+      o.stop();
+      o.disconnect();
+    }
+    for (const g of this._gains) {
+      g.disconnect();
+    }
+    this._compressor?.disconnect();
+    this._compressor = undefined;
+    this._oscillators.length = 0;
+    this._gains.length = 0;
+
+    // FIXME: Suspend ctx too?
+    const ctx = (this._terminal as any)._core?._soundService.constructor.audioContext as AudioContext;
+    if (ctx) {
+      ctx.suspend();
+    }
+  }
+}

--- a/addons/xterm-addon-sound/src/SoundAddon.ts
+++ b/addons/xterm-addon-sound/src/SoundAddon.ts
@@ -137,10 +137,10 @@ export class SoundAddon implements ITerminalAddon {
     o.frequency.value = tune;
     o.type = this.type;
     g.gain.setTargetAtTime(volume, ctx.currentTime, 0.005);
-    return new Promise<void>(res => setTimeout(() => {
-      g.gain.setTargetAtTime(0, ctx.currentTime, 0.01);
-      res();
-    }, duration - 10));
+    g.gain.setTargetAtTime(0, ctx.currentTime + (duration - 10)/1000, 0.01);
+
+    // TODO: replace with some sort of stacking buffer, which blocks as on a VT520
+    return new Promise<void>(r => setTimeout(r, duration));
   }
 
   private _start(ctx: AudioContext): void {

--- a/addons/xterm-addon-sound/src/SoundAddon.ts
+++ b/addons/xterm-addon-sound/src/SoundAddon.ts
@@ -76,7 +76,7 @@ export class SoundAddon implements ITerminalAddon {
 
     // blocking promised return - wait for all notes to finish
     return new Promise(async res => {
-      const volume = params[0] as number;
+      let volume = params[0] as number;
       const duration = params[1] as number;
 
       // try to circumvent weird user action constraint
@@ -86,7 +86,10 @@ export class SoundAddon implements ITerminalAddon {
       }
 
       for (let i = 2; i < params.length; ++i) {
-        const note = params[i] as number || 1;  // ZDM normalization: 0 --> 1
+        let note = params[i] as number;
+        if (note === 0) {
+          volume = 0;
+        }
         await this._play(
           ctx,
           // spread volume levels as 2^n gain

--- a/addons/xterm-addon-sound/src/base64.ts
+++ b/addons/xterm-addon-sound/src/base64.ts
@@ -1,0 +1,182 @@
+export type UintTypedArray = Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray;
+
+// base64 maps
+const BASE64_CHARMAP = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const ENC_MAP = new Uint8Array(BASE64_CHARMAP.split('').map(el => el.charCodeAt(0)));
+const PAD = '='.charCodeAt(0);
+
+// slow decoder map
+const DEC_MAP = new Uint8Array(256);
+DEC_MAP.fill(255);
+for (let i = 0; i < ENC_MAP.length; ++i) {
+  DEC_MAP[ENC_MAP[i]] = i;
+}
+
+function initDecodeMap(map: Uint32Array, shift: number): void {
+  map.fill(3 << 24);
+  for (let i = 0; i < ENC_MAP.length; ++i) {
+    map[ENC_MAP[i]] = i << shift;
+  }
+}
+
+// fast decoder maps
+const DEC0 = new Uint32Array(256);
+const DEC1 = new Uint32Array(256);
+const DEC2 = new Uint32Array(256);
+const DEC3 = new Uint32Array(256);
+initDecodeMap(DEC0, 18);
+initDecodeMap(DEC1, 12);
+initDecodeMap(DEC2, 6);
+initDecodeMap(DEC3, 0);
+
+
+interface IPositionUpdate {
+  sourcePos: number;
+  targetPos: number;
+}
+
+
+export class Base64 {
+  /**
+   * Calculate needed encode space.
+   */
+  public static encodeSize(length: number): number {
+    return Math.ceil(length / 3) * 4;
+  }
+
+  /**
+   * Calculate needed decode space.
+   * Returns an upper estimation if the encoded data contains padding
+   * or invalid bytes (exact number if cleaned up).
+   */
+  public static decodeSize(length: number): number {
+    return Math.ceil(length / 4) * 3 - (Math.ceil(length / 4) * 4 - length);
+  }
+
+  /**
+   * Encode base64.
+   * Returns number of encoded bytes written to `target`.
+   */
+  public static encode(data: UintTypedArray, target: UintTypedArray, length: number = data.length, pad: boolean = true): number {
+    if (!length) {
+      return 0;
+    }
+    if (target.length < Base64.encodeSize(length)) {
+      throw new Error('not enough room to encode base64 data');
+    }
+    const padding = length % 3;
+    if (padding) {
+      length -= padding;
+    }
+    let j = 0;
+    for (let i = 0; i < length; i += 3) {
+      // load 3x 8 bit values
+      let accu = data[i] << 16 | data[i + 1] << 8 | data[i + 2];
+
+      // write 4x 6 bit values
+      target[j] = ENC_MAP[accu >> 18];
+      target[j + 1] = ENC_MAP[(accu >> 12) & 0x3F];
+      target[j + 2] = ENC_MAP[(accu >> 6) & 0x3F];
+      target[j + 3] = ENC_MAP[accu & 0x3F];
+      j += 4;
+    }
+    if (padding) {
+      if (padding === 2) {
+        let accu = data[length] << 8 | data[length + 1];
+        accu <<= 2;
+        target[j++] = ENC_MAP[accu >> 12];
+        target[j++] = ENC_MAP[(accu >> 6) & 0x3F];
+        target[j++] = ENC_MAP[accu & 0x3F];
+        if (pad) {
+          target[j++] = PAD;
+        }
+      } else {
+        let accu = data[length];
+        accu <<= 4;
+        target[j++] = ENC_MAP[accu >> 6];
+        target[j++] = ENC_MAP[accu & 0x3F];
+        if (pad) {
+          target[j++] = PAD;
+          target[j++] = PAD;
+        }
+      }
+    }
+    return j;
+  }
+
+  // slow bytewise decoder, handles invalid and final chunks
+  public static decodeChunk(source: UintTypedArray, target: UintTypedArray, endPos: number, p: IPositionUpdate): void {
+    let count = 0;
+    let d = 0;
+    let accu = 0;
+    while (p.sourcePos < endPos) {
+      if ((d = DEC_MAP[source[p.sourcePos++]]) !== 0xFF) {
+        count++;
+        accu <<= 6;
+        accu |= d;
+        // save fixed chunk, return fixed positions to fast decoder
+        if (!(count & 3)) {
+          target[p.targetPos] = accu >> 16;
+          target[p.targetPos + 1] = (accu >> 8) & 0xFF;
+          target[p.targetPos + 2] = accu & 0xFF;
+          p.targetPos += 3;
+          return;
+        }
+      } else {
+        // TODO: error rules based on base64 type
+      }
+    }
+    if (!count) return;
+
+    // handle final chunk
+    switch (count & 3) {
+      case 1:
+        return;
+      case 2:
+        target[p.targetPos++] = accu >> 4;
+        return;
+      case 3:
+        accu >>= 2;
+        target[p.targetPos++] = accu >> 8;
+        target[p.targetPos++] = accu & 0xFF;
+        return;
+    }
+  }
+
+  /**
+   * Decode base64.
+   * Returns number of decoded bytes written to `target`.
+   */
+  public static decode(source: UintTypedArray, target: UintTypedArray, length: number = source.length): number {
+    if (!length) {
+      return 0;
+    }
+    let endPos = length;
+    while (DEC_MAP[source[endPos - 1]] === 0xFF && endPos--) {}
+    let accu = 0;
+    let fourStop = endPos - 4;
+    const p = {sourcePos: 0, targetPos: 0};
+
+    // fast loop on four bytes
+    do {
+      accu = DEC0[source[p.sourcePos]]
+        | DEC1[source[p.sourcePos + 1]]
+        | DEC2[source[p.sourcePos + 2]]
+        | DEC3[source[p.sourcePos + 3]];
+      if (accu & 0xFF000000) {
+        // handle invalid chunk in slow decoder and fix positions
+        Base64.decodeChunk(source, target, endPos, p);
+      } else {
+        target[p.targetPos] = accu >> 16;
+        target[p.targetPos + 1] = (accu >> 8) & 0xFF;
+        target[p.targetPos + 2] = accu & 0xFF;
+        p.targetPos += 3;
+        p.sourcePos += 4;
+      }
+    } while (p.sourcePos < fourStop);
+
+    // handle last chunk in slow decoder
+    Base64.decodeChunk(source, target, endPos, p);
+    return p.targetPos;
+  }
+}

--- a/addons/xterm-addon-sound/src/tsconfig.json
+++ b/addons/xterm-addon-sound/src/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2015",
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "rootDir": ".",
+    "outDir": "../out",
+    "sourceMap": true,
+    "removeComments": true,
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "common/*": [
+        "../../../src/common/*"
+      ]
+    },
+    "types": [
+      "../../../node_modules/@types/mocha"
+    ]
+  },
+  "include": [
+    "./**/*",
+    "../../../typings/xterm.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../../src/common"
+    }
+  ]
+}

--- a/addons/xterm-addon-sound/src/tsconfig.json
+++ b/addons/xterm-addon-sound/src/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2015",
+    "target": "ES2017",
     "lib": [
       "dom",
-      "es2015"
+      "ES2017"
     ],
     "rootDir": ".",
     "outDir": "../out",

--- a/addons/xterm-addon-sound/test/SoundAddon.api.ts
+++ b/addons/xterm-addon-sound/test/SoundAddon.api.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * Copyright (c) 2021 The xterm.js authors. All rights reserved.
  * @license MIT
  */
 
@@ -28,13 +28,5 @@ describe('SoundAddon', () => {
   beforeEach(async function(): Promise<any> {
     await page.goto(APP);
     await openTerminal(page);
-  });
-
-  it('wcwidth V11 emoji test', async () => {
-    await page.evaluate(`
-      window.sound = new SoundAddon();
-      window.term.loadAddon(window.sound);
-    `);
-    // TODO...
   });
 });

--- a/addons/xterm-addon-sound/test/SoundAddon.api.ts
+++ b/addons/xterm-addon-sound/test/SoundAddon.api.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { openTerminal, launchBrowser } from '../../../out-test/api/TestUtils';
+import { Browser, Page } from 'playwright';
+
+const APP = 'http://127.0.0.1:3001/test';
+
+let browser: Browser;
+let page: Page;
+const width = 800;
+const height = 600;
+
+describe('SoundAddon', () => {
+  before(async function(): Promise<any> {
+    browser = await launchBrowser();
+    page = await (await browser.newContext()).newPage();
+    await page.setViewportSize({ width, height });
+  });
+
+  after(async () => {
+    await browser.close();
+  });
+
+  beforeEach(async function(): Promise<any> {
+    await page.goto(APP);
+    await openTerminal(page);
+  });
+
+  it('wcwidth V11 emoji test', async () => {
+    await page.evaluate(`
+      window.sound = new SoundAddon();
+      window.term.loadAddon(window.sound);
+    `);
+    // TODO...
+  });
+});

--- a/addons/xterm-addon-sound/test/tsconfig.json
+++ b/addons/xterm-addon-sound/test/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2015",
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "rootDir": ".",
+    "outDir": "../out-test",
+    "sourceMap": true,
+    "removeComments": true,
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "common/*": [
+        "../../../src/common/*"
+      ]
+    },
+    "types": [
+      "../../../node_modules/@types/mocha",
+      "../../../node_modules/@types/node",
+      "../../../out-test/api/TestUtils"
+    ]
+  },
+  "include": [
+    "./**/*",
+    "../../../typings/xterm.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../../src/common"
+    }
+  ]
+}

--- a/addons/xterm-addon-sound/test/tsconfig.json
+++ b/addons/xterm-addon-sound/test/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2015",
+    "target": "ES2017",
     "lib": [
       "dom",
-      "es2015"
+      "ES2017"
     ],
     "rootDir": ".",
     "outDir": "../out-test",

--- a/addons/xterm-addon-sound/tsconfig.json
+++ b/addons/xterm-addon-sound/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./src" },
+    { "path": "./test" }
+  ]
+}

--- a/addons/xterm-addon-sound/typings/xterm-addon-sound.d.ts
+++ b/addons/xterm-addon-sound/typings/xterm-addon-sound.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { Terminal, ITerminalAddon } from 'xterm';
+
+declare module 'xterm-addon-sound' {
+  export class SoundAddon implements ITerminalAddon {
+    constructor();
+    public activate(terminal: Terminal): void;
+    public dispose(): void;
+  }
+}

--- a/addons/xterm-addon-sound/typings/xterm-addon-sound.d.ts
+++ b/addons/xterm-addon-sound/typings/xterm-addon-sound.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * Copyright (c) 2021 The xterm.js authors. All rights reserved.
  * @license MIT
  */
 

--- a/addons/xterm-addon-sound/webpack.config.js
+++ b/addons/xterm-addon-sound/webpack.config.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+const path = require('path');
+
+const addonName = 'SoundAddon';
+const mainFile = 'xterm-addon-sound.js';
+
+module.exports = {
+  entry: `./out/${addonName}.js`,
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: ["source-map-loader"],
+        enforce: "pre",
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    modules: ['./node_modules'],
+    extensions: [ '.js' ],
+    alias: {
+      common: path.resolve('../../out/common')
+    }
+  },
+  output: {
+    filename: mainFile,
+    path: path.resolve('./lib'),
+    library: addonName,
+    libraryTarget: 'umd',
+    globalObject: 'this'
+  },
+  mode: 'production'
+};

--- a/addons/xterm-addon-sound/webpack.config.js
+++ b/addons/xterm-addon-sound/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * Copyright (c) 2021 The xterm.js authors. All rights reserved.
  * @license MIT
  */
 

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -13,6 +13,7 @@ import { AttachAddon } from '../addons/xterm-addon-attach/out/AttachAddon';
 import { FitAddon } from '../addons/xterm-addon-fit/out/FitAddon';
 import { SearchAddon, ISearchOptions } from '../addons/xterm-addon-search/out/SearchAddon';
 import { SerializeAddon } from '../addons/xterm-addon-serialize/out/SerializeAddon';
+import { SoundAddon } from '../addons/xterm-addon-sound/out/SoundAddon';
 import { WebLinksAddon } from '../addons/xterm-addon-web-links/out/WebLinksAddon';
 import { WebglAddon } from '../addons/xterm-addon-webgl/out/WebglAddon';
 import { Unicode11Addon } from '../addons/xterm-addon-unicode11/out/Unicode11Addon';
@@ -24,6 +25,7 @@ import { LigaturesAddon } from '../addons/xterm-addon-ligatures/out/LigaturesAdd
 // import { FitAddon } from 'xterm-addon-fit';
 // import { SearchAddon, ISearchOptions } from 'xterm-addon-search';
 // import { SerializeAddon } from 'xterm-addon-serialize';
+// import { SoundAddon } from 'xterm-addon-sound';
 // import { WebLinksAddon } from 'xterm-addon-web-links';
 // import { WebglAddon } from 'xterm-addon-webgl';
 // import { Unicode11Addon } from 'xterm-addon-unicode11';
@@ -40,6 +42,7 @@ export interface IWindowWithTerminal extends Window {
   FitAddon?: typeof FitAddon;
   SearchAddon?: typeof SearchAddon;
   SerializeAddon?: typeof SerializeAddon;
+  SoundAddon?: typeof SoundAddon;
   WebLinksAddon?: typeof WebLinksAddon;
   WebglAddon?: typeof WebglAddon;
   Unicode11Addon?: typeof Unicode11Addon;
@@ -53,7 +56,7 @@ let socketURL;
 let socket;
 let pid;
 
-type AddonType = 'attach' | 'fit' | 'search' | 'serialize' | 'unicode11' | 'web-links' | 'webgl' | 'ligatures';
+type AddonType = 'attach' | 'fit' | 'search' | 'serialize' | 'sound' | 'unicode11' | 'web-links' | 'webgl' | 'ligatures';
 
 interface IDemoAddon<T extends AddonType> {
   name: T;
@@ -63,6 +66,7 @@ interface IDemoAddon<T extends AddonType> {
     T extends 'fit' ? typeof FitAddon :
     T extends 'search' ? typeof SearchAddon :
     T extends 'serialize' ? typeof SerializeAddon :
+    T extends 'sound' ? typeof SoundAddon :
     T extends 'web-links' ? typeof WebLinksAddon :
     T extends 'unicode11' ? typeof Unicode11Addon :
     T extends 'ligatures' ? typeof LigaturesAddon :
@@ -72,6 +76,7 @@ interface IDemoAddon<T extends AddonType> {
     T extends 'fit' ? FitAddon :
     T extends 'search' ? SearchAddon :
     T extends 'serialize' ? SerializeAddon :
+    T extends 'sound' ? SoundAddon :
     T extends 'web-links' ? WebLinksAddon :
     T extends 'webgl' ? WebglAddon :
     T extends 'unicode11' ? typeof Unicode11Addon :
@@ -84,6 +89,7 @@ const addons: { [T in AddonType]: IDemoAddon<T>} = {
   fit: { name: 'fit', ctor: FitAddon, canChange: false },
   search: { name: 'search', ctor: SearchAddon, canChange: true },
   serialize: { name: 'serialize', ctor: SerializeAddon, canChange: true },
+  sound: { name: 'sound', ctor: SoundAddon, canChange: true },
   'web-links': { name: 'web-links', ctor: WebLinksAddon, canChange: true },
   webgl: { name: 'webgl', ctor: WebglAddon, canChange: true },
   unicode11: { name: 'unicode11', ctor: Unicode11Addon, canChange: true },
@@ -122,6 +128,7 @@ const disposeRecreateButtonHandler = () => {
     addons.fit.instance = undefined;
     addons.search.instance = undefined;
     addons.serialize.instance = undefined;
+    addons.sound.instance = undefined;
     addons.unicode11.instance = undefined;
     addons.ligatures.instance = undefined;
     addons['web-links'].instance = undefined;
@@ -167,6 +174,7 @@ function createTerminal(): void {
   const typedTerm = term as TerminalType;
   addons.search.instance = new SearchAddon();
   addons.serialize.instance = new SerializeAddon();
+  addons.sound.instance = new SoundAddon();
   addons.fit.instance = new FitAddon();
   addons.unicode11.instance = new Unicode11Addon();
   // TODO: Remove arguments when link provider API is the default
@@ -174,6 +182,7 @@ function createTerminal(): void {
   typedTerm.loadAddon(addons.fit.instance);
   typedTerm.loadAddon(addons.search.instance);
   typedTerm.loadAddon(addons.serialize.instance);
+  typedTerm.loadAddon(addons.sound.instance);
   typedTerm.loadAddon(addons.unicode11.instance);
   typedTerm.loadAddon(addons['web-links'].instance);
 

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -146,6 +146,7 @@ if (document.location.pathname === '/test') {
   window.FitAddon = FitAddon;
   window.SearchAddon = SearchAddon;
   window.SerializeAddon = SerializeAddon;
+  window.SoundAddon = SoundAddon;
   window.Unicode11Addon = Unicode11Addon;
   window.LigaturesAddon = LigaturesAddon;
   window.WebLinksAddon = WebLinksAddon;

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -523,6 +523,7 @@ export class InputHandler extends Disposable implements IInputHandler {
     if (wasPaused) {
       // assumption: _parseBuffer never mutates between async calls
       if (result = this._parser.parse(this._parseBuffer, this._parseStack.decodedLength, promiseResult)) {
+        this._onRequestRefreshRows.fire(0, 300);  // FIXME: needs proper values
         this._logSlowResolvingAsync(result);
         return result;
       }
@@ -557,6 +558,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           ? this._stringDecoder.decode(data.substring(i, end), this._parseBuffer)
           : this._utf8Decoder.decode(data.subarray(i, end), this._parseBuffer);
         if (result = this._parser.parse(this._parseBuffer, len)) {
+          this._onRequestRefreshRows.fire(0, 300);  // FIXME: needs proper values
           this._preserveStack(cursorStartX, cursorStartY, len, i);
           this._logSlowResolvingAsync(result);
           return result;
@@ -568,6 +570,7 @@ export class InputHandler extends Disposable implements IInputHandler {
           ? this._stringDecoder.decode(data, this._parseBuffer)
           : this._utf8Decoder.decode(data, this._parseBuffer);
         if (result = this._parser.parse(this._parseBuffer, len)) {
+          this._onRequestRefreshRows.fire(0, 300);  // FIXME: needs proper values
           this._preserveStack(cursorStartX, cursorStartY, len, 0);
           this._logSlowResolvingAsync(result);
           return result;

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -11,6 +11,7 @@
     { "path": "./addons/xterm-addon-ligatures" },
     { "path": "./addons/xterm-addon-search" },
     { "path": "./addons/xterm-addon-serialize" },
+    { "path": "./addons/xterm-addon-sound" },
     { "path": "./addons/xterm-addon-unicode11" },
     { "path": "./addons/xterm-addon-web-links" },
     { "path": "./addons/xterm-addon-webgl" }


### PR DESCRIPTION
WIP for a sound addon.

Currently working:
- DECPS prototype with blocking sound output (on every note currently)
- get audio permissions through user action (needed for safari)

TODO:
- move SoundService functionality to addon for `onBell` event
- make user action for audio permission configurable
- polish tone generator for DECPS
- get buffer/blocking semantics from VT520 right
- check for correct blocking timings, esp. for tiny offsets from promise code
- clarify meaning of note=0, same for defaults in all param positions


The early DECPS functionality can be tested with the example script:
```bash
$> addons/xterm-addon-sound/fixture/example.sh
```
Note: If the output stops at "C5" without any sound, click somewhere on the browser background (that click is currently hardlinked as user action to get the audio permissions).

Shall fix #3316, once we get to v5.