### PR TITLE
Halloween Lint using Putout (part 5)

### DIFF
--- a/bin/extract_vtfeatures.js
+++ b/bin/extract_vtfeatures.js
@@ -11,13 +11,13 @@ const Mustache = require('mustache');
  * regexp to fetch all comments
  * Fetches all multiline comments and single lines containing '// @vt:'.
  */
-const REX_COMMENTS = /^\s*?[/][*][*]([\s\S]*?)[*][/]|^\s*?\/\/ ([@]vt[:].*?)$/mug;
+const REX_COMMENTS = /^\s*?\/\*\*([\S\s]*?)\*\/|^\s*?\/\/ (@vt:.*?)$/mug;
 
 /**
  * regexp to parse the @vt line
  * expected data - "@vt: <status> <kind> <mnemonic> "<name>" "<sequence>" "<short description>"
  */
-const REX_VT_LINE = /^[@]vt\:\s*(\w+|#\w+|#\w+\[.*?\])\s*(\w+)\s*(\w+)\s*"(.*?)"\s*"(.*?)"\s*"(.*?)".*$/;
+const REX_VT_LINE = /^@vt:\s*(\w+|#\w+|#\w+\[.*?\])\s*(\w+)\s*(\w+)\s*"(.*?)"\s*"(.*?)"\s*"(.*?)".*$/;
 
 // known vt command types
 const TYPES = [
@@ -362,7 +362,7 @@ function* parseMultiLineGen(filename, s) {
   if (!s.includes('@vt:')) {
     return;
   }
-  const lines = s.split('\n').map(el => el.trim().replace(/[*]/, '').replace(/\s/, ''));
+  const lines = s.split('\n').map(el => el.trim().replace(/\*/, '').replace(/\s/, ''));
   let grabLine = false;
   let longDescription = [];
   let feature = undefined;

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -92,7 +92,7 @@ function checkAndPublishPackage(packageDir) {
 }
 
 function getNextBetaVersion(packageJson) {
-  if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.exec(packageJson.version)) {
+  if (!/^\d+\.\d+\.\d+$/.exec(packageJson.version)) {
     console.error('The package.json version must be of the form x.y.z');
     process.exit(1);
   }
@@ -104,11 +104,11 @@ function getNextBetaVersion(packageJson) {
     return `${nextStableVersion}-${tag}.1`;
   }
   const latestPublishedVersion = publishedVersions.sort((a, b) => {
-    const aVersion = parseInt(a.substr(a.search(/[0-9]+$/)));
-    const bVersion = parseInt(b.substr(b.search(/[0-9]+$/)));
+    const aVersion = parseInt(a.substr(a.search(/\d+$/)));
+    const bVersion = parseInt(b.substr(b.search(/\d+$/)));
     return aVersion > bVersion ? -1 : 1;
   })[0];
-  const latestTagVersion = parseInt(latestPublishedVersion.substr(latestPublishedVersion.search(/[0-9]+$/)), 10);
+  const latestTagVersion = parseInt(latestPublishedVersion.substr(latestPublishedVersion.search(/\d+$/)), 10);
   return `${nextStableVersion}-${tag}.${latestTagVersion + 1}`;
 }
 

--- a/bin/test_api.js
+++ b/bin/test_api.js
@@ -21,7 +21,7 @@ let flagArgs = [];
 
 if (process.argv.length > 2) {
   const args = process.argv.slice(2);
-  flagArgs = args.filter(e => e.startsWith('--')).map(arg => arg.split('=')).reduce((arr, val) => arr.concat([...val], []));
+  flagArgs = args.filter(e => e.startsWith('--')).map(arg => arg.split('=')).reduce((arr, val) => arr.concat(val.slice(), []));
   console.info(flagArgs);
   // ability to inject particular test files via
   // yarn test [testFileA testFileB ...]
@@ -44,7 +44,7 @@ const server = cp.spawn('node', ['demo/start'], {
 
 server.stdout.on('data', (data) => {
   // await for the server to fully start
-  if (data.indexOf("successfully") !== -1) {
+  if (data.includes("successfully")) {
     const run = cp.spawnSync(
       npmBinScript('mocha'),
       [...testFiles, ...flagArgs], {

--- a/src/browser/input/MoveToCell.ts
+++ b/src/browser/input/MoveToCell.ts
@@ -121,7 +121,7 @@ function wrappedRowsCount(startY: number, targetY: number, bufferService: IBuffe
   for (let i = 0; i < Math.abs(startRow - endRow); i++) {
     const direction = verticalDirection(startY, targetY) === Direction.UP ? -1 : 1;
     const line = bufferService.buffer.lines.get(startRow + (direction * i));
-    if (line && line.isWrapped) {
+    if (line?.isWrapped) {
       wrappedRows++;
     }
   }
@@ -136,12 +136,12 @@ function wrappedRowsCount(startY: number, targetY: number, bufferService: IBuffe
 function wrappedRowsForRow(bufferService: IBufferService, currentRow: number): number {
   let rowCount = 0;
   let line = bufferService.buffer.lines.get(currentRow);
-  let lineWraps = line && line.isWrapped;
+  let lineWraps = line?.isWrapped;
 
   while (lineWraps && currentRow >= 0 && currentRow < bufferService.rows) {
     rowCount++;
     line = bufferService.buffer.lines.get(--currentRow);
-    lineWraps = line && line.isWrapped;
+    lineWraps = line?.isWrapped;
   }
 
   return rowCount;

--- a/src/browser/renderer/BaseRenderLayer.ts
+++ b/src/browser/renderer/BaseRenderLayer.ts
@@ -325,12 +325,7 @@ export abstract class BaseRenderLayer implements IRenderLayer {
     this._currentGlyphIdentifier.bold = !!cell.isBold();
     this._currentGlyphIdentifier.dim = !!cell.isDim();
     this._currentGlyphIdentifier.italic = !!cell.isItalic();
-    const atlasDidDraw = this._charAtlas && this._charAtlas.draw(
-      this._ctx,
-      this._currentGlyphIdentifier,
-      x * this._scaledCellWidth + this._scaledCharLeft,
-      y * this._scaledCellHeight + this._scaledCharTop
-    );
+    const atlasDidDraw = this._charAtlas?.draw(this._ctx, this._currentGlyphIdentifier, x * this._scaledCellWidth + this._scaledCharLeft, y * this._scaledCellHeight + this._scaledCharTop);
 
     if (!atlasDidDraw) {
       this._drawUncachedChars(cell, x, y);

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -220,7 +220,7 @@ export class SelectionService extends Disposable implements ISelectionService {
       for (let i = start[1] + 1; i <= end[1] - 1; i++) {
         const bufferLine = buffer.lines.get(i);
         const lineText = buffer.translateBufferLineToString(i, true);
-        if (bufferLine && bufferLine.isWrapped) {
+        if (bufferLine?.isWrapped) {
           result[result.length - 1] += lineText;
         } else {
           result.push(lineText);
@@ -924,7 +924,7 @@ export class SelectionService extends Disposable implements ISelectionService {
     if (followWrappedLinesBelow) {
       if (start + length === this._bufferService.cols && bufferLine.getCodePoint(this._bufferService.cols - 1) !== 32 /* ' ' */) {
         const nextBufferLine = buffer.lines.get(coords[1] + 1);
-        if (nextBufferLine && nextBufferLine.isWrapped && nextBufferLine.getCodePoint(0) !== 32 /* ' ' */) {
+        if (nextBufferLine?.isWrapped && nextBufferLine.getCodePoint(0) !== 32 /* ' ' */) {
           const nextLineWordPosition = this._getWordAt([0, coords[1] + 1], false, false, true);
           if (nextLineWordPosition) {
             length += nextLineWordPosition.length;

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -349,7 +349,7 @@ export function evaluateKeyboardEvent(
       } else if ((!isMac || macOptionIsMeta) && ev.altKey && !ev.metaKey) {
         // On macOS this is a third level shift when !macOptionIsMeta. Use <Esc> instead.
         const keyMapping = KEYCODE_KEY_MAPPINGS[ev.keyCode];
-        const key = keyMapping && keyMapping[!ev.shiftKey ? 0 : 1];
+        const key = keyMapping?.[!ev.shiftKey ? 0 : 1];
         if (key) {
           result.key = C0.ESC + key;
         } else if (ev.keyCode >= 65 && ev.keyCode <= 90) {

--- a/src/common/input/UnicodeV6.test.ts
+++ b/src/common/input/UnicodeV6.test.ts
@@ -162,7 +162,7 @@ it('wcwidth should match all values from the old implementation', function(): vo
     //   we are only interested in 2 LSBs, cut off higher bits
     //     ==> n = n & 3      e.g.       000000000000000000000000000000XX
     return (num: number): number => {
-      num = num | 0;  // get asm.js like optimization under V8
+      num |= 0;  // get asm.js like optimization under V8
       if (num < 32) {
         return control | 0;
       }

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -9,6 +9,7 @@ const MAX_VALUE = 0x7FFFFFFF;
 // max allowed subparams for a single sequence (hardcoded limitation)
 const MAX_SUBPARAMS = 256;
 
+
 /**
  * Params storage class.
  * This type is used by the parser to accumulate sequence parameters and sub parameters
@@ -52,9 +53,9 @@ export class Params implements IParams {
       return params;
     }
     // skip leading sub params
-    for (let i = (values[0] instanceof Array) ? 1 : 0; i < values.length; ++i) {
+    for (let i = (Array.isArray(values[0])) ? 1 : 0; i < values.length; ++i) {
       const value = values[i];
-      if (value instanceof Array) {
+      if (Array.isArray(value)) {
         for (let k = 0; k < value.length; ++k) {
           params.addSubParam(value[k]);
         }

--- a/src/common/parser/Params.ts
+++ b/src/common/parser/Params.ts
@@ -9,7 +9,6 @@ const MAX_VALUE = 0x7FFFFFFF;
 // max allowed subparams for a single sequence (hardcoded limitation)
 const MAX_SUBPARAMS = 256;
 
-
 /**
  * Params storage class.
  * This type is used by the parser to accumulate sequence parameters and sub parameters

--- a/test/api/TestUtils.ts
+++ b/test/api/TestUtils.ts
@@ -71,11 +71,11 @@ export function getBrowserType(): playwright.BrowserType<playwright.WebKitBrowse
 export function launchBrowser() {
   const browserType = getBrowserType();
   const options: Record<string, unknown> = {
-    headless: process.argv.includes('--headless'),
-  }
+    headless: process.argv.includes('--headless')
+  };
 
   const index = process.argv.indexOf('--executablePath');
-  if(index > 0 && process.argv.length > index + 1 && typeof process.argv[index + 1] === 'string') {
+  if (index > 0 && process.argv.length > index + 1 && typeof process.argv[index + 1] === 'string') {
     options.executablePath = process.argv[index + 1];
   }
 


### PR DESCRIPTION
After successfully merged linting sessions [part 1](https://github.com/xtermjs/xterm.js/pull/2953), [part 2](https://github.com/xtermjs/xterm.js/pull/3133) and [part 3](https://github.com/xtermjs/xterm.js/pull/3269), [part 4](https://github.com/xtermjs/xterm.js/pull/3341) the time is come for part 5 :).

As usual, any rule can be disabled.

Command used:

```sh
putout . --fix
```

Applied rules:
- [regexp/optimize](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-regexp);
- [apply-optional-chaining](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-apply-optional-chaining);
- [convert-index-of-to-includes](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-convert-index-of-to-includes);
- [convert-array-copy-to-slice](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-convert-array-copy-to-slice);
- [remove-useless-escape](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-remove-useless-escape);
- [remove-unused-expressions](https://github.com/coderaiser/putout/tree/v21.1.0/packages/remove-unused-expressions);
- [remove-useless-operand](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-remove-useless-operand);
- [apply-is-array](https://github.com/coderaiser/putout/tree/v21.1.0/packages/plugin-apply-is-array);

Current config for [putout v21](https://github.com/coderaiser/putout):

```json
{
    "rules": {
        "apply-is-array": ["on", {
            "inline": true
        },
        "remove-useless-new": "off",
        "remove-useless-return": "off",
        "remove-useless-types-from-constants": "off",
        "remove-useless-type-convertion/with-double-negations": "off",
        "convert-typeof-to-is-type": "off",
        "apply-shorthand-properties": "off",
        "apply-destructuring": "off",
        "apply-numeric-separators": "off",
        "convert-assignment-to-comparison": "off",
        "convert-apply-to-spread": "off",
        "convert-math-pow": "off",
        "convert-for-to-for-of": "off",
        "convert-template-to-string": "off",
        "strict-mode": "off",
        "remove-useless-spread/object": "off",
        "remove-useless-array-constructor": "off",
        "remove-boolean-from-assertions": "off",
        "remove-iife": "off",
        "remove-console": "off",
        "remove-unused-variables": "off",
        "remove-useless-variables": "off",
        "merge-if-statements": "off",
        "promises/add-missing-await": "off",
        "promises/remove-useless-async": "off",
        "simplify-ternary": "off"
    },
    "match": {
        "*.benchmark.ts": {
            "remove-unused-expressions": "off"
        }
    },
    "plugins": [
        "apply-shorthand-properties"
    ],
    "ignore": [
        "*.md",
        "*.json",
        "*ignore",
        "*.yml",
        ".npmrc",
        "*.css",
        "out",
        "out-test",
        "demo"
    ]
}
```

Happy Halloween 🎃!