### PR TITLE
fix text baseline for Legacy Edge

### DIFF
--- a/src/browser/renderer/atlas/Constants.ts
+++ b/src/browser/renderer/atlas/Constants.ts
@@ -3,13 +3,13 @@
  * @license MIT
  */
 
-import { isFirefox } from 'common/Platform';
+import { isFirefox, isLegacyEdge } from 'common/Platform';
 
 export const INVERTED_DEFAULT_COLOR = 257;
 export const DIM_OPACITY = 0.5;
-// The text baseline is set conditionally by browser. Using 'ideographic' for Firefox would
+// The text baseline is set conditionally by browser. Using 'ideographic' for Firefox or Legacy Edge would
 // result in truncated text (Issue 3353). Using 'bottom' for Chrome would result in slightly
 // unaligned Powerline fonts (PR 3356#issuecomment-850928179).
-export const TEXT_BASELINE: CanvasTextBaseline = isFirefox ? 'bottom' : 'ideographic';
+export const TEXT_BASELINE: CanvasTextBaseline = isFirefox || isLegacyEdge ? 'bottom' : 'ideographic';
 
 export const CHAR_ATLAS_CELL_SPACING = 1;

--- a/src/common/Platform.ts
+++ b/src/common/Platform.ts
@@ -18,6 +18,7 @@ const userAgent = (isNode) ? 'node' : navigator.userAgent;
 const platform = (isNode) ? 'node' : navigator.platform;
 
 export const isFirefox = userAgent.includes('Firefox');
+export const isLegacyEdge = userAgent.includes('Edge');
 export const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent);
 
 // Find the users platform. We use this to interpret the meta key


### PR DESCRIPTION
Legacy Edge (or in my case the UWP WebView) has similar as issues as Firefox had with 'ideographic'