### PR TITLE
Support setting extended ansi colors (16-255)

### DIFF
--- a/src/browser/ColorManager.test.ts
+++ b/src/browser/ColorManager.test.ts
@@ -5,7 +5,7 @@
 
 import jsdom = require('jsdom');
 import { assert } from 'chai';
-import { ColorManager } from 'browser/ColorManager';
+import { ColorManager, DEFAULT_ANSI_COLORS } from 'browser/ColorManager';
 
 describe('ColorManager', () => {
   let cm: ColorManager;
@@ -308,6 +308,25 @@ describe('ColorManager', () => {
       assert.equal(cm.colors.background.css, '#0000FF');
       // FG reverts back to default
       assert.equal(cm.colors.foreground.css, '#ffffff');
+    });
+
+    it('should set all extended ansi colors in reverse order', () => {
+      cm.setTheme({
+        extendedAnsi: DEFAULT_ANSI_COLORS.map(a => a.css).slice().reverse()
+      });
+
+      for (let ansiColor = 16; ansiColor <= 255; ansiColor++){
+        assert.equal(cm.colors.ansi[ansiColor].css, DEFAULT_ANSI_COLORS[255 + 16 - ansiColor].css);
+      }
+    });
+
+    it('should set one extended ansi colors and keep the other default', () => {
+      cm.setTheme({
+        extendedAnsi: [ '#ffffff' ]
+      });
+
+      assert.equal(cm.colors.ansi[16].css, '#ffffff');
+      assert.equal(cm.colors.ansi[17].css, DEFAULT_ANSI_COLORS[17].css);
     });
   });
 });

--- a/src/browser/ColorManager.ts
+++ b/src/browser/ColorManager.ts
@@ -163,8 +163,9 @@ export class ColorManager implements IColorManager {
     this.colors.ansi[14] = this._parseColor(theme.brightCyan, DEFAULT_ANSI_COLORS[14]);
     this.colors.ansi[15] = this._parseColor(theme.brightWhite, DEFAULT_ANSI_COLORS[15]);
     if (theme.extendedAnsi) {
-      for (let ansiColor = 0; ansiColor < theme.extendedAnsi.length && ansiColor <= 255 - 16; ansiColor++) {
-        this.colors.ansi[ansiColor + 16] = this._parseColor(theme.extendedAnsi[ansiColor], DEFAULT_ANSI_COLORS[ansiColor + 16]);
+      const colorCount = Math.max(theme.extendedAnsi.length + 16, 256);
+      for (let i = 16; i < colorCount; i++) {
+        this.colors.ansi[i] = this._parseColor(theme.extendedAnsi[i - 16], DEFAULT_ANSI_COLORS[i]);
       }
     }
     // Clear our the cache

--- a/src/browser/ColorManager.ts
+++ b/src/browser/ColorManager.ts
@@ -162,6 +162,11 @@ export class ColorManager implements IColorManager {
     this.colors.ansi[13] = this._parseColor(theme.brightMagenta, DEFAULT_ANSI_COLORS[13]);
     this.colors.ansi[14] = this._parseColor(theme.brightCyan, DEFAULT_ANSI_COLORS[14]);
     this.colors.ansi[15] = this._parseColor(theme.brightWhite, DEFAULT_ANSI_COLORS[15]);
+    if (theme.extendedAnsi) {
+      for (let ansiColor = 0; ansiColor < theme.extendedAnsi.length && ansiColor <= 255 - 16; ansiColor++) {
+        this.colors.ansi[ansiColor + 16] = this._parseColor(theme.extendedAnsi[ansiColor], DEFAULT_ANSI_COLORS[ansiColor + 16]);
+      }
+    }
     // Clear our the cache
     this._contrastCache.clear();
     this._updateRestoreColors();

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -276,6 +276,7 @@ export interface ITheme {
   brightMagenta?: string;
   brightCyan?: string;
   brightWhite?: string;
+  extendedAnsi?: string[];
 }
 
 export const IUnicodeService = createDecorator<IUnicodeService>('UnicodeService');

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -267,6 +267,8 @@ declare module 'xterm-headless' {
     brightCyan?: string;
     /** ANSI bright white (eg. `\x1b[1;37m`) */
     brightWhite?: string;
+    /** ANSI extended colors (16-255) */
+    extendedAnsi?: string[];
   }
 
   /**

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -322,6 +322,8 @@ declare module 'xterm' {
     brightCyan?: string;
     /** ANSI bright white (eg. `\x1b[1;37m`) */
     brightWhite?: string;
+    /** ANSI extended colors (16-255) */
+    extendedAnsi?: string[];
   }
 
   /**
@@ -845,7 +847,7 @@ declare module 'xterm' {
      * Adds an event listener for when data has been parsed by the terminal,
      * after {@link write} is called. This event is useful to listen for any
      * changes in the buffer.
-     * 
+     *
      * This fires at most once per frame, after data parsing completes. Note
      * that this can fire when there are still writes pending if there is a lot
      * of data.


### PR DESCRIPTION
The API is slightly different than proposed in #3601. It is aligned with the current ITheme variables and taking a string[] array of hex values. 

Fixes #3601