### PR TITLE
Only remove padding from restricted powerline chars

### DIFF
--- a/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
+++ b/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
@@ -404,7 +404,7 @@ export class WebglCharAtlas implements IDisposable {
     this._tmpCtx.fillStyle = foregroundColor.css;
 
     // For powerline glyphs left/top padding is excluded (https://github.com/microsoft/vscode/issues/120129)
-    const padding = powerlineGlyph ? 0 : TMP_CANVAS_GLYPH_PADDING * 2;
+    const padding = restrictedPowerlineGlyph ? 0 : TMP_CANVAS_GLYPH_PADDING * 2;
 
     // Draw custom characters if applicable
     let customGlyph = false;


### PR DESCRIPTION
These used to get cut off at the top and bottom:

<img width="175" alt="Screen Shot 2022-08-28 at 1 33 27 pm" src="https://user-images.githubusercontent.com/2193314/187093377-df180214-5394-4fd5-92a2-cfc646ea1c19.png">
