### PR TITLE
Fix ternary in activate call

### DIFF
--- a/src/browser/OscLinkProvider.ts
+++ b/src/browser/OscLinkProvider.ts
@@ -70,7 +70,7 @@ export class OscLinkProvider implements ILinkProvider {
           result.push({
             text,
             range,
-            activate: (e, text) => (linkHandler?.activate(e, text, range) || defaultActivate(e, text)),
+            activate: (e, text) => (linkHandler ? linkHandler.activate(e, text, range) : defaultActivate(e, text)),
             hover: (e, text) => linkHandler?.hover?.(e, text, range),
             leave: (e, text) => linkHandler?.leave?.(e, text, range)
           });


### PR DESCRIPTION
Part of #1134

This was an error causing both activate handlers to trigger