### PR TITLE
Optimize critical I/O path for input latency

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -86,7 +86,7 @@ function startServer() {
       return (data) => {
         s += data;
         if (!sender) {
-          sender = setTimeout(() => {
+          sender = queueMicrotask(() => {
             socket.send(s);
             s = '';
             sender = null;
@@ -103,7 +103,7 @@ function startServer() {
         buffer.push(data);
         length += data.length;
         if (!sender) {
-          sender = setTimeout(() => {
+          sender = queueMicrotask(() => {
             socket.send(Buffer.concat(buffer, length));
             buffer = [];
             sender = null;

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -105,7 +105,7 @@ export class WriteBuffer {
     // schedule chunk processing for next event loop run
     if (!this._writeBuffer.length) {
       this._bufferOffset = 0;
-      setTimeout(() => this._innerWrite());
+      queueMicrotask(() => this._innerWrite());
     }
 
     this._pendingData += data.length;
@@ -217,7 +217,7 @@ export class WriteBuffer {
         this._callbacks = this._callbacks.slice(this._bufferOffset);
         this._bufferOffset = 0;
       }
-      setTimeout(() => this._innerWrite());
+      queueMicrotask(() => this._innerWrite());
     } else {
       this._writeBuffer.length = 0;
       this._callbacks.length = 0;


### PR DESCRIPTION
This reduced input latency from about 10ms -> 4ms on my mac (measurement based on devtools tasks).

Before server microtask:

<img width="603" alt="Screen Shot 2022-09-24 at 4 23 02 pm" src="https://user-images.githubusercontent.com/2193314/192122180-13267bf3-f0d0-499d-8ebd-1b6a49458d0c.png">

After server microtask:

<img width="465" alt="Screen Shot 2022-09-24 at 4 22 38 pm" src="https://user-images.githubusercontent.com/2193314/192122182-93ec214b-f746-4919-b6e6-5669ad8f940e.png">

After server microtask and write buffer microtask:

<img width="550" alt="Screen Shot 2022-09-24 at 4 26 41 pm" src="https://user-images.githubusercontent.com/2193314/192122185-f3ce21ac-c43a-4421-ab85-653610867f27.png">
