### PR TITLE
Expose urlRegex in the public .d.ts file.

### DIFF
--- a/addons/xterm-addon-web-links/src/WebLinkProvider.ts
+++ b/addons/xterm-addon-web-links/src/WebLinkProvider.ts
@@ -5,9 +5,10 @@
 
 import { ILinkProvider, ILink, Terminal, IViewportRange } from 'xterm';
 
-interface ILinkProviderOptions {
+export interface ILinkProviderOptions {
   hover?(event: MouseEvent, text: string, location: IViewportRange): void;
   leave?(event: MouseEvent, text: string): void;
+  urlRegex?: RegExp;
 }
 
 export class WebLinkProvider implements ILinkProvider {

--- a/addons/xterm-addon-web-links/src/WebLinksAddon.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.ts
@@ -3,8 +3,8 @@
  * @license MIT
  */
 
-import { Terminal, ILinkMatcherOptions, ITerminalAddon, IDisposable, IViewportRange } from 'xterm';
-import { WebLinkProvider } from './WebLinkProvider';
+import { Terminal, ILinkMatcherOptions, ITerminalAddon, IDisposable } from 'xterm';
+import { ILinkProviderOptions, WebLinkProvider } from './WebLinkProvider';
 
 const protocolClause = '(https?:\\/\\/)';
 const domainCharacterSet = '[\\da-z\\.-]+';
@@ -38,12 +38,6 @@ function handleLink(event: MouseEvent, uri: string): void {
   } else {
     console.warn('Opening link blocked as opener could not be cleared');
   }
-}
-
-interface ILinkProviderOptions {
-  hover?(event: MouseEvent, text: string, location: IViewportRange): void;
-  leave?(event: MouseEvent, text: string): void;
-  urlRegex?: RegExp;
 }
 
 export class WebLinksAddon implements ITerminalAddon {

--- a/addons/xterm-addon-web-links/typings/xterm-addon-web-links.d.ts
+++ b/addons/xterm-addon-web-links/typings/xterm-addon-web-links.d.ts
@@ -49,5 +49,10 @@ declare module 'xterm-addon-web-links' {
      * happen even when tooltipCallback hasn't fired for the link yet.
      */
     leave?(event: MouseEvent, text: string): void;
+
+    /** 
+     * A callback to use instead of the default one.
+    */
+    urlRegex?: RegExp;
   }
 }


### PR DESCRIPTION
This makes it possible to pass a regex when working against a .d.ts file instead of directly against a WebLinksAddon.ts