### PR TITLE
Adding SendKey to Terminal

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1021,7 +1021,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
 
   public sendKey(key: string, alt: boolean, ctrl: boolean, shift: boolean): boolean {
-    if(!key) {
+    if (!key) {
       return false;
     }
 
@@ -1165,7 +1165,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
             }
           }
           else if (ctrl && key === '_') {
-            data = C0.US;;
+            data = C0.US;
           }
           else if (!alt && !ctrl && cca0 >= 32) {
             data = key;
@@ -1176,12 +1176,11 @@ export class Terminal extends CoreTerminal implements ITerminal {
         }
     }
 
-    if (data != null) {
+    if (data !== null) {
       this.coreService.triggerDataEvent(data, true);
     }
 
     return true;
-    
   }
 
   /**

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -195,6 +195,9 @@ export class MockTerminal implements ITerminal {
   public reset(): void {
     throw new Error('Method not implemented.');
   }
+  public sendKey(key: string, alt: boolean, ctrl: boolean, shift: boolean): boolean {
+    throw new Error('Method not implemented.');
+  }
   public clearTextureAtlas(): void {
     throw new Error('Method not implemented.');
   }

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -81,6 +81,7 @@ export interface IPublicTerminal extends IDisposable {
   refresh(start: number, end: number): void;
   clearTextureAtlas(): void;
   reset(): void;
+  sendKey(key: string, alt: boolean, ctrl: boolean, shift: boolean): boolean;
 }
 
 export type CustomKeyEventHandler = (event: KeyboardEvent) => boolean;

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -102,6 +102,11 @@ export class Terminal implements ITerminalApi {
     this._verifyIntegers(columns, rows);
     this._core.resize(columns, rows);
   }
+
+  public sendKey(key: string, alt: boolean, ctrl: boolean, shift: boolean): boolean {    
+    return this._core.sendKey(key, alt, ctrl, shift);
+  }
+
   public open(parent: HTMLElement): void {
     this._core.open(parent);
   }

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -103,7 +103,7 @@ export class Terminal implements ITerminalApi {
     this._core.resize(columns, rows);
   }
 
-  public sendKey(key: string, alt: boolean, ctrl: boolean, shift: boolean): boolean {    
+  public sendKey(key: string, alt: boolean, ctrl: boolean, shift: boolean): boolean {
     return this._core.sendKey(key, alt, ctrl, shift);
   }
 


### PR DESCRIPTION
For custom HTML on screen keyboards and as a first step away from deprecated keyPress and hard key codes.
(For built in touch-device on-screen-keyboards a beforeinput event handler could call this, for desktop a keydown event handler)