### PR TITLE
ES6 support

### DIFF
--- a/addons/xterm-addon-fit/package.json
+++ b/addons/xterm-addon-fit/package.json
@@ -6,6 +6,10 @@
     "url": "https://xtermjs.org/"
   },
   "main": "lib/xterm-addon-fit.js",
+  "exports": {
+    "import": "./lib/es6/xterm-addon-fit.js",
+    "require": "./lib/xterm-addon-fit.js"
+  },
   "types": "typings/xterm-addon-fit.d.ts",
   "repository": "https://github.com/xtermjs/xterm.js",
   "license": "MIT",
@@ -13,6 +17,7 @@
     "build": "../../node_modules/.bin/tsc -p .",
     "prepackage": "npm run build",
     "package": "../../node_modules/.bin/webpack",
+    "package-module": "../../node_modules/.bin/webpack --config ./webpack.config.module.js",
     "prepublishOnly": "npm run package"
   },
   "peerDependencies": {

--- a/addons/xterm-addon-fit/webpack.config.module.js
+++ b/addons/xterm-addon-fit/webpack.config.module.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+const path = require('path');
+
+const addonName = 'FitAddon';
+const mainFile = 'xterm-addon-fit.js';
+
+module.exports = {
+  entry: `./out/${addonName}.js`,
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: ["source-map-loader"],
+        enforce: "pre",
+        exclude: /node_modules/
+      }
+    ]
+  },
+  experiments: {
+    outputModule: true
+  },
+  output: {
+    filename: mainFile,
+    path: path.resolve('./lib/es6'),
+    libraryTarget: 'module'
+  },
+  mode: 'production'
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "xterm",
   "description": "Full xterm terminal, in your browser",
   "version": "4.15.0",
-  "main": "lib/xterm.js",
+  "main": "./lib/xterm.js",
+  "exports": {
+    "import": "./lib/es6/xterm.js",
+    "require": "./lib/xterm.js"
+  },
   "style": "css/xterm.css",
   "types": "typings/xterm.d.ts",
   "repository": "https://github.com/xtermjs/xterm.js",
@@ -11,6 +15,7 @@
     "prepackage": "npm run build",
     "package": "webpack",
     "package-headless": "webpack --config ./webpack.config.headless.js",
+    "package-module": "webpack --config ./webpack.config.module.js",
     "postpackage-headless": "node ./bin/package_headless.js",
     "start": "node demo/start",
     "start-debug": "node --inspect-brk demo/start",
@@ -67,7 +72,7 @@
     "ts-loader": "^9.1.2",
     "typescript": "^4.4.4",
     "utf8": "^3.0.0",
-    "webpack": "^5.61.0",
+    "webpack": "^5.64.1",
     "webpack-cli": "^4.9.1",
     "ws": "^8.2.3",
     "xterm-benchmark": "^0.3.0"

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,0 +1,20 @@
+{
+  "target": "esnext",
+  "module": "esnext",
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./src/browser" },
+    { "path": "./src/headless" },
+    { "path": "./test/api" },
+    { "path": "./test/benchmark" },
+    { "path": "./addons/xterm-addon-attach" },
+    { "path": "./addons/xterm-addon-fit" },
+    { "path": "./addons/xterm-addon-ligatures" },
+    { "path": "./addons/xterm-addon-search" },
+    { "path": "./addons/xterm-addon-serialize" },
+    { "path": "./addons/xterm-addon-unicode11" },
+    { "path": "./addons/xterm-addon-web-links" },
+    { "path": "./addons/xterm-addon-webgl" }
+  ]
+}

--- a/webpack.config.module.js
+++ b/webpack.config.module.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+const path = require('path');
+
+/**
+ * This webpack config does a production build for xterm.js. It works by taking the output from tsc
+ * (via `yarn watch` or `yarn prebuild`) which are put into `out/` and webpacks them into a
+ * production mode umd library module in `lib/`. The aliases are used fix up the absolute paths
+ * output by tsc (because of `baseUrl` and `paths` in `tsconfig.json`.
+ */
+module.exports = {
+  entry: './out/browser/public/Terminal.js',
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: ["source-map-loader"],
+        enforce: "pre",
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    modules: ['./node_modules'],
+    extensions: [ '.js' ],
+    alias: {
+      common: path.resolve('./out/common'),
+      browser: path.resolve('./out/browser')
+    }
+  },
+  experiments: {
+    outputModule: true
+  },
+  output: {
+    filename: 'xterm.js',
+    path: path.resolve('./lib/es6'),
+    libraryTarget: 'module'
+  },
+  mode: 'production'
+};


### PR DESCRIPTION
at the moment you need to manually run 
npm run package-module

I could do it for the rest of the addons (if you will merge it)

how should I include in an autmatic publish process? (so the npm package contains both ES6 and old one)