### PR TITLE
Use <details> tag for real-world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Note that some APIs are marked *experimental*, these are added to enable experim
 ## Real-world uses
 Xterm.js is used in several world-class applications to provide great terminal experiences.
 
+<details><summary>Examples</summary>
+
 - [**SourceLair**](https://www.sourcelair.com/): In-browser IDE that provides its users with fully-featured Linux terminals based on xterm.js.
 - [**Microsoft Visual Studio Code**](http://code.visualstudio.com/): Modern, versatile, and powerful open source code editor that provides an integrated terminal based on xterm.js.
 - [**ttyd**](https://github.com/tsl0922/ttyd): A command-line tool for sharing terminal over the web, with fully-featured terminal emulation based on xterm.js.
@@ -195,7 +197,9 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**Cratecode**](https://cratecode.com): Learn to program for free through interactive online lessons. Cratecode uses xterm.js to give users access to their own Linux environment.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
-Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Note: Please add any new contributions to the end of the list only.
+</details>
+  
+Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it as an example. We would love to have it on our list. Note: Please add any new contributions to the end of the list only.
 
 ## Releases
 


### PR DESCRIPTION
This update puts the real-world use examples in a `<details>` tag so that it must be manually expanded.

The idea is to simplify the `README.md` page, for which the example real-world uses currently takes a large portion.

Is this a change you'd be interested in merging? If so, please let me know if there are any updates I should make.

The updated version can be viewed at:
https://github.com/dstein64/xterm.js/blob/master/README.md#real-world-uses

![real_world_uses](https://user-images.githubusercontent.com/541289/192155186-d6bdaf61-a814-4506-8df3-782776560bf6.png)
