### PR TITLE
Capture data between terminal creation and connected to terminal in demo

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -17,8 +17,8 @@ function startServer() {
   expressWs(app);
 
   var terminals = {},
-      unsentOutput = {},
-      temporaryDisposable = {};
+    unsentOutput = {},
+    temporaryDisposable = {};
 
   app.use('/xterm.css', express.static(__dirname + '/../css/xterm.css'));
   app.get('/logo.png', (req, res) => {
@@ -81,7 +81,7 @@ function startServer() {
     temporaryDisposable[term.pid].dispose();
     delete temporaryDisposable[term.pid];
     ws.send(unsentOutput[term.pid]);
-
+    delete unsentOutput[term.pid];
 
     // unbuffered delivery after user input
     let userInput = false;
@@ -157,8 +157,6 @@ function startServer() {
       console.log('Closed terminal ' + term.pid);
       // Clean things up
       delete terminals[term.pid];
-      delete unsentOutput[term.pid];
-      delete temporaryDisposable[term.pid];
     });
   });
 


### PR DESCRIPTION
When I opened the demo terminal, the first line was missing. The terminal is functioning whatsoever. Looks like the terminal first line is sent before the terminal frontend is connected. Thanks to `ws.send(logs[term.pid]);` that line is sent to the terminal frontend when the terminal gets connected. 

This commit introducing this: https://github.com/xtermjs/xterm.js/commit/193d305dcd37537aa47758e580059ffd220b8723
This reverts it but keeps the higher timeout. 