### PR TITLE
Fix devcontainer docker build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14-buster
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -8,19 +8,13 @@ RUN apt-get update \
 # Verify git and process tools are installed
 RUN apt-get install -y git procps
 
-# Install yarn, puppeteer deps
+# Install yarn
 RUN apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
     && apt-get -y install --no-install-recommends \
-       yarn fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
-       # https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322921352
-       gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-       libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-       libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-       libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-       ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+       yarn
 
 # Clean up
 RUN apt-get autoremove -y \


### PR DESCRIPTION
Moves the devcontainer from Debian stretch to Debian buster. 
* The node:14 docker container already moved to Debian buster some time ago, but not all required packages are available so it was failing to build the devcontainer completely. 
* Removes the puppeteer dependencies instead of finding replacements. 

Reference: https://github.com/nodejs/docker-node/commit/4f1d6a3875d1833ef57d87ed1999c41dbe6bd82c