### PR TITLE
addon-web-links: strip trailing closing parenthesis

### DIFF
--- a/addons/xterm-addon-web-links/src/WebLinksAddon.ts
+++ b/addons/xterm-addon-web-links/src/WebLinksAddon.ts
@@ -15,7 +15,7 @@ const ipClause = '((\\d{1,3}\\.){3}\\d{1,3})';
 const localHostClause = '(localhost)';
 const portClause = '(:\\d{1,5})';
 const hostClause = '((' + domainBodyClause + '\\.' + tldClause + ')|' + ipClause + '|' + localHostClause + ')' + portClause + '?';
-const pathCharacterSet = '(\\/[\\/\\w\\.\\-%~:+@]*)*([^:"\'\\s])';
+const pathCharacterSet = '(\\/[\\/\\w\\.\\-%~:+@]*)*([^:"\'\\s)])';
 const pathClause = '(' + pathCharacterSet + ')?';
 const queryStringHashFragmentCharacterSet = '[0-9\\w\\[\\]\\(\\)\\/\\?\\!#@$%&\'*+,:;~\\=\\.\\-]*';
 const queryStringClause = '(\\?' + queryStringHashFragmentCharacterSet + ')?';


### PR DESCRIPTION
This fixes link selection in markdown documents.

I've tested the fix in the demo server with the following markdown document:

```markdown
[google](http://google.com)
```
Without the fix link navigation won't work because the trailing parenthesis is included in the selection.
