### PR TITLE
Add Go SSH Web Client to list of xterm users

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**hack.courses**](https://hack.courses): Interactive Linux and command-line classes using xterm.js to expose a real terminal available for everyone.
 - [**Render**](https://render.com): Platform-as-a-service for your apps, websites, and databases using xterm.js to provide a command prompt for user containers and for streaming build and runtime logs.
 - [**CloudTTY**](https://github.com/cloudtty/cloudtty): A Friendly Kubernetes CloudShell (Web Terminal).
+- [**Go SSH Web Client**](https://github.com/wuchihsu/go-ssh-web-client): A simple SSH web client using Go, WebSocket and Xterm.js.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Note: Please add any new contributions to the end of the list only.


### PR DESCRIPTION
[Go SSH Web Client](https://github.com/wuchihsu/go-ssh-web-client) is a simple SSH web client using Go, WebSocket and Xterm.js. It is my small project, could it be added to the list? Thanks.