### PR TITLE
Use proper height and fix alignment for positioned overview ruler decorations

### DIFF
--- a/src/browser/Decorations/OverviewRulerRenderer.ts
+++ b/src/browser/Decorations/OverviewRulerRenderer.ts
@@ -92,13 +92,13 @@ export class OverviewRulerRenderer extends Disposable {
       return;
     }
     this._ctx.lineWidth = 1;
-    this._ctx.strokeStyle = decoration.options.overviewRulerOptions.color;
     this._ctx.fillStyle = decoration.options.overviewRulerOptions.color;
     this._ctx.fillRect(
       !decoration.options.overviewRulerOptions.position ||  decoration.options.overviewRulerOptions.position === 'left' ? 0 : decoration.options.overviewRulerOptions.position === 'right' ? renderSizes[SizeIndex.OUTER_SIZE] + renderSizes[SizeIndex.INNER_SIZE]: renderSizes[SizeIndex.OUTER_SIZE],
       Math.round(this._canvas.height * (decoration.options.marker.line / this._bufferService.buffers.active.lines.length)),
       !decoration.options.overviewRulerOptions.position ? this._width : decoration.options.overviewRulerOptions.position === 'center' ? renderSizes[SizeIndex.INNER_SIZE] : renderSizes[SizeIndex.OUTER_SIZE],
-      window.devicePixelRatio * (!decoration.options.overviewRulerOptions.position ? 2 : 6)
+      // when a position is provided, the element has less width, so increase its height
+      window.devicePixelRatio * (decoration.options.overviewRulerOptions.position ? 6 : 2)
     );
   }
 

--- a/src/browser/Decorations/OverviewRulerRenderer.ts
+++ b/src/browser/Decorations/OverviewRulerRenderer.ts
@@ -15,7 +15,7 @@ import { IBufferService, IDecorationService, IInternalDecoration, IOptionsServic
 const renderSizes = new Uint16Array(3);
 const enum SizeIndex {
   OUTER_SIZE = 0,
-  INNER_SIZE = 0
+  INNER_SIZE = 1
 }
 
 export class OverviewRulerRenderer extends Disposable {
@@ -91,13 +91,14 @@ export class OverviewRulerRenderer extends Disposable {
       this._decorationElements.delete(decoration);
       return;
     }
-    this._ctx.lineWidth = !decoration.options.overviewRulerOptions.position ? 2 : 6;
+    this._ctx.lineWidth = 1;
     this._ctx.strokeStyle = decoration.options.overviewRulerOptions.color;
-    this._ctx.strokeRect(
+    this._ctx.fillStyle = decoration.options.overviewRulerOptions.color;
+    this._ctx.fillRect(
       !decoration.options.overviewRulerOptions.position ||  decoration.options.overviewRulerOptions.position === 'left' ? 0 : decoration.options.overviewRulerOptions.position === 'right' ? renderSizes[SizeIndex.OUTER_SIZE] + renderSizes[SizeIndex.INNER_SIZE]: renderSizes[SizeIndex.OUTER_SIZE],
       Math.round(this._canvas.height * (decoration.options.marker.line / this._bufferService.buffers.active.lines.length)),
-      !decoration.options.overviewRulerOptions.position ? this._width : decoration.options.overviewRulerOptions.position === 'center' ? renderSizes[SizeIndex.INNER_SIZE]: renderSizes[SizeIndex.OUTER_SIZE],
-      window.devicePixelRatio
+      !decoration.options.overviewRulerOptions.position ? this._width : decoration.options.overviewRulerOptions.position === 'center' ? renderSizes[SizeIndex.INNER_SIZE] : renderSizes[SizeIndex.OUTER_SIZE],
+      window.devicePixelRatio * (!decoration.options.overviewRulerOptions.position ? 2 : 6)
     );
   }
 


### PR DESCRIPTION
fixes #3683
when width is `15px`
![Screen Shot 2022-03-16 at 1 22 20 PM](https://user-images.githubusercontent.com/29464607/158650398-0335fe9a-6636-48d1-92a6-02c0160274f2.png)
when width is `14px`
![Screen Shot 2022-03-16 at 1 22 47 PM](https://user-images.githubusercontent.com/29464607/158650453-f50f386c-15b8-42f6-a5a6-4acbfa357e39.png)

