### PR TITLE
Do char atlas warmup via new IdleTaskQueue

### DIFF
--- a/src/common/IdleTaskQueue.ts
+++ b/src/common/IdleTaskQueue.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2022 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+export class IdleTaskQueue {
+  private _tasks: Function[] = [];
+  private _idleCallback?: number;
+  private _maxTaskDuration: number;
+  private _i = 0;
+
+  constructor(targetFps: number = 240) {
+    this._maxTaskDuration = 1000 / targetFps;
+  }
+
+  public enqueue(task: Function): void {
+    this._tasks.push(task);
+    this._start();
+  }
+
+  private _start(): void {
+    if (!this._idleCallback) {
+      this._idleCallback = requestIdleCallback(() => this._process());
+    }
+  }
+
+  private _process(): void {
+    const start = performance.now();
+    this._idleCallback = undefined;
+    while (this._i < this._tasks.length) {
+      this._tasks[this._i++]();
+      if (performance.now() - start > this._maxTaskDuration) {
+        this._start();
+        return;
+      }
+    }
+    // Clear the queue
+    this._i = 0;
+    this._tasks.length = 0;
+  }
+}

--- a/src/common/IdleTaskQueue.ts
+++ b/src/common/IdleTaskQueue.ts
@@ -3,16 +3,27 @@
  * @license MIT
  */
 
+/**
+ * A queue of that runs tasks over several idle callbacks, trying to maintain the specified
+ * frame rate. The tasks will run in the order they are enqueued, but they will run some time later,
+ * and care should be taken to ensure they're non-urgent and will not introduce race conditions.
+ */
 export class IdleTaskQueue {
   private _tasks: Function[] = [];
   private _idleCallback?: number;
   private _maxTaskDuration: number;
   private _i = 0;
 
+  /**
+   * @param targetFps The target frame rate.
+   */
   constructor(targetFps: number = 240) {
     this._maxTaskDuration = 1000 / targetFps;
   }
 
+  /**
+   * Adds a task to the queue which will run in a future idle callback.
+   */
   public enqueue(task: Function): void {
     this._tasks.push(task);
     this._start();


### PR DESCRIPTION
Before (done all at once, block main thread):

<img width="309" alt="Screen Shot 2022-09-24 at 11 13 00 am" src="https://user-images.githubusercontent.com/2193314/192112698-fda304ff-e174-4eb7-bb1b-822640dddc7a.png">

After (done over ~250ms with minimal frame drops):

<img width="855" alt="Screen Shot 2022-09-24 at 11 11 37 am" src="https://user-images.githubusercontent.com/2193314/192112634-8a2283d2-b85f-44ea-ae0f-69de6e6753db.png">

The experience is the same, you see the atlas fill in over that short time but it's all warmed up before the initial shell data comes in anyway.