### PR TITLE
Fix Alt-N/E/U handling in macOS, handle Alt-Shift-Letter

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1097,7 +1097,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     }
 
     // Ignore composing with Alt key on Mac when macOptionIsMeta is enabled
-    const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey
+    const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey;
 
     if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
       if (this.buffer.ybase !== this.buffer.ydisp) {

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1096,14 +1096,17 @@ export class Terminal extends CoreTerminal implements ITerminal {
       return false;
     }
 
-    if (!this._compositionHelper!.keydown(event)) {
+    // Ignore composing with Alt key on Mac when macOptionIsMeta is enabled
+    const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey
+
+    if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
       if (this.buffer.ybase !== this.buffer.ydisp) {
         this._bufferService.scrollToBottom();
       }
       return false;
     }
 
-    if (event.key === 'Dead' || event.key === 'AltGraph') {
+    if (!shouldIgnoreComposition && (event.key === 'Dead' || event.key === 'AltGraph')) {
       this._unprocessedDeadKey = true;
     }
 

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -50,6 +50,7 @@ export interface IKeyboardEvent {
   keyCode: number;
   key: string;
   type: string;
+  code: string;
 }
 
 export interface IScrollEvent {

--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -13,6 +13,7 @@ function testEvaluateKeyboardEvent(partialEvent: {
   shiftKey?: boolean;
   metaKey?: boolean;
   keyCode?: number;
+  code?: string;
   key?: string;
   type?: string;
 }, partialOptions: {
@@ -26,6 +27,7 @@ function testEvaluateKeyboardEvent(partialEvent: {
     shiftKey: partialEvent.shiftKey || false,
     metaKey: partialEvent.metaKey || false,
     keyCode: partialEvent.keyCode !== undefined ? partialEvent.keyCode : 0,
+    code: partialEvent.code || '',
     key: partialEvent.key || '',
     type: partialEvent.type || ''
   };

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -354,7 +354,23 @@ export function evaluateKeyboardEvent(
           result.key = C0.ESC + key;
         } else if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           const keyCode = ev.ctrlKey ? ev.keyCode - 64 : ev.keyCode + 32;
-          result.key = C0.ESC + String.fromCharCode(keyCode);
+          let keyString = String.fromCharCode(keyCode);
+          if (ev.shiftKey) {
+            keyString = keyString.toUpperCase();
+          }
+          result.key = C0.ESC + keyString;
+        } else if (ev.key === 'Dead' && ev.code.startsWith('Key')) {
+          // Reference: https://github.com/xtermjs/xterm.js/issues/3725
+          // Alt will produce a "dead key" (initate composition) with some
+          // of the letters in US layout (e.g. N/E/U).
+          // It's safe to match against Key* since no other `code` values begin with "Key".
+          // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values#code_values_on_mac
+          let keyString = ev.code.slice(3, 4);
+          if (!ev.shiftKey) {
+            keyString = keyString.toLowerCase();
+          }
+          result.key = C0.ESC + keyString;
+          result.cancel = true;
         }
       } else if (isMac && !ev.altKey && !ev.ctrlKey && !ev.shiftKey && ev.metaKey) {
         if (ev.keyCode === 65) { // cmd + a


### PR DESCRIPTION
Fixes #3725 

* Ignore Alt "dead key" event when `macOptionIsMeta` is set.
* Use `event.code` instead of `event.keyCode` to figure out the real key pressed.
* Handle Alt-Shift (send ESC + uppercase letter)