### PR TITLE
ITerminalOptions: Make fields required

### DIFF
--- a/addons/xterm-addon-canvas/src/atlas/CharAtlasCache.ts
+++ b/addons/xterm-addon-canvas/src/atlas/CharAtlasCache.ts
@@ -8,7 +8,7 @@ import { BaseCharAtlas } from './BaseCharAtlas';
 import { DynamicCharAtlas } from './DynamicCharAtlas';
 import { ICharAtlasConfig } from './Types';
 import { IColorSet } from 'browser/Types';
-import { ITerminalOptions } from 'common/services/Services';
+import { ITerminalOptions } from 'xterm';
 
 interface ICharAtlasCacheEntry {
   atlas: BaseCharAtlas;
@@ -25,7 +25,7 @@ const charAtlasCache: ICharAtlasCacheEntry[] = [];
  * one that is in use by another terminal.
  */
 export function acquireCharAtlas(
-  options: ITerminalOptions,
+  options: Required<ITerminalOptions>,
   rendererId: number,
   colors: IColorSet,
   scaledCharWidth: number,

--- a/addons/xterm-addon-canvas/src/atlas/CharAtlasUtils.ts
+++ b/addons/xterm-addon-canvas/src/atlas/CharAtlasUtils.ts
@@ -6,9 +6,9 @@
 import { ICharAtlasConfig } from './Types';
 import { DEFAULT_COLOR } from 'common/buffer/Constants';
 import { IColorSet, IPartialColorSet } from 'browser/Types';
-import { ITerminalOptions } from 'common/services/Services';
+import { ITerminalOptions } from 'xterm';
 
-export function generateConfig(scaledCharWidth: number, scaledCharHeight: number, options: ITerminalOptions, colors: IColorSet): ICharAtlasConfig {
+export function generateConfig(scaledCharWidth: number, scaledCharHeight: number, options: Required<ITerminalOptions>, colors: IColorSet): ICharAtlasConfig {
   // null out some fields that don't matter
   const clonedColors: IPartialColorSet = {
     foreground: colors.foreground,

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -552,18 +552,18 @@ export class WebglRenderer extends Disposable implements IRenderer {
     // Calculate the scaled cell height, if lineHeight is _not_ 1, the resulting value will be
     // floored since lineHeight can never be lower then 1, this guarentees the scaled cell height
     // will always be larger than scaled char height.
-    this.dimensions.scaledCellHeight = Math.floor(this.dimensions.scaledCharHeight * this._terminal.options.lineHeight!);
+    this.dimensions.scaledCellHeight = Math.floor(this.dimensions.scaledCharHeight * this._terminal.options.lineHeight);
 
     // Calculate the y offset within a cell that glyph should draw at in order for it to be centered
     // correctly within the cell.
     this.dimensions.scaledCharTop = this._terminal.options.lineHeight === 1 ? 0 : Math.round((this.dimensions.scaledCellHeight - this.dimensions.scaledCharHeight) / 2);
 
     // Calculate the scaled cell width, taking the letterSpacing into account.
-    this.dimensions.scaledCellWidth = this.dimensions.scaledCharWidth + Math.round(this._terminal.options.letterSpacing!);
+    this.dimensions.scaledCellWidth = this.dimensions.scaledCharWidth + Math.round(this._terminal.options.letterSpacing);
 
     // Calculate the x offset with a cell that text should draw from in order for it to be centered
     // correctly within the cell.
-    this.dimensions.scaledCharLeft = Math.floor(this._terminal.options.letterSpacing! / 2);
+    this.dimensions.scaledCharLeft = Math.floor(this._terminal.options.letterSpacing / 2);
 
     // Recalculate the canvas dimensions, the scaled dimensions define the actual number of pixel in
     // the canvas

--- a/addons/xterm-addon-webgl/src/atlas/CharAtlasUtils.ts
+++ b/addons/xterm-addon-webgl/src/atlas/CharAtlasUtils.ts
@@ -32,21 +32,21 @@ export function generateConfig(scaledCellWidth: number, scaledCellHeight: number
     contrastCache: colors.contrastCache
   };
   return {
-    customGlyphs: terminal.options.customGlyphs!,
+    customGlyphs: terminal.options.customGlyphs,
     devicePixelRatio: window.devicePixelRatio,
-    letterSpacing: terminal.options.letterSpacing!,
-    lineHeight: terminal.options.lineHeight!,
+    letterSpacing: terminal.options.letterSpacing,
+    lineHeight: terminal.options.lineHeight,
     scaledCellWidth,
     scaledCellHeight,
     scaledCharWidth,
     scaledCharHeight,
-    fontFamily: terminal.options.fontFamily!,
-    fontSize: terminal.options.fontSize!,
-    fontWeight: terminal.options.fontWeight as FontWeight,
-    fontWeightBold: terminal.options.fontWeightBold as FontWeight,
-    allowTransparency: terminal.options.allowTransparency!,
-    drawBoldTextInBrightColors: terminal.options.drawBoldTextInBrightColors!,
-    minimumContrastRatio: terminal.options.minimumContrastRatio!,
+    fontFamily: terminal.options.fontFamily,
+    fontSize: terminal.options.fontSize,
+    fontWeight: terminal.options.fontWeight,
+    fontWeightBold: terminal.options.fontWeightBold,
+    allowTransparency: terminal.options.allowTransparency,
+    drawBoldTextInBrightColors: terminal.options.drawBoldTextInBrightColors,
+    minimumContrastRatio: terminal.options.minimumContrastRatio,
     colors: clonedColors
   };
 }

--- a/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
@@ -213,7 +213,7 @@ export class CursorRenderLayer extends BaseRenderLayer {
   private _renderBarCursor(terminal: Terminal, x: number, y: number, cell: ICellData): void {
     this._ctx.save();
     this._ctx.fillStyle = this._colors.cursor.css;
-    this._fillLeftLineAtCell(x, y, terminal.options.cursorWidth!);
+    this._fillLeftLineAtCell(x, y, terminal.options.cursorWidth);
     this._ctx.restore();
   }
 

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -343,7 +343,7 @@ function initOptions(term: TerminalType): void {
   ];
   const stringOptions = {
     cursorStyle: ['block', 'underline', 'bar'],
-    fastScrollModifier: ['alt', 'ctrl', 'shift', undefined],
+    fastScrollModifier: ['none', 'alt', 'ctrl', 'shift'],
     fontFamily: null,
     fontWeight: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
     fontWeightBold: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -141,7 +141,7 @@ export class MockTerminal implements ITerminal {
   public renderer!: IRenderer;
   public linkifier2!: ILinkifier2;
   public isFocused!: boolean;
-  public options: ITerminalOptions = {};
+  public options!: Required<ITerminalOptions>;
   public element!: HTMLElement;
   public screenElement!: HTMLElement;
   public rowContainer!: HTMLElement;

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -16,7 +16,7 @@ export interface ITerminal extends IPublicTerminal, ICoreTerminal {
   browser: IBrowser;
   buffer: IBuffer;
   viewport: IViewport | undefined;
-  options: ITerminalOptions;
+  options: Required<ITerminalOptions>;
   linkifier2: ILinkifier2;
 
   onBlur: IEvent<void>;

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -24,7 +24,7 @@ export class Terminal implements ITerminalApi {
   private _addonManager: AddonManager;
   private _parser: IParser | undefined;
   private _buffer: BufferNamespaceApi | undefined;
-  private _publicOptions: ITerminalOptions;
+  private _publicOptions: Required<ITerminalOptions>;
 
   constructor(options?: ITerminalOptions) {
     this._core = new TerminalCore(options);
@@ -123,7 +123,7 @@ export class Terminal implements ITerminalApi {
       wraparoundMode: m.wraparound
     };
   }
-  public get options(): ITerminalOptions {
+  public get options(): Required<ITerminalOptions> {
     return this._publicOptions;
   }
   public set options(options: ITerminalOptions) {

--- a/src/common/CoreTerminal.ts
+++ b/src/common/CoreTerminal.ts
@@ -88,7 +88,7 @@ export abstract class CoreTerminal extends Disposable implements ICoreTerminal {
   public get cols(): number { return this._bufferService.cols; }
   public get rows(): number { return this._bufferService.rows; }
   public get buffers(): IBufferSet { return this._bufferService.buffers; }
-  public get options(): ITerminalOptions { return this.optionsService.options; }
+  public get options(): Required<ITerminalOptions> { return this.optionsService.options; }
   public set options(options: ITerminalOptions) {
     for (const key in options) {
       this.optionsService.options[key] = options[key];

--- a/src/common/TestUtils.test.ts
+++ b/src/common/TestUtils.test.ts
@@ -121,8 +121,8 @@ export class MockLogService implements ILogService {
 
 export class MockOptionsService implements IOptionsService {
   public serviceBrand: any;
-  public readonly rawOptions: ITerminalOptions = clone(DEFAULT_OPTIONS);
-  public options: ITerminalOptions = this.rawOptions;
+  public readonly rawOptions: Required<ITerminalOptions> = clone(DEFAULT_OPTIONS);
+  public options: Required<ITerminalOptions> = this.rawOptions;
   public onOptionChange: IEvent<string> = new EventEmitter<string>().event;
   constructor(testOptions?: Partial<ITerminalOptions>) {
     if (testOptions) {

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -8,7 +8,7 @@ import { EventEmitter, IEvent } from 'common/EventEmitter';
 import { isMac } from 'common/Platform';
 import { CursorStyle } from 'common/Types';
 
-export const DEFAULT_OPTIONS: Readonly<ITerminalOptions> = {
+export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   cols: 80,
   rows: 24,
   cursorBlink: false,
@@ -45,7 +45,7 @@ export const DEFAULT_OPTIONS: Readonly<ITerminalOptions> = {
   convertEol: false,
   termName: 'xterm',
   cancelEvents: false,
-  overviewRulerWidth: undefined
+  overviewRulerWidth: 0
 };
 
 const FONT_WEIGHT_OPTIONS: Extract<FontWeight, string>[] = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
@@ -53,8 +53,8 @@ const FONT_WEIGHT_OPTIONS: Extract<FontWeight, string>[] = ['normal', 'bold', '1
 export class OptionsService implements IOptionsService {
   public serviceBrand: any;
 
-  public readonly rawOptions: ITerminalOptions;
-  public options: ITerminalOptions;
+  public readonly rawOptions: Required<ITerminalOptions>;
+  public options: Required<ITerminalOptions>;
 
   private _onOptionChange = new EventEmitter<string>();
   public get onOptionChange(): IEvent<string> { return this._onOptionChange.event; }

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -194,8 +194,8 @@ export interface IOptionsService {
    * single options without any validation as we trust TypeScript to enforce correct usage
    * internally.
    */
-  readonly rawOptions: Readonly<ITerminalOptions>;
-  readonly options: ITerminalOptions;
+  readonly rawOptions: Required<ITerminalOptions>;
+  readonly options: Required<ITerminalOptions>;
 
   readonly onOptionChange: IEvent<string>;
 }
@@ -204,40 +204,40 @@ export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '50
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
 
 export interface ITerminalOptions {
-  allowProposedApi: boolean;
-  allowTransparency: boolean;
-  altClickMovesCursor: boolean;
-  cols: number;
-  convertEol: boolean;
-  cursorBlink: boolean;
-  cursorStyle: CursorStyle;
-  cursorWidth: number;
-  customGlyphs: boolean;
-  disableStdin: boolean;
-  drawBoldTextInBrightColors: boolean;
-  fastScrollModifier: 'alt' | 'ctrl' | 'shift' | undefined;
-  fastScrollSensitivity: number;
-  fontSize: number;
-  fontFamily: string;
-  fontWeight: FontWeight;
-  fontWeightBold: FontWeight;
-  letterSpacing: number;
-  lineHeight: number;
-  logLevel: LogLevel;
-  macOptionIsMeta: boolean;
-  macOptionClickForcesSelection: boolean;
-  minimumContrastRatio: number;
-  rightClickSelectsWord: boolean;
-  rows: number;
-  screenReaderMode: boolean;
-  scrollback: number;
-  scrollSensitivity: number;
-  smoothScrollDuration: number;
-  tabStopWidth: number;
-  theme: ITheme;
-  windowsMode: boolean;
-  windowOptions: IWindowOptions;
-  wordSeparator: string;
+  allowProposedApi?: boolean;
+  allowTransparency?: boolean;
+  altClickMovesCursor?: boolean;
+  cols?: number;
+  convertEol?: boolean;
+  cursorBlink?: boolean;
+  cursorStyle?: CursorStyle;
+  cursorWidth?: number;
+  customGlyphs?: boolean;
+  disableStdin?: boolean;
+  drawBoldTextInBrightColors?: boolean;
+  fastScrollModifier?: 'none' | 'alt' | 'ctrl' | 'shift';
+  fastScrollSensitivity?: number;
+  fontSize?: number;
+  fontFamily?: string;
+  fontWeight?: FontWeight;
+  fontWeightBold?: FontWeight;
+  letterSpacing?: number;
+  lineHeight?: number;
+  logLevel?: LogLevel;
+  macOptionIsMeta?: boolean;
+  macOptionClickForcesSelection?: boolean;
+  minimumContrastRatio?: number;
+  rightClickSelectsWord?: boolean;
+  rows?: number;
+  screenReaderMode?: boolean;
+  scrollback?: number;
+  scrollSensitivity?: number;
+  smoothScrollDuration?: number;
+  tabStopWidth?: number;
+  theme?: ITheme;
+  windowsMode?: boolean;
+  windowOptions?: IWindowOptions;
+  wordSeparator?: string;
   overviewRulerWidth?: number;
 
   [key: string]: any;

--- a/src/headless/Terminal.ts
+++ b/src/headless/Terminal.ts
@@ -30,7 +30,7 @@ import { IMarker, ITerminalOptions, ScrollSource } from 'common/Types';
 
 export class Terminal extends CoreTerminal {
   // TODO: We should remove options once components adopt optionsService
-  public get options(): IInitializedTerminalOptions { return this.optionsService.options; }
+  public get options(): Required<IInitializedTerminalOptions> { return this.optionsService.options; }
 
   private _onBell = new EventEmitter<void>();
   public get onBell(): IEvent<void> { return this._onBell.event; }

--- a/src/headless/public/Terminal.ts
+++ b/src/headless/public/Terminal.ts
@@ -21,7 +21,7 @@ export class Terminal implements ITerminalApi {
   private _addonManager: AddonManager;
   private _parser: IParser | undefined;
   private _buffer: BufferNamespaceApi | undefined;
-  private _publicOptions: ITerminalOptions;
+  private _publicOptions: Required<ITerminalOptions>;
 
   constructor(options?: ITerminalOptions & ITerminalInitOnlyOptions) {
     this._core = new TerminalCore(options);
@@ -123,7 +123,7 @@ export class Terminal implements ITerminalApi {
       wraparoundMode: m.wraparound
     };
   }
-  public get options(): ITerminalOptions {
+  public get options(): Required<ITerminalOptions> {
     return this._publicOptions;
   }
   public set options(options: ITerminalOptions) {

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -84,7 +84,7 @@ declare module 'xterm-headless' {
     /**
      * The modifier key hold to multiply scroll speed.
      */
-    fastScrollModifier?: 'alt' | 'ctrl' | 'shift' | undefined;
+    fastScrollModifier?: 'none' | 'alt' | 'ctrl' | 'shift';
 
     /**
      * The spacing in whole pixels between characters.
@@ -538,11 +538,12 @@ declare module 'xterm-headless' {
      * ```typescript
      * console.log(terminal.options.fontSize);
      * ```
+     */
+    get options(): Required<ITerminalOptions>;
+
+    /**
+     * Gets or sets the terminal options. This supports setting multiple options.
      *
-     * @example Set a single option
-     * ```typescript
-     * terminal.options.fontSize = 12;
-     * ```
      *
      * @example Set multiple options
      * ```typescript
@@ -552,7 +553,7 @@ declare module 'xterm-headless' {
      * };
      * ```
      */
-    options: ITerminalOptions;
+    set options(options: ITerminalOptions);
 
     /**
      * Natural language strings that can be localized.

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -544,6 +544,10 @@ declare module 'xterm-headless' {
     /**
      * Gets or sets the terminal options. This supports setting multiple options.
      *
+     * @example Set a single option
+     * ```typescript
+     * terminal.options.fontSize = 12;
+     * ```
      *
      * @example Set multiple options
      * ```typescript

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -706,6 +706,10 @@ declare module 'xterm' {
     /**
      * Gets or sets the terminal options. This supports setting multiple options.
      *
+     * @example Set a single option
+     * ```typescript
+     * terminal.options.fontSize = 12;
+     * ```
      *
      * @example Set multiple options
      * ```typescript

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -91,7 +91,7 @@ declare module 'xterm' {
     /**
      * The modifier key hold to multiply scroll speed.
      */
-    fastScrollModifier?: 'alt' | 'ctrl' | 'shift' | undefined;
+    fastScrollModifier?: 'none' | 'alt' | 'ctrl' | 'shift';
 
     /**
      * The scroll speed multiplier used for fast scrolling.
@@ -700,11 +700,12 @@ declare module 'xterm' {
      * ```typescript
      * console.log(terminal.options.fontSize);
      * ```
+     */
+    get options(): Required<ITerminalOptions>;
+
+    /**
+     * Gets or sets the terminal options. This supports setting multiple options.
      *
-     * @example Set a single option
-     * ```typescript
-     * terminal.options.fontSize = 12;
-     * ```
      *
      * @example Set multiple options
      * ```typescript
@@ -714,7 +715,7 @@ declare module 'xterm' {
      * };
      * ```
      */
-    options: ITerminalOptions;
+    set options(options: ITerminalOptions);
 
     /**
      * Natural language strings that can be localized.
@@ -1069,7 +1070,7 @@ declare module 'xterm' {
   /**
    * An object representing a range within the viewport of the terminal.
    */
-   export interface IViewportRange {
+  export interface IViewportRange {
     /**
      * The start of the range.
      */


### PR DESCRIPTION
Fixes #3948. Pull request #3982 but the other way around, introducing Required. 

It's still a breaking change though, thanks to the options changes in fastScrollModifier and overviewRulerWidth.