### PR TITLE
Lint using 🐊Putout: part 6

### DIFF
--- a/addons/xterm-addon-search/test/SearchAddon.api.ts
+++ b/addons/xterm-addon-search/test/SearchAddon.api.ts
@@ -134,7 +134,7 @@ describe('Search Tests', function(): void {
             .replace(/\n/g, '\\n\\r');
         }
         fixture = fixture
-          .replace(/'/g, '\\\'');
+          .replace(/'/g, `\\'`);
       });
       it('should find all occurrences using findNext', async () => {
         await writeSync(page, fixture);

--- a/addons/xterm-addon-serialize/src/SerializeAddon.test.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.test.ts
@@ -86,7 +86,7 @@ describe('xterm-addon-serialize html', () => {
   it('empty terminal with selection turned off', () => {
     const output = serializeAddon.serializeAsHTML();
     assert.notEqual(output, '');
-    assert.equal((output.match(new RegExp('<div><span> {10}</span><\/div>', 'g')) || []).length, 2);
+    assert.equal((output.match(/<div><span> {10}<\/span><\/div>/g) || []).length, 2);
   });
 
   it('empty terminal with no selection', () => {
@@ -103,84 +103,84 @@ describe('xterm-addon-serialize html', () => {
     const output = serializeAddon.serializeAsHTML({
       onlySelection: true
     });
-    assert.equal((output.match(new RegExp('<div><span>terminal<\/span><\/div>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<div><span>terminal<\/span><\/div>/g) || []).length, 1, output);
   });
 
   it('cells with bold styling', async () => {
     await writeP(terminal, ' ' + sgr('1') + 'terminal' + sgr('22') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'font-weight: bold;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='font-weight: bold;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with italic styling', async () => {
     await writeP(terminal, ' ' + sgr('3') + 'terminal' + sgr('23') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'font-style: italic;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='font-style: italic;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with inverse styling', async () => {
     await writeP(terminal, ' ' + sgr('7') + 'terminal' + sgr('27') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'color: #000000; background-color: #BFBFBF;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='color: #000000; background-color: #BFBFBF;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with underline styling', async () => {
     await writeP(terminal, ' ' + sgr('4') + 'terminal' + sgr('24') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'text-decoration: underline;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='text-decoration: underline;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with invisible styling', async () => {
     await writeP(terminal, ' ' + sgr('8') + 'terminal' + sgr('28') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'visibility: hidden;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='visibility: hidden;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with dim styling', async () => {
     await writeP(terminal, ' ' + sgr('2') + 'terminal' + sgr('22') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'opacity: 0.5;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='opacity: 0.5;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with strikethrough styling', async () => {
     await writeP(terminal, ' ' + sgr('9') + 'terminal' + sgr('29') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'text-decoration: line-through;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='text-decoration: line-through;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with combined styling', async () => {
     await writeP(terminal, sgr('1') + ' ' + sgr('9') + 'termi' + sgr('22') + 'nal' + sgr('29') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'font-weight: bold;\'> <\/span>', 'g')) || []).length, 1, output);
-    assert.equal((output.match(new RegExp('<span style=\'font-weight: bold; text-decoration: line-through;\'>termi<\/span>', 'g')) || []).length, 1, output);
-    assert.equal((output.match(new RegExp('<span style=\'text-decoration: line-through;\'>nal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='font-weight: bold;'> <\/span>/g) || []).length, 1, output);
+    assert.equal((output.match(/<span style='font-weight: bold; text-decoration: line-through;'>termi<\/span>/g) || []).length, 1, output);
+    assert.equal((output.match(/<span style='text-decoration: line-through;'>nal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with color styling', async () => {
     await writeP(terminal, ' ' + sgr('38;5;46') + 'terminal' + sgr('39') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'color: #00ff00;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='color: #00ff00;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('cells with background styling', async () => {
     await writeP(terminal, ' ' + sgr('48;5;46') + 'terminal' + sgr('49') + ' ');
 
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('<span style=\'background-color: #00ff00;\'>terminal<\/span>', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/<span style='background-color: #00ff00;'>terminal<\/span>/g) || []).length, 1, output);
   });
 
   it('empty terminal with default options', async () => {
     const output = serializeAddon.serializeAsHTML();
-    assert.equal((output.match(new RegExp('color: #000000; background-color: #ffffff; font-family: courier-new, courier, monospace; font-size: 15px;', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/color: #000000; background-color: #ffffff; font-family: courier-new, courier, monospace; font-size: 15px;/g) || []).length, 1, output);
   });
 
   it('empty terminal with custom options', async () => {
@@ -193,13 +193,13 @@ describe('xterm-addon-serialize html', () => {
     const output = serializeAddon.serializeAsHTML({
       includeGlobalBackground: true
     });
-    assert.equal((output.match(new RegExp('color: #ff00ff; background-color: #00ff00; font-family: verdana; font-size: 20px;', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/color: #ff00ff; background-color: #00ff00; font-family: verdana; font-size: 20px;/g) || []).length, 1, output);
   });
 
   it('empty terminal with background included', async () => {
     const output = serializeAddon.serializeAsHTML({
       includeGlobalBackground: true
     });
-    assert.equal((output.match(new RegExp('color: #ffffff; background-color: #000000; font-family: courier-new, courier, monospace; font-size: 15px;', 'g')) || []).length, 1, output);
+    assert.equal((output.match(/color: #ffffff; background-color: #000000; font-family: courier-new, courier, monospace; font-size: 15px;/g) || []).length, 1, output);
   });
 });

--- a/addons/xterm-addon-serialize/src/SerializeAddon.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.ts
@@ -544,7 +544,7 @@ export class HTMLSerializeHandler extends BaseSerializeHandler {
       return target;
     }
 
-    targetLength = targetLength - target.length;
+    targetLength -= target.length;
     if (targetLength > padString.length) {
       padString += padString.repeat(targetLength / padString.length);
     }

--- a/addons/xterm-addon-serialize/test/SerializeAddon.api.ts
+++ b/addons/xterm-addon-serialize/test/SerializeAddon.api.ts
@@ -14,7 +14,7 @@ let page: Page;
 const width = 800;
 const height = 600;
 
-const writeRawSync = (page: any, str: string): Promise<void> => writeSync(page, '\' +' + JSON.stringify(str) + '+ \'');
+const writeRawSync = (page: any, str: string): Promise<void> => writeSync(page, `' +` + JSON.stringify(str) + `+ '`);
 
 const testNormalScreenEqual = async (page: any, str: string): Promise<void> => {
   await writeRawSync(page, str);

--- a/src/browser/ColorManager.ts
+++ b/src/browser/ColorManager.ts
@@ -185,7 +185,7 @@ export class ColorManager implements IColorManager {
       foreground: this.colors.foreground,
       background: this.colors.background,
       cursor: this.colors.cursor,
-      ansi: [...this.colors.ansi]
+      ansi: this.colors.ansi.slice()
     };
   }
 

--- a/src/browser/renderer/atlas/CharAtlasUtils.ts
+++ b/src/browser/renderer/atlas/CharAtlasUtils.ts
@@ -16,7 +16,7 @@ export function generateConfig(scaledCharWidth: number, scaledCharHeight: number
     cursor: undefined,
     cursorAccent: undefined,
     selection: undefined,
-    ansi: [...colors.ansi]
+    ansi: colors.ansi.slice()
   };
   return {
     devicePixelRatio: window.devicePixelRatio,

--- a/src/common/input/XParseColor.ts
+++ b/src/common/input/XParseColor.ts
@@ -5,7 +5,7 @@
 
 
 // 'rgb:' rule - matching: r/g/b | rr/gg/bb | rrr/ggg/bbb | rrrr/gggg/bbbb (hex digits)
-const RGB_REX = /^([\da-f]{1})\/([\da-f]{1})\/([\da-f]{1})$|^([\da-f]{2})\/([\da-f]{2})\/([\da-f]{2})$|^([\da-f]{3})\/([\da-f]{3})\/([\da-f]{3})$|^([\da-f]{4})\/([\da-f]{4})\/([\da-f]{4})$/;
+const RGB_REX = /^([\da-f])\/([\da-f])\/([\da-f])$|^([\da-f]{2})\/([\da-f]{2})\/([\da-f]{2})$|^([\da-f]{3})\/([\da-f]{3})\/([\da-f]{3})$|^([\da-f]{4})\/([\da-f]{4})\/([\da-f]{4})$/;
 // '#...' rule - matching any hex digits
 const HASH_REX = /^[\da-f]+$/;
 


### PR DESCRIPTION
>**There is surely nothing other than the single purpose of the present moment. A man's whole life is a succession of moment after moment. There will be nothing else to do, and nothing else to pursue. Live being true to the single purpose of the moment.**
>
> **(c) Yamamoto Tsunetomo "Hagakure"**

![image](https://user-images.githubusercontent.com/1573141/156920958-383dd9c1-def9-4e22-af34-0f3294009589.png)


There is no holidays in the the peaceful swamps since the invasion of hippo herd 🦛.

Anyways 🐊**Putout** does what it always did: searches ways to simplify code. Outside of the window sounds roar of shells and charms of sirens winding the winds. But 🐊he is OK and here is report of **Xterm** linting by 🐊[**v25**](https://github.com/coderaiser/putout/releases/tag/v25.0.0):

☝️ *As usual, any rule can be disabled.*

Command used:

```sh
putout . --fix
```

Applied rules:
- ✅ [convert-array-copy-to-slice](https://github.com/coderaiser/putout/tree/v25.4.0/packages/plugin-convert-array-copy-to-slice#readme)
- ✅ [convert-quotes-to-backticks](https://github.com/coderaiser/putout/tree/v25.4.0/packages/plugin-convert-quotes-to-backticks#readme)
- ✅ [regexp/optimize](https://github.com/coderaiser/putout/tree/v25.4.0/packages/plugin-regexp#optimize)
- ✅ [regexp/apply-literal-notation](https://github.com/coderaiser/putout/tree/v25.4.0/packages/plugin-regexp#regexpapply-literal-notation)
- ✅ [remove-useless-operand](https://github.com/coderaiser/putout/tree/v25.4.0/packages/plugin-remove-useless-operand#readme)

Current config for 🐊[Putout v25](https://github.com/coderaiser/putout):

```json
{
    "rules": {
        "apply-is-array": ["on", {
            "inline": true
        }],
        "remove-useless-new": "off",
        "remove-useless-return": "off",
        "typescript/remove-useless-types-from-constants": "off",
        "remove-useless-type-conversion/with-double-negations": "off",
        "convert-typeof-to-is-type": "off",
        "apply-shorthand-properties": "off",
        "apply-destructuring": "off",
        "apply-numeric-separators": "off",
        "convert-assignment-to-comparison": "off",
        "convert-apply-to-spread": "off",
        "convert-math-pow": "off",
        "convert-for-to-for-of": "off",
        "convert-template-to-string": "off",
        "strict-mode": "off",
        "remove-useless-spread/object": "off",
        "remove-useless-array-constructor": "off",
        "remove-boolean-from-assertions": "off",
        "remove-iife": "off",
        "remove-console": "off",
        "remove-unused-variables": "off",
        "remove-useless-variables": "off",
        "merge-if-statements": "off",
        "promises/add-missing-await": "off",
        "promises/remove-useless-async": "off",
        "simplify-ternary": "off",
        "nodejs/convert-dirname-to-url": "off",
        "try-catch": "off",
        "apply-array-at": "off"
    },
    "match": {
        "*.benchmark.ts": {
            "remove-unused-expressions": "off"
        },
        "SerializeAddon.test.ts": {
            "regexp/optimize": "off"
        }
    },
    "plugins": [
        "apply-shorthand-properties"
    ],
    "ignore": [
        "addons/*/lib/*.js",
        "*.benchmark.js",
        "*.md",
        "*.json",
        "*ignore",
        "*.yml",
        ".npmrc",
        "*.css",
        "out",
        "out-test",
        "demo"
    ]
}
```

Previous reports: 
- [1](https://github.com/xtermjs/xterm.js/pull/2953)
- [2](https://github.com/xtermjs/xterm.js/pull/3133)
- [3](https://github.com/xtermjs/xterm.js/pull/3269)
- [4](https://github.com/xtermjs/xterm.js/pull/3341)
- [5](https://github.com/xtermjs/xterm.js/pull/3538)

> 🐊*Have a clear sky and blooming fields!*
