### PR TITLE
Mouse reporting toggle

### DIFF
--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -423,6 +423,10 @@ export class SelectionService extends Disposable implements ISelectionService {
    * @param event The mouse event.
    */
   public shouldForceSelection(event: MouseEvent): boolean {
+    if (!this._optionsService.rawOptions.allowMouseReporting) {
+      return true;
+    }
+
     if (Browser.isMac) {
       return event.altKey && this._optionsService.rawOptions.macOptionClickForcesSelection;
     }

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -36,6 +36,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   disableStdin: false,
   allowProposedApi: false,
   allowTransparency: false,
+  allowMouseReporting: true,
   tabStopWidth: 8,
   theme: {},
   rightClickSelectsWord: isMac,

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -193,6 +193,7 @@ export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
 export interface ITerminalOptions {
   allowProposedApi?: boolean;
   allowTransparency?: boolean;
+  allowMouseReporting?: boolean;
   altClickMovesCursor?: boolean;
   cols?: number;
   convertEol?: boolean;

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -32,6 +32,12 @@ declare module 'xterm-headless' {
     allowTransparency?: boolean;
 
     /**
+     * If enabled, mouse events will be forwarded to the program running
+     * inside the terminal. The default is true.
+     */
+    allowMouseReporting?: boolean;
+
+    /**
      * If enabled, alt + click will move the prompt cursor to position
      * underneath the mouse. The default is true.
      */

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -39,6 +39,12 @@ declare module 'xterm' {
     allowTransparency?: boolean;
 
     /**
+     * If enabled, mouse events will be forwarded to the program running
+     * inside the terminal. The default is true.
+     */
+    allowMouseReporting?: boolean;
+
+    /**
      * If enabled, alt + click will move the prompt cursor to position
      * underneath the mouse. The default is true.
      */


### PR DESCRIPTION
This is a pull request for #4171. This pull request adds the `allowMouseReporting` option. If the option is enabled, it will do these following things:
- Always force selection. This is akin to enabling the `macOptionClickForcesSelection` and _always_ holding the <kbd>⌥</kbd> button.
- Disable mouse wheel reporting when the scroll-back is empty.
- Disable mouse wheel event handler even when the protocol requested for it (e.g. the `DRAG` protocol).

The `allowMouseReporting` can be toggled without having to reload the xterm.js.