### PR TITLE
Improve performance of overview ruler by computing and rendering color zones

### DIFF
--- a/demo/client.ts
+++ b/demo/client.ts
@@ -556,8 +556,8 @@ function loadTest() {
 function addDecoration() {
   term.options['overviewRulerWidth'] = 15;
   const marker = term.addMarker(1);
-  const decoration = term.registerDecoration({ marker, overviewRulerOptions: { color: '#ef2929'} });
-  decoration.onRender((e) => e.style.backgroundColor = '#ef2929');
+  const decoration = term.registerDecoration({ marker, overviewRulerOptions: { color: '#ef292980', position: 'left' } });
+  decoration.onRender((e) => e.style.backgroundColor = '#ef292980');
 }
 
 function addOverviewRuler() {

--- a/src/browser/Decorations/ColorZoneStore.test.ts
+++ b/src/browser/Decorations/ColorZoneStore.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2017 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { ColorZoneStore } from 'browser/Decorations/ColorZoneStore';
+
+const optionsRedFull = {
+  overviewRulerOptions: {
+    color: 'red',
+    position: 'full' as 'full'
+  }
+};
+
+describe('ColorZoneStore', () => {
+  let store: ColorZoneStore;
+
+  beforeEach(() => {
+    store = new ColorZoneStore();
+    store.setPadding({
+      full: 1,
+      left: 1,
+      center: 1,
+      right: 1
+    });
+  });
+
+  it('should merge adjacent zones', () => {
+    store.addDecoration({
+      marker: { line: 0 },
+      options: optionsRedFull
+    });
+    store.addDecoration({
+      marker: { line: 1 },
+      options: optionsRedFull
+    });
+    assert.deepStrictEqual(store.zones, [
+      {
+        color: 'red',
+        position: 'full',
+        startBufferLine: 0,
+        endBufferLine: 1
+      }
+    ]);
+  });
+
+  it('should not merge non-adjacent zones', () => {
+    store.addDecoration({
+      marker: { line: 0 },
+      options: optionsRedFull
+    });
+    store.addDecoration({
+      marker: { line: 2 },
+      options: optionsRedFull
+    });
+    assert.deepStrictEqual(store.zones, [
+      {
+        color: 'red',
+        position: 'full',
+        startBufferLine: 0,
+        endBufferLine: 0
+      },
+      {
+        color: 'red',
+        position: 'full',
+        startBufferLine: 2,
+        endBufferLine: 2
+      }
+    ]);
+  });
+
+  it('should reuse zone objects', () => {
+    const obj = {
+      marker: { line: 0 },
+      options: optionsRedFull
+    };
+    store.addDecoration(obj);
+    const zone = store.zones[0];
+    store.clear();
+    store.addDecoration({
+      marker: { line: 1 },
+      options: optionsRedFull
+    });
+    // The object reference should be the same
+    assert.equal(zone, store.zones[0]);
+  });
+});

--- a/src/browser/Decorations/ColorZoneStore.ts
+++ b/src/browser/Decorations/ColorZoneStore.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IInternalDecoration } from 'common/services/Services';
-import { IDecorationOverviewRulerOptions } from 'xterm';
 
 export interface IColorZoneStore {
   readonly zones: IColorZone[];
@@ -48,13 +47,10 @@ export class ColorZoneStore implements IColorZoneStore {
       if (z.color === decoration.options.overviewRulerOptions.color &&
           z.position === decoration.options.overviewRulerOptions.position) {
         if (this._lineIntersectsZone(z, decoration.marker.line)) {
-          console.log('intersects, skip');
-          // this._addLineToZone(z, decoration.marker.line);
           return;
         }
         if (this._lineAdjacentToZone(z, decoration.marker.line, decoration.options.overviewRulerOptions.position)) {
           this._addLineToZone(z, decoration.marker.line);
-          console.log('adjacent, add');
           return;
         }
       }
@@ -82,8 +78,8 @@ export class ColorZoneStore implements IColorZoneStore {
 
   private _lineAdjacentToZone(zone: IColorZone, line: number, position: IColorZone['position']): boolean {
     return (
-      (line >= zone.startBufferLine - 1 - this._linePadding[position || 'full'] * 2) &&
-      (line <= zone.endBufferLine + 1 + this._linePadding[position || 'full'] * 2)
+      (line >= zone.startBufferLine - this._linePadding[position || 'full'] * 2) &&
+      (line <= zone.endBufferLine + this._linePadding[position || 'full'] * 2)
     );
   }
 

--- a/src/browser/Decorations/ColorZoneStore.ts
+++ b/src/browser/Decorations/ColorZoneStore.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IInternalDecoration } from 'common/services/Services';
+import { IDecorationOverviewRulerOptions } from 'xterm';
+
+export interface IColorZoneStore {
+  readonly zones: IColorZone[];
+  clear(): void;
+  addDecoration(decoration: IInternalDecoration): void;
+  /**
+   * Sets the amount of padding in lines that will be added between zones, if new lines intersect
+   * the padding they will be merged into the same zone.
+   */
+  setPadding(padding: { [position: string]: number }): void;
+}
+
+export interface IColorZone {
+  /** Color in a format supported by canvas' fillStyle. */
+  color: string;
+  position: 'full' | 'left' | 'center' | 'right' | undefined;
+  startBufferLine: number;
+  endBufferLine: number;
+}
+
+export class ColorZoneStore implements IColorZoneStore {
+  private _zones: IColorZone[] = [];
+  public get zones(): IColorZone[] { return this._zones; }
+
+  private _linePadding: { [position: string]: number } = {
+    full: 0,
+    left: 0,
+    center: 0,
+    right: 0
+  };
+
+  public clear(): void {
+    this._zones.length = 0;
+  }
+
+  public addDecoration(decoration: IInternalDecoration): void {
+    if (!decoration.options.overviewRulerOptions) {
+      return;
+    }
+    for (const z of this._zones) {
+      if (z.color === decoration.options.overviewRulerOptions.color &&
+          z.position === decoration.options.overviewRulerOptions.position) {
+        if (this._lineIntersectsZone(z, decoration.marker.line)) {
+          console.log('intersects, skip');
+          // this._addLineToZone(z, decoration.marker.line);
+          return;
+        }
+        if (this._lineAdjacentToZone(z, decoration.marker.line, decoration.options.overviewRulerOptions.position)) {
+          this._addLineToZone(z, decoration.marker.line);
+          console.log('adjacent, add');
+          return;
+        }
+      }
+    }
+    // TODO: Track zones in an object pool to reduce GC
+    this._zones.push({
+      color: decoration.options.overviewRulerOptions.color,
+      position: decoration.options.overviewRulerOptions.position,
+      startBufferLine: decoration.marker.line,
+      endBufferLine: decoration.marker.line
+    });
+  }
+
+  public setPadding(padding: { [position: string]: number }): void {
+    console.log('padding', padding);
+    this._linePadding = padding;
+  }
+
+  private _lineIntersectsZone(zone: IColorZone, line: number): boolean {
+    return (
+      line >= zone.startBufferLine &&
+      line <= zone.endBufferLine
+    );
+  }
+
+  private _lineAdjacentToZone(zone: IColorZone, line: number, position: IColorZone['position']): boolean {
+    return (
+      (line >= zone.startBufferLine - 1 - this._linePadding[position || 'full'] * 2) &&
+      (line <= zone.endBufferLine + 1 + this._linePadding[position || 'full'] * 2)
+    );
+  }
+
+  private _addLineToZone(zone: IColorZone, line: number): void {
+    zone.startBufferLine = Math.min(zone.startBufferLine, line);
+    zone.endBufferLine = Math.max(zone.endBufferLine, line);
+  }
+}

--- a/src/browser/Decorations/ColorZoneStore.ts
+++ b/src/browser/Decorations/ColorZoneStore.ts
@@ -24,6 +24,11 @@ export interface IColorZone {
   endBufferLine: number;
 }
 
+interface IMinimalDecorationForColorZone {
+  marker: Pick<IInternalDecoration['marker'], 'line'>;
+  options: Pick<IInternalDecoration['options'], 'overviewRulerOptions'>;
+}
+
 export class ColorZoneStore implements IColorZoneStore {
   private _zones: IColorZone[] = [];
 
@@ -51,7 +56,7 @@ export class ColorZoneStore implements IColorZoneStore {
     this._zonePoolIndex = 0;
   }
 
-  public addDecoration(decoration: IInternalDecoration): void {
+  public addDecoration(decoration: IMinimalDecorationForColorZone): void {
     if (!decoration.options.overviewRulerOptions) {
       return;
     }
@@ -62,7 +67,6 @@ export class ColorZoneStore implements IColorZoneStore {
           return;
         }
         if (this._lineAdjacentToZone(z, decoration.marker.line, decoration.options.overviewRulerOptions.position)) {
-          console.log('add line to zone');
           this._addLineToZone(z, decoration.marker.line);
           return;
         }

--- a/src/browser/Decorations/OverviewRulerRenderer.ts
+++ b/src/browser/Decorations/OverviewRulerRenderer.ts
@@ -150,10 +150,10 @@ export class OverviewRulerRenderer extends Disposable {
 
   private _refreshColorZonePadding(): void {
     this._colorZoneStore.setPadding({
-      full: this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.full / 2),
-      left: this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.left / 2),
-      center: this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.center / 2),
-      right: this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.right / 2)
+      full: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.full / 2)),
+      left: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.left / 2)),
+      center: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.center / 2)),
+      right: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.right / 2))
     });
     this._lastKnownBufferLength = this._bufferService.buffers.normal.lines.length;
   }
