### PR TITLE
Lint rule for on=event emitter and rename all methods with on prefix to handle

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -96,7 +96,11 @@
       { "selector": "enumMember", "format": ["UPPER_CASE"] },
       // memberLike - Allow enum-like objects to use UPPER_CASE
       { "selector": "property", "modifiers": ["public"], "format": ["camelCase", "UPPER_CASE"] },
-      { "selector": "method", "modifiers": ["public"], "format": ["camelCase", "UPPER_CASE"] },
+      // restrict on* naming for events only
+      { "selector": "method", "modifiers": ["public"], "format": ["camelCase", "UPPER_CASE"], "custom": {
+        "regex": "^on[A-Z].+",
+        "match": false
+      } },
       // typeLike
       { "selector": "typeLike", "format": ["PascalCase"] },
       { "selector": "interface", "format": ["PascalCase"], "prefix": ["I"] }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,6 +101,14 @@
         "regex": "^on[A-Z].+",
         "match": false
       } },
+      { "selector": "method", "modifiers": ["private"], "format": ["camelCase"], "leadingUnderscore": "require", "custom": {
+        "regex": "^on[A-Z].+",
+        "match": false
+      } },
+      { "selector": "method", "modifiers": ["protected"], "format": ["camelCase"], "leadingUnderscore": "require", "custom": {
+        "regex": "^on[A-Z].+",
+        "match": false
+      } },
       // typeLike
       { "selector": "typeLike", "format": ["PascalCase"] },
       { "selector": "interface", "format": ["PascalCase"], "prefix": ["I"] }

--- a/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
@@ -75,13 +75,13 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     }
   }
 
-  public onOptionsChanged(): void {}
-  public onBlur(): void {}
-  public onFocus(): void {}
-  public onCursorMove(): void {}
-  public onGridChanged(startRow: number, endRow: number): void {}
+  public handleOptionsChanged(): void {}
+  public handleBlur(): void {}
+  public handleFocus(): void {}
+  public handleCursorMove(): void {}
+  public handleGridChanged(startRow: number, endRow: number): void {}
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {
     this._selectionModel.update(this._terminal, start, end, columnSelectMode);
   }
 
@@ -105,7 +105,7 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
 
     // Regenerate char atlas and force a full redraw
     this._refreshCharAtlas(this._colors);
-    this.onGridChanged(0, this._bufferService.rows - 1);
+    this.handleGridChanged(0, this._bufferService.rows - 1);
   }
 
   /**

--- a/addons/xterm-addon-canvas/src/CanvasAddon.ts
+++ b/addons/xterm-addon-canvas/src/CanvasAddon.ts
@@ -45,11 +45,11 @@ export class CanvasAddon extends Disposable implements ITerminalAddon {
     this._renderer = new CanvasRenderer(terminal, colors, screenElement, linkifier, bufferService, charSizeService, optionsService, characterJoinerService, coreService, coreBrowserService, decorationService);
     this.register(forwardEvent(this._renderer.onChangeTextureAtlas, this._onChangeTextureAtlas));
     renderService.setRenderer(this._renderer);
-    renderService.onResize(bufferService.cols, bufferService.rows);
+    renderService.handleResize(bufferService.cols, bufferService.rows);
 
     this.register(toDisposable(() => {
       renderService.setRenderer((this._terminal as any)._core._createRenderer());
-      renderService.onResize(terminal.cols, terminal.rows);
+      renderService.handleResize(terminal.cols, terminal.rows);
       this._renderer?.dispose();
       this._renderer = undefined;
     }));

--- a/addons/xterm-addon-canvas/src/CanvasRenderer.ts
+++ b/addons/xterm-addon-canvas/src/CanvasRenderer.ts
@@ -69,7 +69,7 @@ export class CanvasRenderer extends Disposable implements IRenderer {
 
     this.register(observeDevicePixelDimensions(this._renderLayers[0].canvas, this._coreBrowserService.window, (w, h) => this._setCanvasDevicePixelDimensions(w, h)));
 
-    this.onOptionsChanged();
+    this.handleOptionsChanged();
 
     this.register(toDisposable(() => {
       for (const l of this._renderLayers) {
@@ -83,12 +83,12 @@ export class CanvasRenderer extends Disposable implements IRenderer {
     return this._renderLayers[0].cacheCanvas;
   }
 
-  public onDevicePixelRatioChange(): void {
+  public handleDevicePixelRatioChange(): void {
     // If the device pixel ratio changed, the char atlas needs to be regenerated
     // and the terminal needs to refreshed
     if (this._devicePixelRatio !== this._coreBrowserService.dpr) {
       this._devicePixelRatio = this._coreBrowserService.dpr;
-      this.onResize(this._bufferService.cols, this._bufferService.rows);
+      this.handleResize(this._bufferService.cols, this._bufferService.rows);
     }
   }
 
@@ -101,7 +101,7 @@ export class CanvasRenderer extends Disposable implements IRenderer {
     }
   }
 
-  public onResize(cols: number, rows: number): void {
+  public handleResize(cols: number, rows: number): void {
     // Update character and canvas dimensions
     this._updateDimensions();
 
@@ -115,32 +115,32 @@ export class CanvasRenderer extends Disposable implements IRenderer {
     this._screenElement.style.height = `${this.dimensions.canvasHeight}px`;
   }
 
-  public onCharSizeChanged(): void {
-    this.onResize(this._bufferService.cols, this._bufferService.rows);
+  public handleCharSizeChanged(): void {
+    this.handleResize(this._bufferService.cols, this._bufferService.rows);
   }
 
-  public onBlur(): void {
-    this._runOperation(l => l.onBlur());
+  public handleBlur(): void {
+    this._runOperation(l => l.handleBlur());
   }
 
-  public onFocus(): void {
-    this._runOperation(l => l.onFocus());
+  public handleFocus(): void {
+    this._runOperation(l => l.handleFocus());
   }
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {
-    this._runOperation(l => l.onSelectionChanged(start, end, columnSelectMode));
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {
+    this._runOperation(l => l.handleSelectionChanged(start, end, columnSelectMode));
     // Selection foreground requires a full re-render
     if (this._colors.selectionForeground) {
       this._onRequestRedraw.fire({ start: 0, end: this._bufferService.rows - 1 });
     }
   }
 
-  public onCursorMove(): void {
-    this._runOperation(l => l.onCursorMove());
+  public handleCursorMove(): void {
+    this._runOperation(l => l.handleCursorMove());
   }
 
-  public onOptionsChanged(): void {
-    this._runOperation(l => l.onOptionsChanged());
+  public handleOptionsChanged(): void {
+    this._runOperation(l => l.handleOptionsChanged());
   }
 
   public clear(): void {
@@ -159,7 +159,7 @@ export class CanvasRenderer extends Disposable implements IRenderer {
    */
   public renderRows(start: number, end: number): void {
     for (const l of this._renderLayers) {
-      l.onGridChanged(start, end);
+      l.handleGridChanged(start, end);
     }
   }
 

