### PR TITLE
trycatch font parsing in ligatures addon

### DIFF
--- a/addons/xterm-addon-ligatures/src/font.ts
+++ b/addons/xterm-addon-ligatures/src/font.ts
@@ -90,9 +90,19 @@ export default async function load(fontFamily: string, cacheSize: number): Promi
     if (fonts.hasOwnProperty(family) && fonts[family].length > 0) {
       const font = fonts[family][0];
       if ('blob' in font) {
-        return loadBuffer(await (await font.blob()).arrayBuffer(), { cacheSize });
+        try {
+          return loadBuffer(await (await font.blob()).arrayBuffer(), { cacheSize });
+        } catch (err) {
+          console.error(err);
+          return undefined;
+        }
       }
-      return await loadFile(font.path, { cacheSize });
+      try {
+        return await loadFile(font.path, { cacheSize });
+      } catch (err) {
+        console.error(err);
+        return undefined;
+      }
     }
   }
 


### PR DESCRIPTION
Adding the fix for #3547 to ligatures addon directly so that it can be used with older xterm.js versions
Ref #3617