### PR TITLE
Update `node-pty`'s `on` eventListener to `IPty.onData`

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -114,7 +114,7 @@ function startServer() {
     }
     const send = USE_BINARY ? bufferUtf8(ws, 5) : buffer(ws, 5);
 
-    term.on('data', function(data) {
+    term.onData(function (data) {
       try {
         send(data);
       } catch (ex) {

--- a/demo/server.js
+++ b/demo/server.js
@@ -56,7 +56,7 @@ function startServer() {
     console.log('Created terminal with PID: ' + term.pid);
     terminals[term.pid] = term;
     logs[term.pid] = '';
-    term.onData(function (data) {
+    term.onData(function(data) {
       logs[term.pid] += data;
     });
     res.send(term.pid.toString());
@@ -114,7 +114,7 @@ function startServer() {
     }
     const send = USE_BINARY ? bufferUtf8(ws, 5) : buffer(ws, 5);
 
-    term.onData(function (data) {
+    term.onData(function(data) {
       try {
         send(data);
       } catch (ex) {
@@ -124,7 +124,7 @@ function startServer() {
     ws.on('message', function(msg) {
       term.write(msg);
     });
-    ws.on('close', function () {
+    ws.on('close', function() {
       term.kill();
       console.log('Closed terminal ' + term.pid);
       // Clean things up

--- a/demo/server.js
+++ b/demo/server.js
@@ -56,7 +56,7 @@ function startServer() {
     console.log('Created terminal with PID: ' + term.pid);
     terminals[term.pid] = term;
     logs[term.pid] = '';
-    term.on('data', function(data) {
+    term.onData(function (data) {
       logs[term.pid] += data;
     });
     res.send(term.pid.toString());


### PR DESCRIPTION
According to `node-pty`s type interface, `on("data")` is deprecated, and should be replaced with `onData`, instead.

- Additionally, to the best of my understandings, the tests are running successfully.

Reference to `node-pty.d.ts`:

```javascript
export interface IPty {
   /* ... */

    /**
     * Adds a listener to the data event, fired when data is returned from the pty.
     * @param event The name of the event.
     * @param listener The callback function.
     * @deprecated Use IPty.onData
     */
    on(event: 'data', listener: (data: string) => void): void;
}
```

I appreciate all that everyone does with the `xterm.js`-- thank you to the maintainers and contributors for actively supporting such a great project. 