### PR TITLE
Don't overlap the atlas ontop of options

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -45,7 +45,6 @@ pre {
 
 #container {
     display: flex;
-    height: 75vh;
 }
 #grid {
     flex: 1;


### PR DESCRIPTION
This would prevent mouse input in some options in narrow screens