### PR TITLE
Fix race condition that could when clearing atlas on 2+ terminals

### DIFF
--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -298,7 +298,6 @@ export class WebglRenderer extends Disposable implements IRenderer {
   public clearTextureAtlas(): void {
     this._charAtlas?.clearTexture();
     this._clearModel(true);
-    this._updateModel(0, this._terminal.rows - 1);
     this._requestRedrawViewport();
   }
 

--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -153,6 +153,7 @@ export class TextureAtlas implements ITextureAtlas {
     this._currentRow.height = 0;
     this._fixedRows.length = 0;
     this._didWarmUp = false;
+    this.hasCanvasChanged = true;
   }
 
   public getRasterizedGlyphCombinedChar(chars: string, bg: number, fg: number, ext: number): IRasterizedGlyph {


### PR DESCRIPTION
This is the proper fix for microsoft/vscode#162996, after a bunch of investigation we found that this is causing the problem:

VS Code clears the texture atlas on OS resume to fix an issue where the texture could be corrupted. This calls clearTextureAtlas twice which should be fine, but it's not because inside WebglRenderer.clear we're calling updateModel which is meant to only ever be called in an animation frame. This calls potentially both renderers to have stale views of the texture atlas for those rows and our perf caching of cells (the main purpose of the model) doesn't know it's stale.
