### PR TITLE
protection flag support

### DIFF
--- a/bin/extract_vtfeatures.js
+++ b/bin/extract_vtfeatures.js
@@ -82,14 +82,15 @@ This document lists xterm.js' support of terminal sequences. The sequences are g
 - OSC - Operating System Command: sequence starting with \`ESC ]\` (7bit) or OSC (\`\\x9D\`, 8bit)
 
 Application Program Command (APC), Privacy Message (PM) and Start of String (SOS) are recognized but not supported,
-any sequence of these types will be ignored. They are also not hookable by the API.
+any sequence of these types will be silently ignored. They are also not hookable by the API.
 
-Note that the list only contains sequences implemented in xterm.js' core codebase. Missing sequences are either
-not supported or unstable/experimental. Furthermore addons or integrations can provide additional custom sequences.
+Note that the list only marks sequences implemented in xterm.js' core codebase as supported. Missing sequences are either
+not supported or unstable/experimental. Furthermore addons or integrations can provide additional custom sequences
+(denoted as "External" where known).
 
 To denote the sequences the tables use the same abbreviations as xterm does:
 - \`Ps\`: A single (usually optional) numeric parameter, composed of one or more decimal digits.
-- \`Pm\`: A multiple numeric parameter composed of any number of single numeric parameters, separated by ; character(s),
+- \`Pm\`: Multiple numeric parameters composed of any number of single numeric parameters, separated by ; character(s),
   e.g. \` Ps ; Ps ; ... \`.
 - \`Pt\`: A text parameter composed of printable characters. Note that for most commands with \`Pt\` only
   ASCII printables are specified to work. Additionally the parser will let pass any codepoint greater than C1 as printable.
@@ -334,7 +335,9 @@ const MACRO = [
   // #P[reason] - partial support with a reason as title
   [/#P\[(.*?)\]/g, (s, p1) => `<span title="${p1}" style="text-decoration: underline">Partial</span>`],
   // #B[reason] - supported but broken in a certain way, reason in title
-  [/#B\[(.*?)\]/g, (s, p1) => `<span title="${p1}" style="text-decoration: underline">Broken</span>`]
+  [/#B\[(.*?)\]/g, (s, p1) => `<span title="${p1}" style="text-decoration: underline">Broken</span>`],
+  // #E[notes] - support via external resource, eg. addon
+  [/#E\[(.*?)\]/g, (s, p1) => `<span title="${p1}" style="text-decoration: underline">External</span>`]
 ];
 
 function applyMacros(s) {

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -2177,7 +2177,6 @@ describe('InputHandler', () => {
       coreService.onData(d => sendStack.push(d));
       // DCS $ q " q ST
       await inputHandler.parseP('\x1bP$q"q\x1b\\');
-      console.log(sendStack);
       // default - DECSCA unset (0 or 2)
       assert.deepEqual(sendStack.pop(), '\x1bP1$r0"q\x1b\\');
       // DECSCA 1 - protected set

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -2146,6 +2146,50 @@ describe('InputHandler', () => {
       });
     });
   });
+
+  describe('DECSCA and DECSED/DECSEL', () => {
+    it('default is unprotected', async () => {
+      await inputHandler.parseP('some text');
+      await inputHandler.parseP('\x1b[?2K');
+      assert.deepEqual(getLines(bufferService, 2), ['', '']);
+      await inputHandler.parseP('some text');
+      await inputHandler.parseP('\x1b[?2J');
+      assert.deepEqual(getLines(bufferService, 2), ['', '']);
+    });
+    it('DECSCA 1 with DECSEL', async () => {
+      await inputHandler.parseP('###\x1b[1"qlineerase\x1b[0"q***');
+      await inputHandler.parseP('\x1b[?2K');
+      assert.deepEqual(getLines(bufferService, 2), ['   lineerase', '']);
+      // normal EL works as before
+      await inputHandler.parseP('\x1b[2K');
+      assert.deepEqual(getLines(bufferService, 2), ['', '']);
+    });
+    it('DECSCA 1 with DECSED', async () => {
+      await inputHandler.parseP('###\x1b[1"qdisplayerase\x1b[0"q***');
+      await inputHandler.parseP('\x1b[?2J');
+      assert.deepEqual(getLines(bufferService, 2), ['   displayerase', '']);
+      // normal ED works as before
+      await inputHandler.parseP('\x1b[2J');
+      assert.deepEqual(getLines(bufferService, 2), ['', '']);
+    });
+    it('DECRQSS reports correct DECSCA state', async () => {
+      const sendStack: string[] = [];
+      coreService.onData(d => sendStack.push(d));
+      // DCS $ q " q ST
+      await inputHandler.parseP('\x1bP$q"q\x1b\\');
+      console.log(sendStack);
+      // default - DECSCA unset (0 or 2)
+      assert.deepEqual(sendStack.pop(), '\x1bP1$r0"q\x1b\\');
+      // DECSCA 1 - protected set
+      await inputHandler.parseP('###\x1b[1"q');
+      await inputHandler.parseP('\x1bP$q"q\x1b\\');
+      assert.deepEqual(sendStack.pop(), '\x1bP1$r1"q\x1b\\');
+      // DECSCA 2 - protected reset (same as 0)
+      await inputHandler.parseP('###\x1b[2"q');
+      await inputHandler.parseP('\x1bP$q"q\x1b\\');
+      assert.deepEqual(sendStack.pop(), '\x1bP1$r0"q\x1b\\');  // reported as DECSCA 0
+    });
+  });
 });
 
 

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -3243,7 +3243,8 @@ export class InputHandler extends Disposable implements IInputHandler {
     if (data === '"q') return f(`P1$r${this._curAttrData.isProtected() ? 1 : 0}"q`);
     if (data === '"p') return f(`P1$r61;1"p`);
     if (data === 'r') return f(`P1$r${b.scrollTop + 1};${b.scrollBottom + 1}r`);
