### PR TITLE
Fix memory leak

### DIFF
--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -6,7 +6,7 @@
 import { GlyphRenderer } from './GlyphRenderer';
 import { LinkRenderLayer } from './renderLayer/LinkRenderLayer';
 import { CursorRenderLayer } from './renderLayer/CursorRenderLayer';
-import { acquireCharAtlas } from './atlas/CharAtlasCache';
+import { acquireCharAtlas, removeTerminalFromCache } from './atlas/CharAtlasCache';
 import { WebglCharAtlas } from './atlas/WebglCharAtlas';
 import { RectangleRenderer } from './RectangleRenderer';
 import { IWebGL2RenderingContext } from './Types';
@@ -112,6 +112,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
       l.dispose();
     }
     this._canvas.parentElement?.removeChild(this._canvas);
+    removeTerminalFromCache(this._terminal);
     super.dispose();
   }
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/155232

After doing v8 heap profiling I found out that using terminal references
in the atlas cache makes it impossible for js to garbage collect the
terminals after disposal, causing both gpu and ram memory leak, therefore
switching to a simpler solution by just using an immutable id to break
the reference chain.