### PR TITLE
Apply row/col changes from xterm to xterm-headless

### DIFF
--- a/src/headless/public/Terminal.test.ts
+++ b/src/headless/public/Terminal.test.ts
@@ -125,13 +125,10 @@ describe('Headless API Tests', function (): void {
     });
     it('get options', () => {
       const options: ITerminalOptions = term.options;
-      strictEqual(options.cols, 80);
-      strictEqual(options.rows, 24);
+      strictEqual(options.lineHeight, 1);
+      strictEqual(options.cursorWidth, 1);
     });
     it('set options', async () => {
-      const options: ITerminalOptions = term.options;
-      throws(() => options.cols = 40);
-      throws(() => options.rows = 20);
       term.options.scrollback = 1;
       strictEqual(term.options.scrollback, 1);
       term.options= {

--- a/src/headless/public/Terminal.ts
+++ b/src/headless/public/Terminal.ts
@@ -7,11 +7,10 @@ import { IEvent } from 'common/EventEmitter';
 import { BufferNamespaceApi } from 'common/public/BufferNamespaceApi';
 import { ParserApi } from 'common/public/ParserApi';
 import { UnicodeApi } from 'common/public/UnicodeApi';
-import { IBufferNamespace as IBufferNamespaceApi, IMarker, IModes, IParser, ITerminalAddon, IUnicodeHandling, Terminal as ITerminalApi } from 'xterm-headless';
+import { IBufferNamespace as IBufferNamespaceApi, IMarker, IModes, IParser, ITerminalAddon, ITerminalInitOnlyOptions, IUnicodeHandling, Terminal as ITerminalApi } from 'xterm-headless';
 import { Terminal as TerminalCore } from 'headless/Terminal';
 import { AddonManager } from 'common/public/AddonManager';
 import { ITerminalOptions } from 'common/Types';
-
 /**
  * The set of options that only have an effect when set in the Terminal constructor.
  */
@@ -24,7 +23,7 @@ export class Terminal implements ITerminalApi {
   private _buffer: BufferNamespaceApi | undefined;
   private _publicOptions: ITerminalOptions;
 
-  constructor(options?: ITerminalOptions) {
+  constructor(options?: ITerminalOptions & ITerminalInitOnlyOptions) {
     this._core = new TerminalCore(options);
     this._addonManager = new AddonManager();
 

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -49,11 +49,6 @@ declare module 'xterm-headless' {
     convertEol?: boolean;
 
     /**
-     * The number of columns in the terminal.
-     */
-    cols?: number;
-
-    /**
      * Whether the cursor blinks.
      */
     cursorBlink?: boolean;
@@ -146,11 +141,6 @@ declare module 'xterm-headless' {
     rightClickSelectsWord?: boolean;
 
     /**
-     * The number of rows in the terminal.
-     */
-    rows?: number;
-
-    /**
      * Whether screen reader support is enabled. When on this will expose
      * supporting elements in the DOM to support NVDA on Windows and VoiceOver
      * on macOS.
@@ -208,6 +198,22 @@ declare module 'xterm-headless' {
      * All features are disabled by default for security reasons.
      */
     windowOptions?: IWindowOptions;
+  }
+
+  /**
+   * An object containing additional options for the terminal that can only be
+   * set on start up.
+   */
+  export interface ITerminalInitOnlyOptions {
+    /**
+     * The number of columns in the terminal.
+     */
+    cols?: number;
+
+    /**
+     * The number of rows in the terminal.
+     */
+    rows?: number;
   }
 
   /**
@@ -558,7 +564,7 @@ declare module 'xterm-headless' {
      *
      * @param options An object containing a set of options.
      */
-    constructor(options?: ITerminalOptions);
+    constructor(options?: ITerminalOptions & ITerminalInitOnlyOptions);
 
     /**
      * Adds an event listener for when the bell is triggered.

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -14,7 +14,7 @@ declare module 'xterm-headless' {
   export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
 
   /**
-   * An object containing start up options for the terminal.
+   * An object containing options for the terminal.
    */
   export interface ITerminalOptions {
     /**


### PR DESCRIPTION
Pulled this out of closed #3968. 
Align xterm with xterm-headless after https://github.com/xtermjs/xterm.js/pull/3960.