### PR TITLE
clear all markers

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1325,7 +1325,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       // Don't clear if it's already clear
       return;
     }
-    this.buffer.clearAllMarkers(0);
+    this.buffer.clearAllMarkers();
     this.buffer.lines.set(0, this.buffer.lines.get(this.buffer.ybase + this.buffer.y)!);
     this.buffer.lines.length = 1;
     this.buffer.ydisp = 0;

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -601,16 +601,13 @@ export class Buffer implements IBuffer {
   }
 
   /**
-   * Clears markers on all lines except for those on a particular line.
-   * @param excludeY The line to exclude.
+   * Clears markers on all lines
    */
-  public clearAllMarkers(excludeY: number): void {
+  public clearAllMarkers(): void {
     this._isClearing = true;
     for (let i = 0; i < this.markers.length; i++) {
-      if (this.markers[i].line !== excludeY) {
-        this.markers[i].dispose();
-        this.markers.splice(i--, 1);
-      }
+      this.markers[i].dispose();
+      this.markers.splice(i--, 1);
     }
     this._isClearing = false;
   }
@@ -671,7 +668,7 @@ export class Buffer implements IBuffer {
 export class BufferStringIterator implements IBufferStringIterator {
   private _current: number;
 
-  constructor (
+  constructor(
     private _buffer: IBuffer,
     private _trimRight: boolean,
     private _startIndex: number = 0,

--- a/src/common/buffer/Types.d.ts
+++ b/src/common/buffer/Types.d.ts
@@ -10,7 +10,7 @@ import { IEvent } from 'common/EventEmitter';
 export type BufferIndex = [number, number];
 
 export interface IBufferStringIteratorResult {
-  range: {first: number, last: number};
+  range: { first: number, last: number };
   content: string;
 }
 
@@ -46,7 +46,7 @@ export interface IBuffer {
   getWhitespaceCell(attr?: IAttributeData): ICellData;
   addMarker(y: number): IMarker;
   clearMarkers(y: number): void;
-  clearAllMarkers(excludeY: number): void;
+  clearAllMarkers(): void;
 }
 
 export interface IBufferSet extends IDisposable {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/151645 and reverts the changes meant to fix https://github.com/microsoft/vscode/issues/144142 without causing that issue again because the actual fix is now in https://github.com/microsoft/vscode/blob/2d4988b53b9d7d8c309ffe9f7ef457b4b8fd672e/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts#L397-L404