### PR TITLE
Mark IKeyboardEvent.keyCode as deprecated

### DIFF
--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -46,6 +46,7 @@ export interface IKeyboardEvent {
   ctrlKey: boolean;
   shiftKey: boolean;
   metaKey: boolean;
+  /** @deprecated See KeyboardEvent.keyCode */
   keyCode: number;
   key: string;
   type: string;


### PR DESCRIPTION
This makes it so it shows up in editors, this was being hidden before since our IKeyboardEvent interface cannot depend on the DOM so it hides the deprecation status:

![image](https://user-images.githubusercontent.com/2193314/146812286-4cf47443-96df-48b6-80b4-3761bed105fd.png)
