### PR TITLE
Add libv86 terminal forwarding to README "Programs using xterm.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**OpenSumi**](https://github.com/opensumi/core): A framework helps you quickly build Cloud or Desktop IDE products.
 - [**KubeSail**](https://kubesail.com): The Self-Hosting Company - uses xterm to allow users to exec into kubernetes pods and build github apps
 - [**WiTTY**](https://github.com/syssecfsu/witty): Web-based interactive terminal emulator that allows users to easily record, share, and replay console sessions.
+- [**libv86 Terminal Forwarding**](https://github.com/hello-smile6/libv86-terminal-forwarding): Peer-to-peer SSH for the web, using WebRTC via [Bugout](https://github.com/chr15m/bugout) for data transfer and [v86](https://github.com/copy/v86) for web-based virtualization.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Note: Please add any new contributions to the end of the list only.


### PR DESCRIPTION
I made a website that lets people run a virtual machine on their computer and remotely access it from any device, including those without enough memory to run v86. It uses xterm.js for displaying information.

https://github.com/hello-smile6/libv86-terminal-forwarding