### PR TITLE
WebglRenderer always clear _glyphRenderer if _model is cleared

### DIFF
--- a/addons/xterm-addon-webgl/src/GlyphRenderer.ts
+++ b/addons/xterm-addon-webgl/src/GlyphRenderer.ts
@@ -238,21 +238,24 @@ export class GlyphRenderer  extends Disposable {
     // a_cellpos only changes on resize
   }
 
-  public clear(force?: boolean): void {
+  public clear(): void {
     const terminal = this._terminal;
     const newCount = terminal.cols * terminal.rows * INDICES_PER_CELL;
 
-    // Don't clear if not forced and the array length is correct
-    if (!force && this._vertices.count === newCount) {
-      return;
-    }
-
     // Clear vertices
-    this._vertices.count = newCount;
-    this._vertices.attributes = new Float32Array(newCount);
-    for (let i = 0; i < this._vertices.attributesBuffers.length; i++) {
-      this._vertices.attributesBuffers[i] = new Float32Array(newCount);
+    if (this._vertices.count !== newCount) {
+      this._vertices.attributes = new Float32Array(newCount);
+    } else {
+      this._vertices.attributes.fill(0);
     }
+    for (let i = 0; i < this._vertices.attributesBuffers.length; i++) {
+      if (this._vertices.count !== newCount) {
+        this._vertices.attributesBuffers[i] = new Float32Array(newCount);
+      } else {
+        this._vertices.attributesBuffers[i].fill(0);
+      }
+    }
+    this._vertices.count = newCount;
     let i = 0;
     for (let y = 0; y < terminal.rows; y++) {
       for (let x = 0; x < terminal.cols; x++) {
@@ -267,9 +270,6 @@ export class GlyphRenderer  extends Disposable {
     const gl = this._gl;
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
     this.clear();
-  }
-
-  public setColors(): void {
   }
 
   public render(renderModel: IRenderModel): void {

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -207,7 +207,8 @@ export class WebglRenderer extends Disposable implements IRenderer {
 
     this._refreshCharAtlas();
 
-    // Force a full refresh
+    // Force a full refresh. Resizing `_glyphRenderer` should clear it already,
+    // so there is no need to clear it again here.
     this._clearModel(false);
   }
 

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -163,12 +163,11 @@ export class WebglRenderer extends Disposable implements IRenderer {
     }
 
     this._rectangleRenderer.setColors();
-    this._glyphRenderer.setColors();
 
     this._refreshCharAtlas();
 
     // Force a full refresh
-    this._model.clear();
+    this._clearModel(true);
   }
 
   public onDevicePixelRatioChange(): void {
@@ -209,7 +208,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._refreshCharAtlas();
 
     // Force a full refresh
-    this._model.clear();
+    this._clearModel(false);
   }
 
   public onCharSizeChanged(): void {
@@ -293,16 +292,27 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._glyphRenderer.setAtlas(this._charAtlas);
   }
 
+  /**
+   * Clear the model.
+   * @param clearGlyphRenderer Whether to also clear the glyph renderer. This
+   * should be true generally to make sure it is in the same state as the model.
+   */
+  private _clearModel(clearGlyphRenderer: boolean): void {
+    this._model.clear();
+    if (clearGlyphRenderer) {
+      this._glyphRenderer.clear();
+    }
+  }
+
   public clearCharAtlas(): void {
     this._charAtlas?.clearTexture();
-    this._model.clear();
+    this._clearModel(true);
     this._updateModel(0, this._terminal.rows - 1);
     this._requestRedrawViewport();
   }
 
   public clear(): void {
-    this._model.clear();
-    this._glyphRenderer.clear(true);
+    this._clearModel(true);
     for (const l of this._renderLayers) {
       l.reset(this._terminal);
     }
@@ -334,7 +344,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
 
     // Tell renderer the frame is beginning
     if (this._glyphRenderer.beginFrame()) {
-      this._model.clear();
+      this._clearModel(true);
       this._updateSelectionModel(undefined, undefined);
     }
 


### PR DESCRIPTION
This fix the issue mentioned by OP and [this comment](https://github.com/xtermjs/xterm.js/issues/3878#issuecomment-1221782722) in #3878.

 It can happen when neovim sets some colors and then deletes some characters, and this is what happens inside the `WebglRenderer`:
* `setColors()` is called, and it clears `this._model` but not `this._glyphRenderer`.
* `_updateModel()` is called to update `this._model` to match the terminal buffer. Because `this._model` was cleared earlier, the code [here](https://github.com/xtermjs/xterm.js/blob/93bc9bf1525f663fda72c7637ae0366c2e5a9868/addons/xterm-addon-webgl/src/WebglRenderer.ts#L420) thinks that the cell is up-to-date and there is no need to update `this._glyphRenderer`.