### PR TITLE
Don't change overview ruler position based on decorations

### DIFF
--- a/src/browser/Decorations/OverviewRulerRenderer.ts
+++ b/src/browser/Decorations/OverviewRulerRenderer.ts
@@ -141,13 +141,6 @@ export class OverviewRulerRenderer extends Disposable {
   }
 
   private _refreshStyle(decoration: IInternalDecoration): void {
-    if (this._shouldUpdateAnchor) {
-      if (decoration.options.anchor === 'right') {
-        this._canvas.style.right = decoration.options.x ? `${decoration.options.x * this._renderService.dimensions.actualCellWidth}px` : '';
-      } else {
-        this._canvas.style.left = decoration.options.x ? `${decoration.options.x * this._renderService.dimensions.actualCellWidth}px` : '';
-      }
-    }
     if (!decoration.options.overviewRulerOptions) {
       this._decorationElements.delete(decoration);
       return;


### PR DESCRIPTION
The original fix for #3705 ended up revealing this other bug; the canvas
shouldn't be set based on the anchor of its decorations.

Fixes #3705

Updating was causing this bug:

![image](https://user-images.githubusercontent.com/2193314/159946305-64a7a12a-470d-4448-9231-b9a58b3bfd0e.png)
