### PR TITLE
Fix a typo in serialize addon test

### DIFF
--- a/addons/xterm-addon-serialize/test/SerializeAddon.api.ts
+++ b/addons/xterm-addon-serialize/test/SerializeAddon.api.ts
@@ -83,7 +83,7 @@ describe('SerializeAddon', () => {
     const buffer3 = await page.evaluate(`inspectBuffer(term.buffer.normal);`);
 
     await page.evaluate(`term.reset();`);
-    await writeRawSync(page, '1234567890n12345');
+    await writeRawSync(page, '123456789012345');
     const buffer4 = await page.evaluate(`inspectBuffer(term.buffer.normal);`);
 
     assert.throw(() => {


### PR DESCRIPTION
Fix a typo in serialize addon test.

The two line in this test are mean to represent exact content with line wrap different only would be detected by test utilities.

But due to a typo. The two lines end up having different visible text content.

This PR fix such issue.