@@ -177,8 +177,16 @@ export class OverviewRulerRenderer extends Disposable {
       this._colorZoneStore.addDecoration(decoration);
     }
     this._ctx.lineWidth = 1;
-    for (const zone of this._colorZoneStore.zones) {
-      this._renderColorZone(zone);
+    const zones = this._colorZoneStore.zones;
+    for (const zone of zones) {
+      if (zone.position !== 'full') {
+        this._renderColorZone(zone);
+      }
+    }
+    for (const zone of zones) {
+      if (zone.position === 'full') {
+        this._renderColorZone(zone);
+      }
     }
     this._shouldUpdateDimensions = false;
     this._shouldUpdateAnchor = false;

--- a/src/browser/Decorations/OverviewRulerRenderer.ts
+++ b/src/browser/Decorations/OverviewRulerRenderer.ts
@@ -33,7 +33,6 @@ const drawX = {
 export class OverviewRulerRenderer extends Disposable {
   private readonly _canvas: HTMLCanvasElement;
   private readonly _ctx: CanvasRenderingContext2D;
-  private readonly _decorationElements: Map<IInternalDecoration, HTMLElement> = new Map();
   private readonly _colorZoneStore: IColorZoneStore = new ColorZoneStore();
   private get _width(): number {
     return this._optionsService.options.overviewRulerWidth || 0;
@@ -75,7 +74,6 @@ export class OverviewRulerRenderer extends Disposable {
    */
   private _registerDecorationListeners(): void {
     this.register(this._decorationService.onDecorationRegistered(() => this._queueRefresh(undefined, true)));
-    this.register(this._decorationService.onDecorationRemoved(decoration => this._removeDecoration(decoration)));
   }
 
   /**
@@ -120,10 +118,6 @@ export class OverviewRulerRenderer extends Disposable {
   }
 
   public override dispose(): void {
-    for (const decoration of this._decorationElements) {
-      decoration[0].dispose();
-    }
-    this._decorationElements.clear();
     this._canvas?.remove();
     super.dispose();
   }
@@ -220,10 +214,5 @@ export class OverviewRulerRenderer extends Disposable {
       this._refreshDecorations();
       this._animationFrame = undefined;
     });
-  }
-
-  private _removeDecoration(decoration: IInternalDecoration): void {
-    this._decorationElements.get(decoration)?.remove();
-    this._decorationElements.delete(decoration);
   }
 }

--- a/src/browser/Decorations/OverviewRulerRenderer.ts
+++ b/src/browser/Decorations/OverviewRulerRenderer.ts
@@ -150,10 +150,10 @@ export class OverviewRulerRenderer extends Disposable {
 
   private _refreshColorZonePadding(): void {
     this._colorZoneStore.setPadding({
-      full: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.full / 2)),
-      left: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.left / 2)),
-      center: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.center / 2)),
-      right: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * (drawHeight.right / 2))
+      full: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * drawHeight.full),
+      left: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * drawHeight.left),
+      center: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * drawHeight.center),
+      right: Math.floor(this._bufferService.buffers.active.lines.length / (this._canvas.height - 1) * drawHeight.right)
     });
     this._lastKnownBufferLength = this._bufferService.buffers.normal.lines.length;
   }
@@ -196,7 +196,6 @@ export class OverviewRulerRenderer extends Disposable {
     // TODO: Is _decorationElements needed?
 
     this._ctx.fillStyle = zone.color;
-    console.log('zone height', drawHeight[zone.position || 'full']);
     this._ctx.fillRect(
       /* x */ drawX[zone.position || 'full'],
       /* y */ Math.round(

--- a/src/browser/Terminal.test.ts
+++ b/src/browser/Terminal.test.ts
@@ -231,7 +231,7 @@ describe('Terminal', () => {
       });
       term.paste('foo');
     });
-    it('should sanitize \n chars', done => {
+    it('should sanitize \\n chars', done => {
       term.onData(e => {
         assert.equal(e, '\rfoo\rbar\r');
         done();


### PR DESCRIPTION
Fixes #3703

Perf of the problem case when finding in a full buffer:

![image](https://user-images.githubusercontent.com/2193314/161280685-885e221e-58d3-4d25-beac-12b53ddd08fa.png)