-    if (data === 'm') return f(`P1$r0m`);  // FIXME: report real settings instead of 0m
+    // FIXME: report real SGR settings instead of 0m
+    if (data === 'm') return f(`P1$r0m`);
     if (data === ' q') return f(`P1$r${STYLES[opts.cursorStyle] - (opts.cursorBlink ? 1 : 0)} q`);
     return f(`P0$r`);
   }

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -2060,7 +2060,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * | 1005  | Disable UTF-8 Mouse Mode.                               | #N      |
    * | 1006  | Disable SGR Mouse Mode.                                 | #Y      |
    * | 1015  | Disable urxvt Mouse Mode.                               | #N      |
-   * | 1006  | Disable SGR-Pixels Mouse Mode.                          | #Y      |
+   * | 1016  | Disable SGR-Pixels Mouse Mode.                          | #Y      |
    * | 1047  | Use Normal Screen Buffer (clearing screen if in alt).   | #Y      |
    * | 1048  | Restore cursor as in DECRC.                             | #Y      |
    * | 1049  | Use Normal Screen Buffer and restore cursor.            | #Y      |

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -204,9 +204,9 @@ export interface IBufferLine {
   addCodepointToCell(index: number, codePoint: number): void;
   insertCells(pos: number, n: number, ch: ICellData, eraseAttr?: IAttributeData): void;
   deleteCells(pos: number, n: number, fill: ICellData, eraseAttr?: IAttributeData): void;
-  replaceCells(start: number, end: number, fill: ICellData, eraseAttr?: IAttributeData, protect?: boolean): void;
+  replaceCells(start: number, end: number, fill: ICellData, eraseAttr?: IAttributeData, respectProtect?: boolean): void;
   resize(cols: number, fill: ICellData): void;
-  fill(fillCellData: ICellData, protect?: boolean): void;
+  fill(fillCellData: ICellData, respectProtect?: boolean): void;
   copyFrom(line: IBufferLine): void;
   clone(): IBufferLine;
   getTrimmedLength(): number;

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -150,6 +150,7 @@ export interface IAttributeData {
   isItalic(): number;
   isDim(): number;
   isStrikethrough(): number;
+  isProtected(): number;
 
   // color modes
   getFgColorMode(): number;

--- a/src/common/Types.d.ts
+++ b/src/common/Types.d.ts
@@ -203,9 +203,9 @@ export interface IBufferLine {
   addCodepointToCell(index: number, codePoint: number): void;
   insertCells(pos: number, n: number, ch: ICellData, eraseAttr?: IAttributeData): void;
   deleteCells(pos: number, n: number, fill: ICellData, eraseAttr?: IAttributeData): void;
-  replaceCells(start: number, end: number, fill: ICellData, eraseAttr?: IAttributeData): void;
+  replaceCells(start: number, end: number, fill: ICellData, eraseAttr?: IAttributeData, protect?: boolean): void;
   resize(cols: number, fill: ICellData): void;
-  fill(fillCellData: ICellData): void;
+  fill(fillCellData: ICellData, protect?: boolean): void;
   copyFrom(line: IBufferLine): void;
   clone(): IBufferLine;
   getTrimmedLength(): number;

--- a/src/common/buffer/AttributeData.ts
+++ b/src/common/buffer/AttributeData.ts
@@ -46,6 +46,7 @@ export class AttributeData implements IAttributeData {
   public isItalic(): number        { return this.bg & BgFlags.ITALIC; }
   public isDim(): number           { return this.bg & BgFlags.DIM; }
   public isStrikethrough(): number { return this.fg & FgFlags.STRIKETHROUGH; }
+  public isProtected(): number     { return this.bg & BgFlags.PROTECTED; }
 
   // color modes
   public getFgColorMode(): number { return this.fg & Attributes.CM_MASK; }

--- a/src/common/buffer/BufferLine.ts
+++ b/src/common/buffer/BufferLine.ts
@@ -168,6 +168,11 @@ export class BufferLine implements IBufferLine {
     return '';
   }
 
+  /** Get state of protected flag. */
+  public isProtected(index: number): number {
+    return this._data[index * CELL_SIZE + Cell.BG] & BgFlags.PROTECTED;
+  }
+
   /**
    * Load data at `index` into `cell`. This is used to access cells in a way that's more friendly
    * to GC as it significantly reduced the amount of new objects/references needed.
@@ -298,7 +303,24 @@ export class BufferLine implements IBufferLine {
     }
   }
 
-  public replaceCells(start: number, end: number, fillCellData: ICellData, eraseAttr?: IAttributeData): void {
+  public replaceCells(start: number, end: number, fillCellData: ICellData, eraseAttr?: IAttributeData, protect: boolean = false): void {
+    // full branching on protect==true, hopefully getting fast JIT for standard case
+    if (protect) {
+      if (start && this.getWidth(start - 1) === 2 && !this.isProtected(start - 1)) {
+        this.setCellFromCodePoint(start - 1, 0, 1, eraseAttr?.fg || 0, eraseAttr?.bg || 0, eraseAttr?.extended || new ExtendedAttrs());
+      }
+      if (end < this.length && this.getWidth(end - 1) === 2 && !this.isProtected(end)) {
+        this.setCellFromCodePoint(end, 0, 1, eraseAttr?.fg || 0, eraseAttr?.bg || 0, eraseAttr?.extended || new ExtendedAttrs());
+      }
+      while (start < end  && start < this.length) {
+        if (!this.isProtected(start)) {
+          this.setCell(start, fillCellData);
+        }
+        start++;
+      }
+      return;
+    }
+
     // handle fullwidth at start: reset cell one to the left if start is second cell of a wide char
     if (start && this.getWidth(start - 1) === 2) {
       this.setCellFromCodePoint(start - 1, 0, 1, eraseAttr?.fg || 0, eraseAttr?.bg || 0, eraseAttr?.extended || new ExtendedAttrs());
@@ -352,7 +374,16 @@ export class BufferLine implements IBufferLine {
   }
 
   /** fill a line with fillCharData */
-  public fill(fillCellData: ICellData): void {
+  public fill(fillCellData: ICellData, protect: boolean = false): void {
+    // full branching on protect==true, hopefully getting fast JIT for standard case
+    if (protect) {
+      for (let i = 0; i < this.length; ++i) {
+        if (!this.isProtected(i)) {
+          this.setCell(i, fillCellData);
+        }
+      }
+      return;
+    }
     this._combined = {};
     this._extendedAttrs = {};
     for (let i = 0; i < this.length; ++i) {

--- a/src/common/buffer/BufferLine.ts
+++ b/src/common/buffer/BufferLine.ts
@@ -303,9 +303,9 @@ export class BufferLine implements IBufferLine {
     }
   }
 
-  public replaceCells(start: number, end: number, fillCellData: ICellData, eraseAttr?: IAttributeData, protect: boolean = false): void {
-    // full branching on protect==true, hopefully getting fast JIT for standard case
-    if (protect) {
+  public replaceCells(start: number, end: number, fillCellData: ICellData, eraseAttr?: IAttributeData, respectProtect: boolean = false): void {
+    // full branching on respectProtect==true, hopefully getting fast JIT for standard case
+    if (respectProtect) {
       if (start && this.getWidth(start - 1) === 2 && !this.isProtected(start - 1)) {
         this.setCellFromCodePoint(start - 1, 0, 1, eraseAttr?.fg || 0, eraseAttr?.bg || 0, eraseAttr?.extended || new ExtendedAttrs());
       }
@@ -374,9 +374,9 @@ export class BufferLine implements IBufferLine {
   }
 
   /** fill a line with fillCharData */
-  public fill(fillCellData: ICellData, protect: boolean = false): void {
-    // full branching on protect==true, hopefully getting fast JIT for standard case
-    if (protect) {
+  public fill(fillCellData: ICellData, respectProtect: boolean = false): void {
+    // full branching on respectProtect==true, hopefully getting fast JIT for standard case
+    if (respectProtect) {
       for (let i = 0; i < this.length; ++i) {
         if (!this.isProtected(i)) {
           this.setCell(i, fillCellData);

--- a/src/common/buffer/Constants.ts
+++ b/src/common/buffer/Constants.ts
@@ -123,11 +123,12 @@ export const enum FgFlags {
 
 export const enum BgFlags {
   /**
-   * bit 27..32 (upper 3 unused)
+   * bit 27..32 (upper 2 unused)
    */
   ITALIC = 0x4000000,
   DIM = 0x8000000,
-  HAS_EXTENDED = 0x10000000
+  HAS_EXTENDED = 0x10000000,
+  PROTECTED = 0x20000000
 }
 
 export const enum ExtFlags {


### PR DESCRIPTION
Fixes #3651.

TODO:
- [x] some unit tests
- [x] DECRQSS report
- [x] consolidate DECRQSS

@Tyriar Rewrote the PR, this time without additional work in `InputHandler.print`, so this should not impact normal print data flow at all. :muscle: 

Sidenote: Due to changing DECRQSS into an InputHandler function with some inline definitions I could save >3kB on the package.

Edit: Also fixed some feature docs, thus the website should be re-deployed at some point (still on v4.14).