### PR TITLE
Handle Delete in `CompositionHelper`

### DIFF
--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -196,6 +196,8 @@ export class CompositionHelper {
           this._coreService.triggerDataEvent(diff, true);
         } else if (newValue.length < oldValue.length) {
           this._coreService.triggerDataEvent(`${C0.DEL}`, true);
+        } else if ((newValue.length === oldValue.length) && (newValue !== oldValue)) {
+          this._coreService.triggerDataEvent(newValue, true);
         }
 
       }

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -5,6 +5,7 @@
 
 import { IRenderService } from 'browser/services/Services';
 import { IBufferService, ICoreService, IOptionsService } from 'common/services/Services';
+import { C0 } from 'common/data/EscapeSequences';
 
 interface IPosition {
   start: number;
@@ -186,11 +187,17 @@ export class CompositionHelper {
       // Ignore if a composition has started since the timeout
       if (!this._isComposing) {
         const newValue = this._textarea.value;
+
         const diff = newValue.replace(oldValue, '');
-        if (diff.length > 0) {
-          this._dataAlreadySent = diff;
+
+        this._dataAlreadySent = diff;
+
+        if (newValue.length > oldValue.length) {
           this._coreService.triggerDataEvent(diff, true);
+        } else if (newValue.length < oldValue.length) {
+          this._coreService.triggerDataEvent(`${C0.DEL}`, true);
         }
+
       }
     }, 0);
   }


### PR DESCRIPTION
### Details
#### Browser
Tested in chrome on Android device running SDK 12.

#### Version 4.19.0

#### Issue - relates to https://github.com/xtermjs/xterm.js/issues/3600
Deleting characters doesn't work as expected on Android since the `CompositionHelper` expects the diff to have > 1 length if there's a difference.

Steps:
- type: `1`
- tap backspace button


expected:
- character is removed


actual:
- character remains, tapping backspace once more then removes character

Example:
+ single character entry: https://user-images.githubusercontent.com/3418052/183525959-2bb604e9-76cb-4e91-89a8-da14663e7218.mp4
+ many + press & hold to delete: https://user-images.githubusercontent.com/3418052/183528031-449451f7-eb3e-4e59-9970-e52922660ea7.mp4



