### PR TITLE
Remove electron renderer target from ligatures addon

### DIFF
--- a/addons/xterm-addon-ligatures/webpack.config.js
+++ b/addons/xterm-addon-ligatures/webpack.config.js
@@ -11,7 +11,6 @@ const mainFile = 'xterm-addon-ligatures.js';
 module.exports = {
   entry: `./out/${addonName}.js`,
   devtool: 'source-map',
-  target: 'electron-renderer',
   module: {
     rules: [
       {


### PR DESCRIPTION
This causes global to be required which is not available in sandboxed electron
renderers

See microsoft/vscode#157008