--- a/addons/xterm-addon-canvas/src/CursorRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/CursorRenderLayer.ts
@@ -79,20 +79,20 @@ export class CursorRenderLayer extends BaseRenderLayer {
   public reset(): void {
     this._clearCursor();
     this._cursorBlinkStateManager?.restartBlinkAnimation();
-    this.onOptionsChanged();
+    this.handleOptionsChanged();
   }
 
-  public onBlur(): void {
+  public handleBlur(): void {
     this._cursorBlinkStateManager?.pause();
     this._onRequestRedraw.fire({ start: this._bufferService.buffer.y, end: this._bufferService.buffer.y });
   }
 
-  public onFocus(): void {
+  public handleFocus(): void {
     this._cursorBlinkStateManager?.resume();
     this._onRequestRedraw.fire({ start: this._bufferService.buffer.y, end: this._bufferService.buffer.y });
   }
 
-  public onOptionsChanged(): void {
+  public handleOptionsChanged(): void {
     if (this._optionsService.rawOptions.cursorBlink) {
       if (!this._cursorBlinkStateManager) {
         this._cursorBlinkStateManager = new CursorBlinkStateManager(this._coreBrowserService.isFocused, () => {
@@ -108,11 +108,11 @@ export class CursorRenderLayer extends BaseRenderLayer {
     this._onRequestRedraw.fire({ start: this._bufferService.buffer.y, end: this._bufferService.buffer.y });
   }
 
-  public onCursorMove(): void {
+  public handleCursorMove(): void {
     this._cursorBlinkStateManager?.restartBlinkAnimation();
   }
 
-  public onGridChanged(startRow: number, endRow: number): void {
+  public handleGridChanged(startRow: number, endRow: number): void {
     if (!this._cursorBlinkStateManager || this._cursorBlinkStateManager.isPaused) {
       this._render(false);
     } else {

--- a/addons/xterm-addon-canvas/src/LinkRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/LinkRenderLayer.ts
@@ -28,8 +28,8 @@ export class LinkRenderLayer extends BaseRenderLayer {
   ) {
     super(terminal, container, 'link', zIndex, true, colors, bufferService, optionsService, decorationService, coreBrowserService);
 
-    this.register(linkifier2.onShowLinkUnderline(e => this._onShowLinkUnderline(e)));
-    this.register(linkifier2.onHideLinkUnderline(e => this._onHideLinkUnderline(e)));
+    this.register(linkifier2.onShowLinkUnderline(e => this._handleShowLinkUnderline(e)));
+    this.register(linkifier2.onHideLinkUnderline(e => this._handleHideLinkUnderline(e)));
   }
 
   public resize(dim: IRenderDimensions): void {
@@ -54,7 +54,7 @@ export class LinkRenderLayer extends BaseRenderLayer {
     }
   }
 
-  private _onShowLinkUnderline(e: ILinkifierEvent): void {
+  private _handleShowLinkUnderline(e: ILinkifierEvent): void {
     if (e.fg === INVERTED_DEFAULT_COLOR) {
       this._ctx.fillStyle = this._colors.background.css;
     } else if (e.fg && is256Color(e.fg)) {
@@ -78,7 +78,7 @@ export class LinkRenderLayer extends BaseRenderLayer {
     this._state = e;
   }
 
-  private _onHideLinkUnderline(e: ILinkifierEvent): void {
+  private _handleHideLinkUnderline(e: ILinkifierEvent): void {
     this._clearCurrentLink();
   }
 }

--- a/addons/xterm-addon-canvas/src/SelectionRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/SelectionRenderLayer.ts
@@ -59,18 +59,18 @@ export class SelectionRenderLayer extends BaseRenderLayer {
     }
   }
 
-  public onBlur(): void {
+  public handleBlur(): void {
     this.reset();
     this._redrawSelection(this._selectionModel.selectionStart, this._selectionModel.selectionEnd, this._selectionModel.columnSelectMode);
   }
 
-  public onFocus(): void {
+  public handleFocus(): void {
     this.reset();
     this._redrawSelection(this._selectionModel.selectionStart, this._selectionModel.selectionEnd, this._selectionModel.columnSelectMode);
   }
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
-    super.onSelectionChanged(start, end, columnSelectMode);
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
+    super.handleSelectionChanged(start, end, columnSelectMode);
     this._redrawSelection(start, end, columnSelectMode);
   }
 

--- a/addons/xterm-addon-canvas/src/TextRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/TextRenderLayer.ts
@@ -236,7 +236,7 @@ export class TextRenderLayer extends BaseRenderLayer {
     this._forEachCell(firstRow, lastRow, (cell, x, y) => this._drawChars(cell, x, y));
   }
 
-  public onGridChanged(firstRow: number, lastRow: number): void {
+  public handleGridChanged(firstRow: number, lastRow: number): void {
     // Resize has not been called yet
     if (this._state.cache.length === 0) {
       return;
@@ -251,7 +251,7 @@ export class TextRenderLayer extends BaseRenderLayer {
     this._drawForeground(firstRow, lastRow);
   }
 
-  public onOptionsChanged(): void {
+  public handleOptionsChanged(): void {
     this._setTransparency(this._optionsService.rawOptions.allowTransparency);
   }
 

--- a/addons/xterm-addon-canvas/src/Types.d.ts
+++ b/addons/xterm-addon-canvas/src/Types.d.ts
@@ -42,14 +42,14 @@ export interface IRenderer extends IDisposable {
   readonly onRequestRedraw: IEvent<IRequestRedrawEvent>;
 
   setColors(colors: IColorSet): void;
-  onDevicePixelRatioChange(): void;
-  onResize(cols: number, rows: number): void;
-  onCharSizeChanged(): void;
-  onBlur(): void;
-  onFocus(): void;
-  onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
-  onCursorMove(): void;
-  onOptionsChanged(): void;
+  handleDevicePixelRatioChange(): void;
+  handleResize(cols: number, rows: number): void;
+  handleCharSizeChanged(): void;
+  handleBlur(): void;
+  handleFocus(): void;
+  handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  handleCursorMove(): void;
+  handleOptionsChanged(): void;
   clear(): void;
   renderRows(start: number, end: number): void;
   clearTextureAtlas?(): void;
@@ -62,22 +62,22 @@ export interface IRenderLayer extends IDisposable {
   /**
    * Called when the terminal loses focus.
    */
-  onBlur(): void;
+  handleBlur(): void;
 
   /**
    * * Called when the terminal gets focus.
    */
-  onFocus(): void;
+  handleFocus(): void;
 
   /**
    * Called when the cursor is moved.
    */
-  onCursorMove(): void;
+  handleCursorMove(): void;
 
   /**
    * Called when options change.
    */
-  onOptionsChanged(): void;
+  handleOptionsChanged(): void;
 
   /**
    * Called when the theme changes.
@@ -88,12 +88,12 @@ export interface IRenderLayer extends IDisposable {
    * Called when the data in the grid has changed (or needs to be rendered
    * again).
    */
-  onGridChanged(startRow: number, endRow: number): void;
+  handleGridChanged(startRow: number, endRow: number): void;
 
   /**
    * Calls when the selection changes.
    */
-  onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
 
   /**
    * Resize the render layer.

--- a/addons/xterm-addon-webgl/src/GlyphRenderer.ts
+++ b/addons/xterm-addon-webgl/src/GlyphRenderer.ts
@@ -167,7 +167,7 @@ export class GlyphRenderer extends Disposable {
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
     // Set viewport
-    this.onResize();
+    this.handleResize();
   }
 
   public beginFrame(): boolean {
@@ -263,7 +263,7 @@ export class GlyphRenderer extends Disposable {
     }
   }
 
-  public onResize(): void {
+  public handleResize(): void {
     const gl = this._gl;
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
     this.clear();

--- a/addons/xterm-addon-webgl/src/RectangleRenderer.ts
+++ b/addons/xterm-addon-webgl/src/RectangleRenderer.ts
@@ -151,7 +151,7 @@ export class RectangleRenderer extends Disposable {
     gl.drawElementsInstanced(this._gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, this._vertices.count);
   }
 
-  public onResize(): void {
+  public handleResize(): void {
     this._updateViewportRectangle();
   }
 

--- a/addons/xterm-addon-webgl/src/WebglAddon.ts
+++ b/addons/xterm-addon-webgl/src/WebglAddon.ts
@@ -51,7 +51,7 @@ export class WebglAddon extends Disposable implements ITerminalAddon {
     this.register(toDisposable(() => {
       const renderService: IRenderService = (this._terminal as any)._core._renderService;
       renderService.setRenderer((this._terminal as any)._core._createRenderer());
-      renderService.onResize(terminal.cols, terminal.rows);
+      renderService.handleResize(terminal.cols, terminal.rows);
     }));
   }
 

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -162,16 +162,16 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._clearModel(true);
   }
 
-  public onDevicePixelRatioChange(): void {
+  public handleDevicePixelRatioChange(): void {
     // If the device pixel ratio changed, the char atlas needs to be regenerated
     // and the terminal needs to refreshed
     if (this._devicePixelRatio !== this._coreBrowserService.dpr) {
       this._devicePixelRatio = this._coreBrowserService.dpr;
-      this.onResize(this._terminal.cols, this._terminal.rows);
+      this.handleResize(this._terminal.cols, this._terminal.rows);
     }
   }
 
-  public onResize(cols: number, rows: number): void {
+  public handleResize(cols: number, rows: number): void {
     // Update character and canvas dimensions
     this._updateDimensions();
 
@@ -193,9 +193,9 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._core.screenElement!.style.height = `${this.dimensions.canvasHeight}px`;
 
     this._rectangleRenderer.setDimensions(this.dimensions);
-    this._rectangleRenderer.onResize();
+    this._rectangleRenderer.handleResize();
     this._glyphRenderer.setDimensions(this.dimensions);
-    this._glyphRenderer.onResize();
+    this._glyphRenderer.handleResize();
 
     this._refreshCharAtlas();
 
@@ -204,43 +204,43 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._clearModel(false);
   }
 
-  public onCharSizeChanged(): void {
-    this.onResize(this._terminal.cols, this._terminal.rows);
+  public handleCharSizeChanged(): void {
+    this.handleResize(this._terminal.cols, this._terminal.rows);
   }
 
-  public onBlur(): void {
+  public handleBlur(): void {
     for (const l of this._renderLayers) {
-      l.onBlur(this._terminal);
+      l.handleBlur(this._terminal);
     }
     // Request a redraw for active/inactive selection background
     this._requestRedrawViewport();
   }
 
-  public onFocus(): void {
+  public handleFocus(): void {
     for (const l of this._renderLayers) {
-      l.onFocus(this._terminal);
+      l.handleFocus(this._terminal);
     }
     // Request a redraw for active/inactive selection background
     this._requestRedrawViewport();
   }
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
     for (const l of this._renderLayers) {
-      l.onSelectionChanged(this._terminal, start, end, columnSelectMode);
+      l.handleSelectionChanged(this._terminal, start, end, columnSelectMode);
     }
     this._model.selection.update(this._terminal, start, end, columnSelectMode);
     this._requestRedrawViewport();
   }
 
-  public onCursorMove(): void {
+  public handleCursorMove(): void {
     for (const l of this._renderLayers) {
-      l.onCursorMove(this._terminal);
+      l.handleCursorMove(this._terminal);
     }
   }
 
-  public onOptionsChanged(): void {
+  public handleOptionsChanged(): void {
     for (const l of this._renderLayers) {
-      l.onOptionsChanged(this._terminal);
+      l.handleOptionsChanged(this._terminal);
     }
     this._updateDimensions();
     this._refreshCharAtlas();
@@ -258,7 +258,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     this._glyphRenderer = this.register(new GlyphRenderer(this._terminal, this._gl, this.dimensions));
 
     // Update dimensions and acquire char atlas
-    this.onCharSizeChanged();
+    this.handleCharSizeChanged();
   }
 
   /**
@@ -328,7 +328,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
 
     // Update render layers
     for (const l of this._renderLayers) {
-      l.onGridChanged(this._terminal, start, end);
+      l.handleGridChanged(this._terminal, start, end);
     }
 
     // Tell renderer the frame is beginning

--- a/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
@@ -54,12 +54,12 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     }
   }
 
-  public onOptionsChanged(terminal: Terminal): void {}
-  public onBlur(terminal: Terminal): void {}
-  public onFocus(terminal: Terminal): void {}
-  public onCursorMove(terminal: Terminal): void {}
-  public onGridChanged(terminal: Terminal, startRow: number, endRow: number): void {}
-  public onSelectionChanged(terminal: Terminal, start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {}
+  public handleOptionsChanged(terminal: Terminal): void {}
+  public handleBlur(terminal: Terminal): void {}
+  public handleFocus(terminal: Terminal): void {}
+  public handleCursorMove(terminal: Terminal): void {}
+  public handleGridChanged(terminal: Terminal, startRow: number, endRow: number): void {}
+  public handleSelectionChanged(terminal: Terminal, start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean = false): void {}
 
   public setColors(terminal: Terminal, colorSet: IColorSet): void {
     this._refreshCharAtlas(terminal, colorSet);
@@ -81,7 +81,7 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
 
     // Regenerate char atlas and force a full redraw
     this._refreshCharAtlas(terminal, this._colors);
-    this.onGridChanged(terminal, 0, terminal.rows - 1);
+    this.handleGridChanged(terminal, 0, terminal.rows - 1);
   }
 
   /**

--- a/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
@@ -55,7 +55,7 @@ export class CursorRenderLayer extends BaseRenderLayer {
       'block': this._renderBlockCursor.bind(this),
       'underline': this._renderUnderlineCursor.bind(this)
     };
-    this.onOptionsChanged(terminal);
+    this.handleOptionsChanged(terminal);
     this.register(toDisposable(() => {
       this._cursorBlinkStateManager?.dispose();
       this._cursorBlinkStateManager = undefined;
@@ -77,20 +77,20 @@ export class CursorRenderLayer extends BaseRenderLayer {
   public reset(terminal: Terminal): void {
     this._clearCursor();
     this._cursorBlinkStateManager?.restartBlinkAnimation(terminal);
-    this.onOptionsChanged(terminal);
+    this.handleOptionsChanged(terminal);
   }
 
-  public onBlur(terminal: Terminal): void {
+  public handleBlur(terminal: Terminal): void {
     this._cursorBlinkStateManager?.pause();
     this._onRequestRefreshRowsEvent.fire({ start: terminal.buffer.active.cursorY, end: terminal.buffer.active.cursorY });
   }
 
-  public onFocus(terminal: Terminal): void {
+  public handleFocus(terminal: Terminal): void {
     this._cursorBlinkStateManager?.resume(terminal);
     this._onRequestRefreshRowsEvent.fire({ start: terminal.buffer.active.cursorY, end: terminal.buffer.active.cursorY });
   }
 
-  public onOptionsChanged(terminal: Terminal): void {
+  public handleOptionsChanged(terminal: Terminal): void {
     if (terminal.options.cursorBlink) {
       if (!this._cursorBlinkStateManager) {
         this._cursorBlinkStateManager = new CursorBlinkStateManager(() => {
@@ -106,11 +106,11 @@ export class CursorRenderLayer extends BaseRenderLayer {
     this._onRequestRefreshRowsEvent.fire({ start: terminal.buffer.active.cursorY, end: terminal.buffer.active.cursorY });
   }
 
-  public onCursorMove(terminal: Terminal): void {
+  public handleCursorMove(terminal: Terminal): void {
     this._cursorBlinkStateManager?.restartBlinkAnimation(terminal);
   }
 
-  public onGridChanged(terminal: Terminal, startRow: number, endRow: number): void {
+  public handleGridChanged(terminal: Terminal, startRow: number, endRow: number): void {
     if (!this._cursorBlinkStateManager || this._cursorBlinkStateManager.isPaused) {
       this._render(terminal, false);
     } else {

--- a/addons/xterm-addon-webgl/src/renderLayer/LinkRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/LinkRenderLayer.ts
@@ -24,8 +24,8 @@ export class LinkRenderLayer extends BaseRenderLayer {
   ) {
     super(container, 'link', zIndex, true, colors, coreBrowserService);
 
-    this.register(terminal.linkifier2.onShowLinkUnderline(e => this._onShowLinkUnderline(e)));
-    this.register(terminal.linkifier2.onHideLinkUnderline(e => this._onHideLinkUnderline(e)));
+    this.register(terminal.linkifier2.onShowLinkUnderline(e => this._handleShowLinkUnderline(e)));
+    this.register(terminal.linkifier2.onHideLinkUnderline(e => this._handleHideLinkUnderline(e)));
   }
 
   public resize(terminal: Terminal, dim: IRenderDimensions): void {
@@ -50,7 +50,7 @@ export class LinkRenderLayer extends BaseRenderLayer {
     }
   }
 
-  private _onShowLinkUnderline(e: ILinkifierEvent): void {
+  private _handleShowLinkUnderline(e: ILinkifierEvent): void {
     if (e.fg === INVERTED_DEFAULT_COLOR) {
       this._ctx.fillStyle = this._colors.background.css;
     } else if (e.fg !== undefined && is256Color(e.fg)) {
@@ -74,7 +74,7 @@ export class LinkRenderLayer extends BaseRenderLayer {
     this._state = e;
   }
 
-  private _onHideLinkUnderline(e: ILinkifierEvent): void {
+  private _handleHideLinkUnderline(e: ILinkifierEvent): void {
     this._clearCurrentLink();
   }
 }

--- a/addons/xterm-addon-webgl/src/renderLayer/Types.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/Types.ts
@@ -11,22 +11,22 @@ export interface IRenderLayer extends IDisposable {
   /**
    * Called when the terminal loses focus.
    */
-  onBlur(terminal: Terminal): void;
+  handleBlur(terminal: Terminal): void;
 
   /**
    * * Called when the terminal gets focus.
    */
-  onFocus(terminal: Terminal): void;
+  handleFocus(terminal: Terminal): void;
 
   /**
    * Called when the cursor is moved.
    */
-  onCursorMove(terminal: Terminal): void;
+  handleCursorMove(terminal: Terminal): void;
 
   /**
    * Called when options change.
    */
-  onOptionsChanged(terminal: Terminal): void;
+  handleOptionsChanged(terminal: Terminal): void;
 
   /**
    * Called when the theme changes.
@@ -37,12 +37,12 @@ export interface IRenderLayer extends IDisposable {
    * Called when the data in the grid has changed (or needs to be rendered
    * again).
    */
-  onGridChanged(terminal: Terminal, startRow: number, endRow: number): void;
+  handleGridChanged(terminal: Terminal, startRow: number, endRow: number): void;
 
   /**
    * Calls when the selection changes.
    */
-  onSelectionChanged(terminal: Terminal, start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  handleSelectionChanged(terminal: Terminal, start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
 
   /**
    * Registers a handler to join characters to render as a group

--- a/src/browser/AccessibilityManager.ts
+++ b/src/browser/AccessibilityManager.ts
@@ -65,8 +65,8 @@ export class AccessibilityManager extends Disposable {
       this._rowContainer.appendChild(this._rowElements[i]);
     }
 
-    this._topBoundaryFocusListener = e => this._onBoundaryFocus(e, BoundaryPosition.TOP);
-    this._bottomBoundaryFocusListener = e => this._onBoundaryFocus(e, BoundaryPosition.BOTTOM);
+    this._topBoundaryFocusListener = e => this._handleBoundaryFocus(e, BoundaryPosition.TOP);
+    this._bottomBoundaryFocusListener = e => this._handleBoundaryFocus(e, BoundaryPosition.BOTTOM);
     this._rowElements[0].addEventListener('focus', this._topBoundaryFocusListener);
     this._rowElements[this._rowElements.length - 1].addEventListener('focus', this._bottomBoundaryFocusListener);
 
@@ -87,14 +87,14 @@ export class AccessibilityManager extends Disposable {
     this._terminal.element.insertAdjacentElement('afterbegin', this._accessibilityTreeRoot);
 
     this.register(this._renderRowsDebouncer);
-    this.register(this._terminal.onResize(e => this._onResize(e.rows)));
+    this.register(this._terminal.onResize(e => this._handleResize(e.rows)));
     this.register(this._terminal.onRender(e => this._refreshRows(e.start, e.end)));
     this.register(this._terminal.onScroll(() => this._refreshRows()));
     // Line feed is an issue as the prompt won't be read out after a command is run
-    this.register(this._terminal.onA11yChar(char => this._onChar(char)));
-    this.register(this._terminal.onLineFeed(() => this._onChar('\n')));
-    this.register(this._terminal.onA11yTab(spaceCount => this._onTab(spaceCount)));
-    this.register(this._terminal.onKey(e => this._onKey(e.key)));
+    this.register(this._terminal.onA11yChar(char => this._handleChar(char)));
+    this.register(this._terminal.onLineFeed(() => this._handleChar('\n')));
+    this.register(this._terminal.onA11yTab(spaceCount => this._handleTab(spaceCount)));
+    this.register(this._terminal.onKey(e => this._handleKey(e.key)));
     this.register(this._terminal.onBlur(() => this._clearLiveRegion()));
     this.register(this._renderService.onDimensionsChange(() => this._refreshRowsDimensions()));
 
@@ -110,7 +110,7 @@ export class AccessibilityManager extends Disposable {
     }));
   }
 
-  private _onBoundaryFocus(e: FocusEvent, position: BoundaryPosition): void {
+  private _handleBoundaryFocus(e: FocusEvent, position: BoundaryPosition): void {
     const boundaryElement = e.target as HTMLElement;
     const beforeBoundaryElement = this._rowElements[position === BoundaryPosition.TOP ? 1 : this._rowElements.length - 2];
 
@@ -170,7 +170,7 @@ export class AccessibilityManager extends Disposable {
     e.stopImmediatePropagation();
   }
 
-  private _onResize(rows: number): void {
+  private _handleResize(rows: number): void {
     // Remove bottom boundary listener
     this._rowElements[this._rowElements.length - 1].removeEventListener('focus', this._bottomBoundaryFocusListener);
 
@@ -198,13 +198,13 @@ export class AccessibilityManager extends Disposable {
     return element;
   }
 
-  private _onTab(spaceCount: number): void {
+  private _handleTab(spaceCount: number): void {
     for (let i = 0; i < spaceCount; i++) {
-      this._onChar(' ');
+      this._handleChar(' ');
     }
   }
 
-  private _onChar(char: string): void {
+  private _handleChar(char: string): void {
     if (this._liveRegionLineCount < MAX_ROWS_TO_READ + 1) {
       if (this._charsToConsume.length > 0) {
         // Have the screen reader ignore the char if it was just input
@@ -244,7 +244,7 @@ export class AccessibilityManager extends Disposable {
     }
   }
 
-  private _onKey(keyChar: string): void {
+  private _handleKey(keyChar: string): void {
     this._clearLiveRegion();
     this._charsToConsume.push(keyChar);
   }
@@ -278,7 +278,7 @@ export class AccessibilityManager extends Disposable {
       return;
     }
     if (this._rowElements.length !== this._terminal.rows) {
-      this._onResize(this._terminal.rows);
+      this._handleResize(this._terminal.rows);
     }
     for (let i = 0; i < this._terminal.rows; i++) {
       this._refreshRowDimensions(this._rowElements[i]);

--- a/src/browser/ColorManager.ts
+++ b/src/browser/ColorManager.ts
@@ -102,7 +102,7 @@ export class ColorManager implements IColorManager {
     this._updateRestoreColors();
   }
 
-  public onOptionsChange(key: string, value: any): void {
+  public handleOptionsChange(key: string, value: any): void {
     switch (key) {
       case 'minimumContrastRatio':
         this._contrastCache.clear();

--- a/src/browser/Linkifier2.ts
+++ b/src/browser/Linkifier2.ts
@@ -64,12 +64,12 @@ export class Linkifier2 extends Disposable implements ILinkifier2 {
       this._isMouseOut = true;
       this._clearCurrentLink();
     }));
-    this.register(addDisposableDomListener(this._element, 'mousemove', this._onMouseMove.bind(this)));
+    this.register(addDisposableDomListener(this._element, 'mousemove', this._handleMouseMove.bind(this)));
     this.register(addDisposableDomListener(this._element, 'mousedown', this._handleMouseDown.bind(this)));
     this.register(addDisposableDomListener(this._element, 'mouseup', this._handleMouseUp.bind(this)));
   }
 
-  private _onMouseMove(event: MouseEvent): void {
+  private _handleMouseMove(event: MouseEvent): void {
     this._lastMouseEvent = event;
 
     if (!this._element || !this._mouseService) {
@@ -97,12 +97,12 @@ export class Linkifier2 extends Disposable implements ILinkifier2 {
     }
 
     if (!this._lastBufferCell || (position.x !== this._lastBufferCell.x || position.y !== this._lastBufferCell.y)) {
-      this._onHover(position);
+      this._handleHover(position);
       this._lastBufferCell = position;
     }
   }
 
-  private _onHover(position: IBufferCellPosition): void {
+  private _handleHover(position: IBufferCellPosition): void {
     // TODO: This currently does not cache link provider results across wrapped lines, activeLine should be something like `activeRange: {startY, endY}`
     // Check if we need to clear the link
     if (this._activeLine !== position.y) {

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -316,7 +316,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
   /**
    * Binds the desired focus behavior on a given terminal object.
    */
-  private _onTextAreaFocus(ev: KeyboardEvent): void {
+  private _handleTextAreaFocus(ev: KeyboardEvent): void {
     if (this.coreService.decPrivateModes.sendFocus) {
       this.coreService.triggerDataEvent(C0.ESC + '[I');
     }
@@ -337,7 +337,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
   /**
    * Binds the desired blur behavior on a given terminal object.
    */
-  private _onTextAreaBlur(): void {
+  private _handleTextAreaBlur(): void {
     // Text can safely be removed on blur. Doing it earlier could interfere with
     // screen readers reading it out.
     this.textarea!.value = '';
@@ -488,8 +488,8 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this.textarea.setAttribute('autocapitalize', 'off');
     this.textarea.setAttribute('spellcheck', 'false');
     this.textarea.tabIndex = 0;
-    this.register(addDisposableDomListener(this.textarea, 'focus', (ev: KeyboardEvent) => this._onTextAreaFocus(ev)));
-    this.register(addDisposableDomListener(this.textarea, 'blur', () => this._onTextAreaBlur()));
+    this.register(addDisposableDomListener(this.textarea, 'focus', (ev: KeyboardEvent) => this._handleTextAreaFocus(ev)));
+    this.register(addDisposableDomListener(this.textarea, 'blur', () => this._handleTextAreaBlur()));
     this._helperContainer.appendChild(this.textarea);
 
     this._coreBrowserService = this._instantiationService.createInstance(CoreBrowserService, this.textarea, this._document.defaultView ?? window);

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -238,7 +238,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       }
     }
     this._renderService?.setColors(this._colorManager.colors);
-    this.viewport?.onThemeChange(this._colorManager.colors);
+    this.viewport?.handleThemeChange(this._colorManager.colors);
   }
 
   protected _setup(): void {
@@ -289,7 +289,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
         // When the font changes the size of the cells may change which requires a renderer clear
         if (this._renderService) {
           this._renderService.clear();
-          this._renderService.onResize(this.cols, this.rows);
+          this._renderService.handleResize(this.cols, this.rows);
           this.refresh(0, this.rows - 1);
         }
         break;
@@ -500,7 +500,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
     this._theme = this.options.theme || this._theme;
     this._colorManager = new ColorManager();
-    this.register(this.optionsService.onOptionChange(e => this._colorManager!.onOptionsChange(e, this.optionsService.rawOptions[e])));
+    this.register(this.optionsService.onOptionChange(e => this._colorManager!.handleOptionsChange(e, this.optionsService.rawOptions[e])));
     this._colorManager.setTheme(this._theme);
 
     this._characterJoinerService = this._instantiationService.createInstance(CharacterJoinerService);
@@ -533,17 +533,17 @@ export class Terminal extends CoreTerminal implements ITerminal {
       this._viewportScrollArea,
       this.element
     );
-    this.viewport.onThemeChange(this._colorManager.colors);
+    this.viewport.handleThemeChange(this._colorManager.colors);
     this.register(this._inputHandler.onRequestSyncScrollBar(() => this.viewport!.syncScrollArea()));
     this.register(this.viewport);
 
     this.register(this.onCursorMove(() => {
-      this._renderService!.onCursorMove();
+      this._renderService!.handleCursorMove();
       this._syncTextArea();
     }));
-    this.register(this.onResize(() => this._renderService!.onResize(this.cols, this.rows)));
-    this.register(this.onBlur(() => this._renderService!.onBlur()));
-    this.register(this.onFocus(() => this._renderService!.onFocus()));
+    this.register(this.onResize(() => this._renderService!.handleResize(this.cols, this.rows)));
+    this.register(this.onBlur(() => this._renderService!.handleBlur()));
+    this.register(this.onFocus(() => this._renderService!.handleFocus()));
     this.register(this._renderService.onDimensionsChange(() => this.viewport!.syncScrollArea()));
 
     this._selectionService = this.register(this._instantiationService.createInstance(SelectionService,
@@ -554,7 +554,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this._instantiationService.setService(ISelectionService, this._selectionService);
     this.register(this._selectionService.onRequestScrollLines(e => this.scrollLines(e.amount, e.suppressScrollEvent)));
     this.register(this._selectionService.onSelectionChange(() => this._onSelectionChange.fire()));
-    this.register(this._selectionService.onRequestRedraw(e => this._renderService!.onSelectionChanged(e.start, e.end, e.columnSelectMode)));
+    this.register(this._selectionService.onRequestRedraw(e => this._renderService!.handleSelectionChanged(e.start, e.end, e.columnSelectMode)));
     this.register(this._selectionService.onLinuxMouseSelection(text => {
       // If there's a new selection, put it into the textarea, focus and select it
       // in order to register it as a selection on the OS. This event is fired
@@ -571,7 +571,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
     this.linkifier2.attachToDom(this.screenElement, this._mouseService, this._renderService);
     this.register(this._instantiationService.createInstance(BufferDecorationRenderer, this.screenElement));
-    this.register(addDisposableDomListener(this.element, 'mousedown', (e: MouseEvent) => this._selectionService!.onMouseDown(e)));
+    this.register(addDisposableDomListener(this.element, 'mousedown', (e: MouseEvent) => this._selectionService!.handleMouseDown(e)));
 
     // apply mouse event classes set by escape codes before terminal was attached
     if (this.coreMouseService.areMouseEventsActive) {
@@ -621,7 +621,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     this._theme = theme;
     this._colorManager?.setTheme(theme);
     this._renderService?.setColors(this._colorManager!.colors);
-    this.viewport?.onThemeChange(this._colorManager!.colors);
+    this.viewport?.handleThemeChange(this._colorManager!.colors);
   }
 
   /**
@@ -860,20 +860,20 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
       // normal viewport scrolling
       // conditionally stop event, if the viewport still had rows to scroll within
-      if (this.viewport!.onWheel(ev)) {
+      if (this.viewport!.handleWheel(ev)) {
         return this.cancel(ev);
       }
     }, { passive: false }));
 
     this.register(addDisposableDomListener(el, 'touchstart', (ev: TouchEvent) => {
       if (this.coreMouseService.areMouseEventsActive) return;
-      this.viewport!.onTouchStart(ev);
+      this.viewport!.handleTouchStart(ev);
       return this.cancel(ev);
     }, { passive: true }));
 
     this.register(addDisposableDomListener(el, 'touchmove', (ev: TouchEvent) => {
       if (this.coreMouseService.areMouseEventsActive) return;
-      if (!this.viewport!.onTouchMove(ev)) {
+      if (!this.viewport!.handleTouchMove(ev)) {
         return this.cancel(ev);
       }
     }, { passive: false }));

--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -285,14 +285,14 @@ export class MockRenderer implements IRenderer {
   public registerDecoration(decorationOptions: IDecorationOptions): IDecoration {
     throw new Error('Method not implemented.');
   }
-  public onResize(cols: number, rows: number): void { }
-  public onCharSizeChanged(): void { }
-  public onBlur(): void { }
-  public onFocus(): void { }
-  public onSelectionChanged(start: [number, number], end: [number, number]): void { }
-  public onCursorMove(): void { }
-  public onOptionsChanged(): void { }
-  public onDevicePixelRatioChange(): void { }
+  public handleResize(cols: number, rows: number): void { }
+  public handleCharSizeChanged(): void { }
+  public handleBlur(): void { }
+  public handleFocus(): void { }
+  public handleSelectionChanged(start: [number, number], end: [number, number]): void { }
+  public handleCursorMove(): void { }
+  public handleOptionsChanged(): void { }
+  public handleDevicePixelRatioChange(): void { }
   public clear(): void { }
   public renderRows(start: number, end: number): void { }
 }
@@ -302,16 +302,16 @@ export class MockViewport implements IViewport {
     throw new Error('Method not implemented.');
   }
   public scrollBarWidth: number = 0;
-  public onThemeChange(colors: IColorSet): void {
+  public handleThemeChange(colors: IColorSet): void {
     throw new Error('Method not implemented.');
   }
-  public onWheel(ev: WheelEvent): boolean {
+  public handleWheel(ev: WheelEvent): boolean {
     throw new Error('Method not implemented.');
   }
-  public onTouchStart(ev: TouchEvent): void {
+  public handleTouchStart(ev: TouchEvent): void {
     throw new Error('Method not implemented.');
   }
-  public onTouchMove(ev: TouchEvent): boolean {
+  public handleTouchMove(ev: TouchEvent): boolean {
     throw new Error('Method not implemented.');
   }
   public syncScrollArea(): void { }
@@ -410,25 +410,25 @@ export class MockRenderService implements IRenderService {
   public setColors(colors: IColorSet): void {
     throw new Error('Method not implemented.');
   }
-  public onDevicePixelRatioChange(): void {
+  public handleDevicePixelRatioChange(): void {
     throw new Error('Method not implemented.');
   }
-  public onResize(cols: number, rows: number): void {
+  public handleResize(cols: number, rows: number): void {
     throw new Error('Method not implemented.');
   }
-  public onCharSizeChanged(): void {
+  public handleCharSizeChanged(): void {
     throw new Error('Method not implemented.');
   }
-  public onBlur(): void {
+  public handleBlur(): void {
     throw new Error('Method not implemented.');
   }
-  public onFocus(): void {
+  public handleFocus(): void {
     throw new Error('Method not implemented.');
   }
-  public onSelectionChanged(start: [number, number], end: [number, number], columnSelectMode: boolean): void {
+  public handleSelectionChanged(start: [number, number], end: [number, number], columnSelectMode: boolean): void {
     throw new Error('Method not implemented.');
   }
-  public onCursorMove(): void {
+  public handleCursorMove(): void {
     throw new Error('Method not implemented.');
   }
   public clear(): void {
@@ -498,7 +498,7 @@ export class MockSelectionService implements ISelectionService {
   public refresh(isLinuxMouseSelection?: boolean): void {
     throw new Error('Method not implemented.');
   }
-  public onMouseDown(event: MouseEvent): void {
+  public handleMouseDown(event: MouseEvent): void {
     throw new Error('Method not implemented.');
   }
   public isCellInSelection(x: number, y: number): boolean {

--- a/src/browser/Types.d.ts
+++ b/src/browser/Types.d.ts
@@ -108,7 +108,7 @@ export interface IBrowser {
 
 export interface IColorManager {
   colors: IColorSet;
-  onOptionsChange(key: string, value: any): void;
+  handleOptionsChange(key: string, value: any): void;
 }
 
 export interface IColorSet {
@@ -147,10 +147,10 @@ export interface IViewport extends IDisposable {
   scrollBarWidth: number;
   syncScrollArea(immediate?: boolean): void;
   getLinesScrolled(ev: WheelEvent): number;
-  onWheel(ev: WheelEvent): boolean;
-  onTouchStart(ev: TouchEvent): void;
-  onTouchMove(ev: TouchEvent): boolean;
-  onThemeChange(colors: IColorSet): void;
+  handleWheel(ev: WheelEvent): boolean;
+  handleTouchStart(ev: TouchEvent): void;
+  handleTouchMove(ev: TouchEvent): boolean;
+  handleThemeChange(colors: IColorSet): void;
 }
 
 export interface ILinkifierEvent {

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -77,7 +77,7 @@ export class Viewport extends Disposable implements IViewport {
     setTimeout(() => this.syncScrollArea(), 0);
   }
 
-  public onThemeChange(colors: IColorSet): void {
+  public handleThemeChange(colors: IColorSet): void {
     this._viewportElement.style.backgroundColor = colors.background.css;
   }
 
@@ -234,7 +234,7 @@ export class Viewport extends Disposable implements IViewport {
    * `Viewport`.
    * @param ev The mouse wheel event.
    */
-  public onWheel(ev: WheelEvent): boolean {
+  public handleWheel(ev: WheelEvent): boolean {
     const amount = this._getPixelsScrolled(ev);
     if (amount === 0) {
       return false;
@@ -315,7 +315,7 @@ export class Viewport extends Disposable implements IViewport {
    * Handles the touchstart event, recording the touch occurred.
    * @param ev The touch event.
    */
-  public onTouchStart(ev: TouchEvent): void {
+  public handleTouchStart(ev: TouchEvent): void {
     this._lastTouchY = ev.touches[0].pageY;
   }
 
@@ -323,7 +323,7 @@ export class Viewport extends Disposable implements IViewport {
    * Handles the touchmove event, scrolling the viewport if the position shifted.
    * @param ev The touch event.
    */
-  public onTouchMove(ev: TouchEvent): boolean {
+  public handleTouchMove(ev: TouchEvent): boolean {
     const deltaY = this._lastTouchY - ev.touches[0].pageY;
     this._lastTouchY = ev.touches[0].pageY;
     if (deltaY === 0) {

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -65,7 +65,7 @@ export class Viewport extends Disposable implements IViewport {
     // Unfortunately the overlay scrollbar would be hidden underneath the screen element in that case,
     // therefore we account for a standard amount to make it visible
     this.scrollBarWidth = (this._viewportElement.offsetWidth - this._scrollArea.offsetWidth) || FALLBACK_SCROLL_BAR_WIDTH;
-    this.register(addDisposableDomListener(this._viewportElement, 'scroll', this._onScroll.bind(this)));
+    this.register(addDisposableDomListener(this._viewportElement, 'scroll', this._handleScroll.bind(this)));
 
     // Track properties used in performance critical code manually to avoid using slow getters
     this._activeBuffer = this._bufferService.buffer;
@@ -157,7 +157,7 @@ export class Viewport extends Disposable implements IViewport {
    * terminal to scroll to it.
    * @param ev The scroll event.
    */
-  private _onScroll(ev: Event): void {
+  private _handleScroll(ev: Event): void {
     // Record current scroll top position
     this._lastScrollTop = this._viewportElement.scrollTop;
 

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -241,7 +241,7 @@ export class DomRenderer extends Disposable implements IRenderer {
     this._themeStyleElement.textContent = styles;
   }
 
-  public onDevicePixelRatioChange(): void {
+  public handleDevicePixelRatioChange(): void {
     this._updateDimensions();
   }
 
@@ -258,30 +258,30 @@ export class DomRenderer extends Disposable implements IRenderer {
     }
   }
 
-  public onResize(cols: number, rows: number): void {
+  public handleResize(cols: number, rows: number): void {
     this._refreshRowElements(cols, rows);
     this._updateDimensions();
   }
 
-  public onCharSizeChanged(): void {
+  public handleCharSizeChanged(): void {
     this._updateDimensions();
   }
 
-  public onBlur(): void {
+  public handleBlur(): void {
     this._rowContainer.classList.remove(FOCUS_CLASS);
   }
 
-  public onFocus(): void {
+  public handleFocus(): void {
     this._rowContainer.classList.add(FOCUS_CLASS);
   }
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
     // Remove all selections
     while (this._selectionContainer.children.length) {
       this._selectionContainer.removeChild(this._selectionContainer.children[0]);
     }
 
-    this._rowFactory.onSelectionChanged(start, end, columnSelectMode);
+    this._rowFactory.handleSelectionChanged(start, end, columnSelectMode);
     this.renderRows(0, this._bufferService.rows - 1);
 
     // Selection does not exist
@@ -341,11 +341,11 @@ export class DomRenderer extends Disposable implements IRenderer {
     return element;
   }
 
-  public onCursorMove(): void {
+  public handleCursorMove(): void {
     // No-op, the cursor is drawn when rows are drawn
   }
 
-  public onOptionsChanged(): void {
+  public handleOptionsChanged(): void {
     // Force a refresh
     this._updateDimensions();
     this._injectCss();

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -87,8 +87,8 @@ export class DomRenderer extends Disposable implements IRenderer {
     this._screenElement.appendChild(this._rowContainer);
     this._screenElement.appendChild(this._selectionContainer);
 
-    this.register(this._linkifier2.onShowLinkUnderline(e => this._onLinkHover(e)));
-    this.register(this._linkifier2.onHideLinkUnderline(e => this._onLinkLeave(e)));
+    this.register(this._linkifier2.onShowLinkUnderline(e => this._handleLinkHover(e)));
+    this.register(this._linkifier2.onHideLinkUnderline(e => this._handleLinkLeave(e)));
 
     this.register(toDisposable(() => {
       this._element.classList.remove(TERMINAL_CLASS_PREFIX + this._terminalClass);
@@ -376,11 +376,11 @@ export class DomRenderer extends Disposable implements IRenderer {
     return `.${TERMINAL_CLASS_PREFIX}${this._terminalClass}`;
   }
 
-  private _onLinkHover(e: ILinkifierEvent): void {
+  private _handleLinkHover(e: ILinkifierEvent): void {
     this._setCellUnderline(e.x1, e.x2, e.y1, e.y2, e.cols, true);
   }
 
-  private _onLinkLeave(e: ILinkifierEvent): void {
+  private _handleLinkLeave(e: ILinkifierEvent): void {
     this._setCellUnderline(e.x1, e.x2, e.y1, e.y2, e.cols, false);
   }
 

--- a/src/browser/renderer/dom/DomRendererRowFactory.test.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.test.ts
@@ -299,7 +299,7 @@ describe('DomRendererRowFactory', () => {
       it('should force selected cells with content to be rendered above the background', () => {
         lineData.setCell(0, CellData.fromCharData([DEFAULT_ATTR, 'a', 1, 'a'.charCodeAt(0)]));
         lineData.setCell(1, CellData.fromCharData([DEFAULT_ATTR, 'b', 1, 'b'.charCodeAt(0)]));
-        rowFactory.onSelectionChanged([1, 0], [2, 0], false);
+        rowFactory.handleSelectionChanged([1, 0], [2, 0], false);
         const fragment = rowFactory.createRow(lineData, 0, false, undefined, 0, false, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span>a</span><span class="xterm-decoration-top">b</span>'
@@ -307,7 +307,7 @@ describe('DomRendererRowFactory', () => {
       });
       it('should force whitespace cells to be rendered above the background', () => {
         lineData.setCell(1, CellData.fromCharData([DEFAULT_ATTR, 'a', 1, 'a'.charCodeAt(0)]));
-        rowFactory.onSelectionChanged([0, 0], [2, 0], false);
+        rowFactory.handleSelectionChanged([0, 0], [2, 0], false);
         const fragment = rowFactory.createRow(lineData, 0, false, undefined, 0, false, 5, 20);
         assert.equal(getFragmentHtml(fragment),
           '<span class="xterm-decoration-top"> </span><span class="xterm-decoration-top">a</span>'

--- a/src/browser/renderer/dom/DomRendererRowFactory.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.ts
@@ -48,7 +48,7 @@ export class DomRendererRowFactory {
     this._colors = colors;
   }
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
     this._selectionStart = start;
     this._selectionEnd = end;
     this._columnSelectMode = columnSelectMode;

--- a/src/browser/renderer/shared/Types.d.ts
+++ b/src/browser/renderer/shared/Types.d.ts
@@ -62,14 +62,14 @@ export interface IRenderer extends IDisposable {
 
   dispose(): void;
   setColors(colors: IColorSet): void;
-  onDevicePixelRatioChange(): void;
-  onResize(cols: number, rows: number): void;
-  onCharSizeChanged(): void;
-  onBlur(): void;
-  onFocus(): void;
-  onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
-  onCursorMove(): void;
-  onOptionsChanged(): void;
+  handleDevicePixelRatioChange(): void;
+  handleResize(cols: number, rows: number): void;
+  handleCharSizeChanged(): void;
+  handleBlur(): void;
+  handleFocus(): void;
+  handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  handleCursorMove(): void;
+  handleOptionsChanged(): void;
   clear(): void;
   renderRows(start: number, end: number): void;
   clearTextureAtlas?(): void;

--- a/src/browser/selection/SelectionModel.test.ts
+++ b/src/browser/selection/SelectionModel.test.ts
@@ -50,17 +50,17 @@ describe('SelectionModel', () => {
     it('should trim a portion of the selection when a part of it is trimmed', () => {
       model.selectionStart = [0, 0];
       model.selectionEnd = [10, 2];
-      model.onTrim(1);
+      model.handleTrim(1);
       assert.deepEqual(model.finalSelectionStart, [0, 0]);
       assert.deepEqual(model.finalSelectionEnd, [10, 1]);
-      model.onTrim(1);
+      model.handleTrim(1);
       assert.deepEqual(model.finalSelectionStart, [0, 0]);
       assert.deepEqual(model.finalSelectionEnd, [10, 0]);
     });
     it('should clear selection when it is trimmed in its entirety', () => {
       model.selectionStart = [0, 0];
       model.selectionEnd = [10, 0];
-      model.onTrim(1);
+      model.handleTrim(1);
       assert.deepEqual(model.finalSelectionStart, undefined);
       assert.deepEqual(model.finalSelectionEnd, undefined);
     });

--- a/src/browser/selection/SelectionModel.ts
+++ b/src/browser/selection/SelectionModel.ts
@@ -120,7 +120,7 @@ export class SelectionModel {
    * @param amount The amount the buffer is being trimmed.
    * @return Whether a refresh is necessary.
    */
-  public onTrim(amount: number): boolean {
+  public handleTrim(amount: number): boolean {
     // Adjust the selection position based on the trimmed amount.
     if (this.selectionStart) {
       this.selectionStart[1] -= amount;

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -92,13 +92,13 @@ export class RenderService extends Disposable implements IRenderService {
     // Detect whether IntersectionObserver is detected and enable renderer pause
     // and resume based on terminal visibility if so
     if ('IntersectionObserver' in coreBrowserService.window) {
-      const observer = new coreBrowserService.window.IntersectionObserver(e => this._onIntersectionChange(e[e.length - 1]), { threshold: 0 });
+      const observer = new coreBrowserService.window.IntersectionObserver(e => this._handleIntersectionChange(e[e.length - 1]), { threshold: 0 });
       observer.observe(screenElement);
       this.register({ dispose: () => observer.disconnect() });
     }
   }
 
-  private _onIntersectionChange(entry: IntersectionObserverEntry): void {
+  private _handleIntersectionChange(entry: IntersectionObserverEntry): void {
     this._isPaused = entry.isIntersecting === undefined ? (entry.intersectionRatio === 0) : !entry.isIntersecting;
 
     // Terminal was hidden on open

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -68,13 +68,13 @@ export class RenderService extends Disposable implements IRenderService {
     this.register(this._renderDebouncer);
 
     this._screenDprMonitor = new ScreenDprMonitor(coreBrowserService.window);
-    this._screenDprMonitor.setListener(() => this.onDevicePixelRatioChange());
+    this._screenDprMonitor.setListener(() => this.handleDevicePixelRatioChange());
     this.register(this._screenDprMonitor);
 
     this.register(bufferService.onResize(() => this._fullRefresh()));
     this.register(bufferService.buffers.onBufferActivate(() => this._renderer?.clear()));
     this.register(optionsService.onOptionChange(() => this._handleOptionsChanged()));
-    this.register(this._charSizeService.onCharSizeChange(() => this.onCharSizeChanged()));
+    this.register(this._charSizeService.onCharSizeChange(() => this.handleCharSizeChanged()));
 
     // Do a full refresh whenever any decoration is added or removed. This may not actually result
     // in changes but since decorations should be used sparingly or added/removed all in the same
@@ -87,7 +87,7 @@ export class RenderService extends Disposable implements IRenderService {
 
     // dprchange should handle this case, we need this as well for browsers that don't support the
     // matchMedia query.
-    this.register(addDisposableDomListener(coreBrowserService.window, 'resize', () => this.onDevicePixelRatioChange()));
+    this.register(addDisposableDomListener(coreBrowserService.window, 'resize', () => this.handleDevicePixelRatioChange()));
 
     // Detect whether IntersectionObserver is detected and enable renderer pause
     // and resume based on terminal visibility if so
@@ -132,7 +132,7 @@ export class RenderService extends Disposable implements IRenderService {
 
     // Update selection if needed
     if (this._needsSelectionRefresh) {
-      this._renderer.onSelectionChanged(this._selectionState.start, this._selectionState.end, this._selectionState.columnSelectMode);
+      this._renderer.handleSelectionChanged(this._selectionState.start, this._selectionState.end, this._selectionState.columnSelectMode);
       this._needsSelectionRefresh = false;
     }
 
@@ -153,7 +153,7 @@ export class RenderService extends Disposable implements IRenderService {
     if (!this._renderer) {
       return;
     }
-    this._renderer.onOptionsChanged();
+    this._renderer.handleOptionsChanged();
     this.refreshRows(0, this._rowCount - 1);
     this._fireOnCanvasResize();
   }
@@ -212,7 +212,7 @@ export class RenderService extends Disposable implements IRenderService {
     this._fullRefresh();
   }
 
-  public onDevicePixelRatioChange(): void {
+  public handleDevicePixelRatioChange(): void {
     // Force char size measurement as DomMeasureStrategy(getBoundingClientRect) is not stable
     // when devicePixelRatio changes
     this._charSizeService.measure();
@@ -220,44 +220,44 @@ export class RenderService extends Disposable implements IRenderService {
     if (!this._renderer) {
       return;
     }
-    this._renderer.onDevicePixelRatioChange();
+    this._renderer.handleDevicePixelRatioChange();
     this.refreshRows(0, this._rowCount - 1);
   }
 
-  public onResize(cols: number, rows: number): void {
+  public handleResize(cols: number, rows: number): void {
     if (!this._renderer) {
       return;
     }
     if (this._isPaused) {
-      this._pausedResizeTask.set(() => this._renderer!.onResize(cols, rows));
+      this._pausedResizeTask.set(() => this._renderer!.handleResize(cols, rows));
     } else {
-      this._renderer.onResize(cols, rows);
+      this._renderer.handleResize(cols, rows);
     }
     this._fullRefresh();
   }
 
   // TODO: Is this useful when we have onResize?
-  public onCharSizeChanged(): void {
-    this._renderer?.onCharSizeChanged();
+  public handleCharSizeChanged(): void {
+    this._renderer?.handleCharSizeChanged();
   }
 
-  public onBlur(): void {
-    this._renderer?.onBlur();
+  public handleBlur(): void {
+    this._renderer?.handleBlur();
   }
 
-  public onFocus(): void {
-    this._renderer?.onFocus();
+  public handleFocus(): void {
+    this._renderer?.handleFocus();
   }
 
-  public onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
+  public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
     this._selectionState.start = start;
     this._selectionState.end = end;
     this._selectionState.columnSelectMode = columnSelectMode;
-    this._renderer?.onSelectionChanged(start, end, columnSelectMode);
+    this._renderer?.handleSelectionChanged(start, end, columnSelectMode);
   }
 
-  public onCursorMove(): void {
-    this._renderer?.onCursorMove();
+  public handleCursorMove(): void {
+    this._renderer?.handleCursorMove();
   }
 
   public clear(): void {

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -376,7 +376,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * @param amount The amount the buffer is being trimmed.
    */
   private _onTrim(amount: number): void {
-    const needsRefresh = this._model.onTrim(amount);
+    const needsRefresh = this._model.handleTrim(amount);
     if (needsRefresh) {
       this.refresh();
     }
@@ -438,7 +438,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * Handles te mousedown event, setting up for a new selection.
    * @param event The mousedown event.
    */
-  public onMouseDown(event: MouseEvent): void {
+  public handleMouseDown(event: MouseEvent): void {
     this._mouseDownTimeStamp = event.timeStamp;
     // If we have selection, we want the context menu on right click even if the
     // terminal is in mouse mode.

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -134,15 +134,15 @@ export class SelectionService extends Disposable implements ISelectionService {
     super();
 
     // Init listeners
-    this._mouseMoveListener = event => this._onMouseMove(event as MouseEvent);
-    this._mouseUpListener = event => this._onMouseUp(event as MouseEvent);
+    this._mouseMoveListener = event => this._handleMouseMove(event as MouseEvent);
+    this._mouseUpListener = event => this._handleMouseUp(event as MouseEvent);
     this._coreService.onUserInput(() => {
       if (this.hasSelection) {
         this.clearSelection();
       }
     });
-    this._trimListener = this._bufferService.buffer.lines.onTrim(amount => this._onTrim(amount));
-    this.register(this._bufferService.buffers.onBufferActivate(e => this._onBufferActivate(e)));
+    this._trimListener = this._bufferService.buffer.lines.onTrim(amount => this._handleTrim(amount));
+    this.register(this._bufferService.buffers.onBufferActivate(e => this._handleBufferActivate(e)));
 
     this.enable();
 
@@ -375,7 +375,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * Handle the buffer being trimmed, adjust the selection position.
    * @param amount The amount the buffer is being trimmed.
    */
-  private _onTrim(amount: number): void {
+  private _handleTrim(amount: number): void {
     const needsRefresh = this._model.handleTrim(amount);
     if (needsRefresh) {
       this.refresh();
@@ -468,14 +468,14 @@ export class SelectionService extends Disposable implements ISelectionService {
     this._dragScrollAmount = 0;
 
     if (this._enabled && event.shiftKey) {
-      this._onIncrementalClick(event);
+      this._handleIncrementalClick(event);
     } else {
       if (event.detail === 1) {
-        this._onSingleClick(event);
+        this._handleSingleClick(event);
       } else if (event.detail === 2) {
-        this._onDoubleClick(event);
+        this._handleDoubleClick(event);
       } else if (event.detail === 3) {
-        this._onTripleClick(event);
+        this._handleTripleClick(event);
       }
     }
 
@@ -512,7 +512,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * position.
    * @param event The mouse event.
    */
-  private _onIncrementalClick(event: MouseEvent): void {
+  private _handleIncrementalClick(event: MouseEvent): void {
     if (this._model.selectionStart) {
       this._model.selectionEnd = this._getMouseBufferCoords(event);
     }
@@ -523,7 +523,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * start position.
    * @param event The mouse event.
    */
-  private _onSingleClick(event: MouseEvent): void {
+  private _handleSingleClick(event: MouseEvent): void {
     this._model.selectionStartLength = 0;
     this._model.isSelectAllActive = false;
     this._activeSelectionMode = this.shouldColumnSelect(event) ? SelectionMode.COLUMN : SelectionMode.NORMAL;
@@ -557,7 +557,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * Performs a double click, selecting the current word.
    * @param event The mouse event.
    */
-  private _onDoubleClick(event: MouseEvent): void {
+  private _handleDoubleClick(event: MouseEvent): void {
     if (this._selectWordAtCursor(event, true)) {
       this._activeSelectionMode = SelectionMode.WORD;
     }
@@ -568,7 +568,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * select mode.
    * @param event The mouse event.
    */
-  private _onTripleClick(event: MouseEvent): void {
+  private _handleTripleClick(event: MouseEvent): void {
     const coords = this._getMouseBufferCoords(event);
     if (coords) {
       this._activeSelectionMode = SelectionMode.LINE;
@@ -589,7 +589,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * end of the selection and refreshing the selection.
    * @param event The mousemove event.
    */
-  private _onMouseMove(event: MouseEvent): void {
+  private _handleMouseMove(event: MouseEvent): void {
     // If the mousemove listener is active it means that a selection is
     // currently being made, we should stop propagation to prevent mouse events
     // to be sent to the pty.
@@ -690,7 +690,7 @@ export class SelectionService extends Disposable implements ISelectionService {
    * Handles the mouseup event, removing the mousedown listeners.
    * @param event The mouseup event.
    */
-  private _onMouseUp(event: MouseEvent): void {
+  private _handleMouseUp(event: MouseEvent): void {
     const timeElapsed = event.timeStamp - this._mouseDownTimeStamp;
 
     this._removeMouseDownListeners();
@@ -746,14 +746,14 @@ export class SelectionService extends Disposable implements ISelectionService {
     this._onSelectionChange.fire();
   }
 
-  private _onBufferActivate(e: {activeBuffer: IBuffer, inactiveBuffer: IBuffer}): void {
+  private _handleBufferActivate(e: {activeBuffer: IBuffer, inactiveBuffer: IBuffer}): void {
     this.clearSelection();
     // Only adjust the selection on trim, shiftElements is rarely used (only in
     // reverseIndex) and delete in a splice is only ever used when the same
     // number of elements was just added. Given this is could actually be
     // beneficial to leave the selection as is for these cases.
     this._trimListener.dispose();
-    this._trimListener = e.activeBuffer.lines.onTrim(amount => this._onTrim(amount));
+    this._trimListener = e.activeBuffer.lines.onTrim(amount => this._handleTrim(amount));
   }
 
   /**

--- a/src/browser/services/Services.ts
+++ b/src/browser/services/Services.ts
@@ -74,14 +74,13 @@ export interface IRenderService extends IDisposable {
   hasRenderer(): boolean;
   setRenderer(renderer: IRenderer): void;
   setColors(colors: IColorSet): void;
-  onDevicePixelRatioChange(): void;
-  onResize(cols: number, rows: number): void;
-  // TODO: Is this useful when we have onResize?
-  onCharSizeChanged(): void;
-  onBlur(): void;
-  onFocus(): void;
-  onSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
-  onCursorMove(): void;
+  handleDevicePixelRatioChange(): void;
+  handleResize(cols: number, rows: number): void;
+  handleCharSizeChanged(): void;
+  handleBlur(): void;
+  handleFocus(): void;
+  handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void;
+  handleCursorMove(): void;
   clear(): void;
 }
 
@@ -110,7 +109,7 @@ export interface ISelectionService {
   shouldColumnSelect(event: KeyboardEvent | MouseEvent): boolean;
   shouldForceSelection(event: MouseEvent): boolean;
   refresh(isLinuxMouseSelection?: boolean): void;
-  onMouseDown(event: MouseEvent): void;
+  handleMouseDown(event: MouseEvent): void;
   isCellInSelection(x: number, y: number): boolean;
 }
 


### PR DESCRIPTION
This makes it clear that on* = an event (strict) and handle* = an event handler (not strict), and enforces future occurrences with eslint,

Fixes https://github.com/xtermjs/xterm.js/issues/4183