### PR TITLE
use correct start col/row in next search

### DIFF
--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -139,7 +139,12 @@ export class SearchAddon implements ITerminalAddon {
     let result = this._find(term, 0, 0, searchOptions);
     while (result && !this._searchResults.get(`${result.row}-${result.col}`)) {
       this._searchResults.set(`${result.row}-${result.col}`, result);
-      result = this._find(term, result.row, result.col + 1, searchOptions);
+      result = this._find(
+        term,
+        result.col + result.term.length >= this._terminal.cols ? result.row + 1 : result.row,
+        result.col + result.term.length >= this._terminal.cols ? 0 : result.col + 1,
+        searchOptions
+      );
     }
     this._searchResults.forEach(result => {
       const resultDecoration = this._createResultDecoration(result, searchOptions.decorations!);
@@ -157,15 +162,13 @@ export class SearchAddon implements ITerminalAddon {
     }
   }
 
-  private _find(term: string, startRow?: number, startCol?: number, searchOptions?: ISearchOptions): ISearchResult | undefined {
+  private _find(term: string, startRow: number, startCol: number, searchOptions?: ISearchOptions): ISearchResult | undefined {
     if (!this._terminal || !term || term.length === 0) {
       this._terminal?.clearSelection();
       this.clearDecorations();
       return undefined;
     }
     let result: ISearchResult | undefined = undefined;
-    startCol = startCol || 0;
-    startRow = startRow ?? 0;
 
     this._initLinesCache();
 

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -168,6 +168,10 @@ export class SearchAddon implements ITerminalAddon {
       this.clearDecorations();
       return undefined;
     }
+    if (startRow > this._terminal.rows || startCol > this._terminal.cols) {
+      throw new Error(`Invalid row: ${startRow} or col: ${startCol} to search in terminal with ${this._terminal.rows} rows and ${this._terminal.cols} cols`);
+    }
+
     let result: ISearchResult | undefined = undefined;
 
     this._initLinesCache();


### PR DESCRIPTION
I believe the search results were incomplete because when a result started on the last col, incrementing col by 1 resulted in an invalid place to begin the next search, so no result would be found and it would return

Fixes #3706