### PR TITLE
Defer paused renderer resize to idle callback

### DIFF
--- a/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
+++ b/addons/xterm-addon-webgl/src/atlas/WebglCharAtlas.ts
@@ -16,7 +16,7 @@ import { tryDrawCustomChar } from 'browser/renderer/CustomGlyphs';
 import { excludeFromContrastRatioDemands, isPowerlineGlyph, isRestrictedPowerlineGlyph } from 'browser/renderer/RendererUtils';
 import { IUnicodeService } from 'common/services/Services';
 import { FourKeyMap } from 'common/MultiKeyMap';
-import { IdleTaskQueue } from 'common/IdleTaskQueue';
+import { IdleTaskQueue } from 'common/Idle';
 
 // For debugging purposes, it can be useful to set this to a really tiny value,
 // to verify that LRU eviction works.

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -12,7 +12,7 @@ import { addDisposableDomListener } from 'browser/Lifecycle';
 import { IColorSet, IRenderDebouncerWithCallback } from 'browser/Types';
 import { IOptionsService, IBufferService, IDecorationService } from 'common/services/Services';
 import { ICharSizeService, ICoreBrowserService, IRenderService } from 'browser/services/Services';
-import { IdleTaskQueue } from 'common/IdleTaskQueue';
+import { DebouncedIdleTask } from 'common/Idle';
 
 interface ISelectionState {
   start: [number, number] | undefined;
@@ -106,7 +106,7 @@ export class RenderService extends Disposable implements IRenderService {
     }
 
     if (!this._isPaused && this._needsFullRefresh) {
-      this._pausedResizeQueue.flush();
+      this._pausedResizeTask.flush();
       this.refreshRows(0, this._rowCount - 1);
       this._needsFullRefresh = false;
     }
@@ -205,11 +205,10 @@ export class RenderService extends Disposable implements IRenderService {
     this.refreshRows(0, this._rowCount - 1);
   }
 
-  private _pausedResizeQueue = new IdleTaskQueue();
+  private _pausedResizeTask = new DebouncedIdleTask();
   public onResize(cols: number, rows: number): void {
     if (this._isPaused) {
-      this._pausedResizeQueue.clear();
-      this._pausedResizeQueue.enqueue(() => this._renderer.onResize(cols, rows));
+      this._pausedResizeTask.set(() => this._renderer.onResize(cols, rows));
     } else {
       this._renderer.onResize(cols, rows);
     }

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -25,6 +25,7 @@ export class RenderService extends Disposable implements IRenderService {
 
   private _renderDebouncer: IRenderDebouncerWithCallback;
   private _screenDprMonitor: ScreenDprMonitor;
+  private _pausedResizeTask = new DebouncedIdleTask();
 
   private _isPaused: boolean = false;
   private _needsFullRefresh: boolean = false;
@@ -205,7 +206,6 @@ export class RenderService extends Disposable implements IRenderService {
     this.refreshRows(0, this._rowCount - 1);
   }
 
-  private _pausedResizeTask = new DebouncedIdleTask();
   public onResize(cols: number, rows: number): void {
     if (this._isPaused) {
       this._pausedResizeTask.set(() => this._renderer.onResize(cols, rows));

--- a/src/common/Idle.ts
+++ b/src/common/Idle.ts
@@ -9,7 +9,7 @@
  * and care should be taken to ensure they're non-urgent and will not introduce race conditions.
  */
 export class IdleTaskQueue {
-  private _tasks: Function[] = [];
+  private _tasks: (() => void)[] = [];
   private _idleCallback?: number;
   private _maxTaskDuration: number;
   private _i = 0;
@@ -24,7 +24,7 @@ export class IdleTaskQueue {
   /**
    * Adds a task to the queue which will run in a future idle callback.
    */
-  public enqueue(task: Function): void {
+  public enqueue(task: () => void): void {
     this._tasks.push(task);
     this._start();
   }
@@ -68,5 +68,25 @@ export class IdleTaskQueue {
       }
     }
     this.clear();
+  }
+}
+
+export class DebouncedIdleTask {
+  private _queue: IdleTaskQueue;
+
+  /**
+   * @param targetFps The target frame rate.
+   */
+  constructor(targetFps: number = 240) {
+    this._queue = new IdleTaskQueue(targetFps);
+  }
+
+  public set(task: () => void): void {
+    this._queue.clear();
+    this._queue.enqueue(task);
+  }
+
+  public flush(): void {
+    this._queue.flush();
   }
 }

--- a/src/common/IdleTaskQueue.ts
+++ b/src/common/IdleTaskQueue.ts
@@ -29,6 +29,28 @@ export class IdleTaskQueue {
     this._start();
   }
 
+  /**
+   * Flushes the queue, running all remaining tasks synchronously.
+   */
+  public flush(): void {
+    while (this._i < this._tasks.length) {
+      this._tasks[this._i++]();
+    }
+    this.clear();
+  }
+
+  /**
+   * Clears any remaining tasks from the queue, these will not be run.
+   */
+  public clear(): void {
+    if (this._idleCallback) {
+      cancelIdleCallback(this._idleCallback);
+      this._idleCallback = undefined;
+    }
+    this._i = 0;
+    this._tasks.length = 0;
+  }
+
   private _start(): void {
     if (!this._idleCallback) {
       this._idleCallback = requestIdleCallback(() => this._process());
@@ -45,8 +67,6 @@ export class IdleTaskQueue {
         return;
       }
     }
-    // Clear the queue
-    this._i = 0;
-    this._tasks.length = 0;
+    this.clear();
   }
 }


### PR DESCRIPTION
Before (macbook, hide terminal element, full buffer, resize 87-287 cols):

Not sure what the start bit is but it demonstrates it takes ~13ms

<img width="628" alt="Screen Shot 2022-09-24 at 11 50 55 am" src="https://user-images.githubusercontent.com/2193314/192114094-0884f6d9-45a5-4d7e-9c23-59fce7c8e705.png">


After:

<img width="612" alt="Screen Shot 2022-09-24 at 11 52 36 am" src="https://user-images.githubusercontent.com/2193314/192114151-bce82df9-3355-47bc-9717-bae151aaa28a.png">
