### PR TITLE
Add Render to list of xterm.js users

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**WiTTY**](https://github.com/syssecfsu/witty): Web-based interactive terminal emulator that allows users to easily record, share, and replay console sessions.
 - [**libv86 Terminal Forwarding**](https://github.com/hello-smile6/libv86-terminal-forwarding): Peer-to-peer SSH for the web, using WebRTC via [Bugout](https://github.com/chr15m/bugout) for data transfer and [v86](https://github.com/copy/v86) for web-based virtualization.
 - [**hack.courses**](https://hack.courses): Interactive Linux and command-line classes using xterm.js to expose a real terminal available for everyone.
+- [**Render**](https://render.com): Platform-as-a-service for your apps, websites, and databases using xterm.js to provide a command prompt for user containers and for streaming build and runtime logs.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Note: Please add any new contributions to the end of the list only.


### PR DESCRIPTION
Hi folks- Copying this over from an erroneous [PR](https://github.com/xtermjs/xtermjs.org/pull/177) I made on the xtermjs.org website repo:

> Hello xterm.js folks- Thanks for creating and maintaining this great project. This PR adds [Render](https://render.com) to the list of xterm.js real world uses.
> 
> We have been using xterm.js for a few years to give our users a command prompt for their deployed container. We also use it to show streaming build and runtime logs for user services.
> 
> <img width="1286" alt="CleanShot 2022-06-24 at 10 41 48@2x" src="https://user-images.githubusercontent.com/275734/175614250-2ae45e61-62bf-4861-a647-6de96e010989.png">