### PR TITLE
wide characters overflow the cache canvas on WebGL render

### DIFF
--- a/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
+++ b/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
@@ -14,7 +14,6 @@ import { AttributeData } from 'common/buffer/AttributeData';
 import { channels, rgba } from 'browser/Color';
 import { tryDrawCustomChar } from 'browser/renderer/CustomGlyphs';
 
-// FIXME: rendering many characters can overflow the texture rarely
 // For debugging purposes, it can be useful to set this to a really tiny value,
 // to verify that LRU eviction works.
 const TEXTURE_WIDTH = 1024;

--- a/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
+++ b/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
@@ -14,8 +14,9 @@ import { AttributeData } from 'common/buffer/AttributeData';
 import { channels, rgba } from 'browser/Color';
 import { tryDrawCustomChar } from 'browser/renderer/CustomGlyphs';
 
-// In practice we're probably never going to exhaust a texture this large. For debugging purposes,
-// however, it can be useful to set this to a really tiny value, to verify that LRU eviction works.
+// FIXME: rendering many characters can overflow the texture rarely
+// For debugging purposes, it can be useful to set this to a really tiny value,
+// to verify that LRU eviction works.
 const TEXTURE_WIDTH = 1024;
 const TEXTURE_HEIGHT = 1024;
 
@@ -463,7 +464,7 @@ export class WebglCharAtlas implements IDisposable {
     const clippedImageData = this._clipImageData(imageData, this._workBoundingBox);
 
     // Check if there is enough room in the current row and go to next if needed
-    if (this._currentRowX + this._config.scaledCharWidth > TEXTURE_WIDTH) {
+    if (this._currentRowX + rasterizedGlyph.size.x > TEXTURE_WIDTH) {
       this._currentRowX = 0;
       this._currentRowY += this._currentRowHeight;
       this._currentRowHeight = 0;


### PR DESCRIPTION
This change resolves microsoft/vscode#137047 in most cases.

When WebglCharAtlas draws a wide glyph (e.g. CJK chars) to their cacheCanvas, the glyph overflows the canvas if remaining of the current row width is bigger than the configured char width but less than the actual glyph width.

Base branch
--

![](https://user-images.githubusercontent.com/20679825/141491372-8fba45ab-bbe5-42ce-9edc-263414e4daee.png)


Head branch
--

![](https://user-images.githubusercontent.com/20679825/141490990-96244683-cf96-4c7c-8d6b-2ec7913997ad.png)


