### PR TITLE
dispose of markers on buffer clear

### DIFF
--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -80,6 +80,21 @@ describe('Terminal', () => {
         term.clear();
       });
     });
+    it.only('should fire a scroll event when scrollback is cleared', () => {
+      return new Promise<void>(async r => {
+        const marker1 = term.addMarker(0);
+        const marker2 = term.addMarker(1);
+        await term.writeP('\n'.repeat(INIT_ROWS));
+        const marker3= term.addMarker(0);
+        const marker4 = term.addMarker(1);
+        marker1?.onDispose(() => r());
+        marker2?.onDispose(() => r());
+        marker3?.onDispose(() => r());
+        marker4?.onDispose(() => r());
+        term.clear();
+        assert.equal(term.markers.length, 0);
+      });
+    });
     it('should fire a key event after a keypress DOM event', (done) => {
       term.onKey(e => {
         assert.equal(typeof e.key, 'string');

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -80,21 +80,6 @@ describe('Terminal', () => {
         term.clear();
       });
     });
-    it.only('should fire a scroll event when scrollback is cleared', () => {
-      return new Promise<void>(async r => {
-        const marker1 = term.addMarker(0);
-        const marker2 = term.addMarker(1);
-        await term.writeP('\n'.repeat(INIT_ROWS));
-        const marker3= term.addMarker(0);
-        const marker4 = term.addMarker(1);
-        marker1?.onDispose(() => r());
-        marker2?.onDispose(() => r());
-        marker3?.onDispose(() => r());
-        marker4?.onDispose(() => r());
-        term.clear();
-        assert.equal(term.markers.length, 0);
-      });
-    });
     it('should fire a key event after a keypress DOM event', (done) => {
       term.onKey(e => {
         assert.equal(typeof e.key, 'string');

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1293,6 +1293,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       // Don't clear if it's already clear
       return;
     }
+    this.buffer.clearMarkers();
     this.buffer.lines.set(0, this.buffer.lines.get(this.buffer.ybase + this.buffer.y)!);
     this.buffer.lines.length = 1;
     this.buffer.ydisp = 0;

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -254,6 +254,9 @@ export class MockBuffer implements IBuffer {
   public getWhitespaceCell(attr?: IAttributeData): ICellData {
     throw new Error('Method not implemented.');
   }
+  public clearMarkers(): void {
+    throw new Error('Method not implemented.');
+  }
 }
 
 export class MockRenderer implements IRenderer {

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -625,7 +625,7 @@ export class Buffer implements IBuffer {
   }
 
   private _removeMarker(marker: Marker): void {
-    if (this._isClearing !== BufferState.CLEARING) {
+    if (!this._isClearing) {
       this.markers.splice(this.markers.indexOf(marker), 1);
     }
   }

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -16,7 +16,6 @@ import { DEFAULT_CHARSET } from 'common/data/Charsets';
 import { ExtendedAttrs } from 'common/buffer/AttributeData';
 
 export const MAX_BUFFER_SIZE = 4294967295; // 2^32 - 1
-const enum BufferState { CLEARING = 'clearing' }
 
 /**
  * This class represents a terminal buffer (an internal state of the terminal), where the
@@ -44,7 +43,7 @@ export class Buffer implements IBuffer {
   private _whitespaceCell: ICellData = CellData.fromCharData([0, WHITESPACE_CELL_CHAR, WHITESPACE_CELL_WIDTH, WHITESPACE_CELL_CODE]);
   private _cols: number;
   private _rows: number;
-  private _state: string | undefined;
+  private _isClearing: boolean = false;
 
   constructor(
     private _hasScrollback: boolean,
@@ -587,12 +586,12 @@ export class Buffer implements IBuffer {
   }
 
   public clearMarkers(): void {
-    this._state = BufferState.CLEARING;
+    this._isClearing = true;
     for (const marker of this.markers) {
       marker.dispose();
     }
     this.markers = [];
-    this._state = undefined;
+    this._isClearing = false;
   }
 
   public addMarker(y: number): Marker {
@@ -626,7 +625,7 @@ export class Buffer implements IBuffer {
   }
 
   private _removeMarker(marker: Marker): void {
-    if (this._state !== BufferState.CLEARING) {
+    if (this._isClearing !== BufferState.CLEARING) {
       this.markers.splice(this.markers.indexOf(marker), 1);
     }
   }

--- a/src/common/buffer/Types.d.ts
+++ b/src/common/buffer/Types.d.ts
@@ -10,7 +10,7 @@ import { IEvent } from 'common/EventEmitter';
 export type BufferIndex = [number, number];
 
 export interface IBufferStringIteratorResult {
-  range: { first: number, last: number };
+  range: {first: number, last: number};
   content: string;
 }
 

--- a/src/common/buffer/Types.d.ts
+++ b/src/common/buffer/Types.d.ts
@@ -10,7 +10,7 @@ import { IEvent } from 'common/EventEmitter';
 export type BufferIndex = [number, number];
 
 export interface IBufferStringIteratorResult {
-  range: {first: number, last: number};
+  range: { first: number, last: number };
   content: string;
 }
 
@@ -45,6 +45,7 @@ export interface IBuffer {
   getNullCell(attr?: IAttributeData): ICellData;
   getWhitespaceCell(attr?: IAttributeData): ICellData;
   addMarker(y: number): IMarker;
+  clearMarkers(): void;
 }
 
 export interface IBufferSet extends IDisposable {

--- a/test/api/Terminal.api.ts
+++ b/test/api/Terminal.api.ts
@@ -15,7 +15,7 @@ let page: Page;
 const width = 800;
 const height = 600;
 
-describe.only('API Integration Tests', function(): void {
+describe('API Integration Tests', function(): void {
   before(async () => {
     browser = await launchBrowser();
     page = await (await browser.newContext()).newPage();


### PR DESCRIPTION
While working on #1852, I noticed that when `clear` is called, the decorations aren't disposed of because their markers aren't disposed.