### PR TITLE
'CSI 0 m' should clear the extended attribute

### DIFF
--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -1689,8 +1689,8 @@ describe('InputHandler', () => {
     });
   });
 
-  describe.only('Reset text attributes (SGR 0)', () => {
-    it('resets every attributes if there is no url', async () => {
+  describe('reset text attributes (SGR 0)', () => {
+    it('resets all attributes if there is no url', async () => {
       await inputHandler.parseP('\x1b[30m\x1b[40m\x1b[4m');
       assert.notEqual(inputHandler.curAttrData.fg, 0);
       assert.notEqual(inputHandler.curAttrData.bg, 0);
@@ -1702,7 +1702,7 @@ describe('InputHandler', () => {
       assert.isTrue(inputHandler.curAttrData.extended.isEmpty());
     });
 
-    it('resets every attributes except for the url', async () => {
+    it('resets all attributes except for the url', async () => {
       await inputHandler.parseP('\x1b[30m\x1b[40m\x1b[4m');
       await inputHandler.parseP('\x1b]8;;http://example.com\x1b\\');
       assert.notEqual(inputHandler.curAttrData.fg, 0);

--- a/src/common/InputHandler.test.ts
+++ b/src/common/InputHandler.test.ts
@@ -9,7 +9,7 @@ import { IBufferLine, IAttributeData, IColorEvent, ColorIndex, ColorRequestType 
 import { DEFAULT_ATTR_DATA } from 'common/buffer/BufferLine';
 import { CellData } from 'common/buffer/CellData';
 import { Attributes, BgFlags, UnderlineStyle } from 'common/buffer/Constants';
-import { AttributeData } from 'common/buffer/AttributeData';
+import { AttributeData, ExtendedAttrs } from 'common/buffer/AttributeData';
 import { Params } from 'common/parser/Params';
 import { MockCoreService, MockBufferService, MockOptionsService, MockLogService, MockCoreMouseService, MockCharsetService, MockUnicodeService, MockOscLinkService } from 'common/TestUtils.test';
 import { IBufferService, ICoreService } from 'common/services/Services';
@@ -1714,12 +1714,9 @@ describe('InputHandler', () => {
       await inputHandler.parseP('\x1b[m');
       assert.equal(inputHandler.curAttrData.fg, 0);
       assert.equal(inputHandler.curAttrData.bg, BgFlags.HAS_EXTENDED);
-      assert.equal(inputHandler.curAttrData.extended.urlId, urlId);
-      // Check that `extended._ext === 0`. Note that `extended.ext` does not
-      // equal `extended._ext` because it is affected by the url.
-      const extended = inputHandler.curAttrData.extended.clone();
-      extended.urlId = 0;
-      assert.equal(extended.ext, 0);
+      const expectedExtended = new ExtendedAttrs();
+      expectedExtended.urlId = urlId;
+      assert.deepEqual(inputHandler.curAttrData.extended, expectedExtended);
     });
   });
 

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -2360,14 +2360,14 @@ export class InputHandler extends Disposable implements IInputHandler {
     attr.fg = DEFAULT_ATTR_DATA.fg;
     attr.bg = DEFAULT_ATTR_DATA.bg;
 
+    // Reset `extended` except for the `urlId`.
     if (!attr.extended.isEmpty()) {
-      // Treat extended attrs as immutable, thus always clone from old one.
-      // This is needed since the buffer only holds references to it.
-      attr.extended = attr.extended.clone();
-      attr.extended.ext = 0;
+      const urlId = attr.extended.urlId;
+      attr.extended = DEFAULT_ATTR_DATA.extended.clone();
 
-      if (attr.extended.urlId) {
-        attr.bg |= BgFlags.HAS_EXTENDED;
+      if (urlId) {
+        attr.extended.urlId = urlId;
+        attr.updateExtended();
       }
     }
   }

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -2359,17 +2359,12 @@ export class InputHandler extends Disposable implements IInputHandler {
   private _processSGR0(attr: IAttributeData): void {
     attr.fg = DEFAULT_ATTR_DATA.fg;
     attr.bg = DEFAULT_ATTR_DATA.bg;
-
-    // Reset `extended` except for the `urlId`.
-    if (!attr.extended.isEmpty()) {
-      const urlId = attr.extended.urlId;
-      attr.extended = DEFAULT_ATTR_DATA.extended.clone();
-
-      if (urlId) {
-        attr.extended.urlId = urlId;
-        attr.updateExtended();
-      }
-    }
+    attr.extended = attr.extended.clone();
+    // Reset underline style and color. Note that we don't want to reset other
+    // fields such as the url id.
+    attr.extended.underlineStyle = UnderlineStyle.NONE;
+    attr.extended.underlineColor &= ~(Attributes.CM_MASK | Attributes.RGB_MASK);
+    attr.updateExtended();
   }
 
   /**


### PR DESCRIPTION
Before this change, `echo -e '\033[4m\033[m\033]8;;\033\hello'` will print 'hello' with a underline. This is what happened:

- `\033[4m`: set underline style
- `\033[m`: reset style. However, in [InputHandler.ts](https://github.com/xtermjs/xterm.js/blob/0b84d17b18e836a37ed544df337630709bc7aede/src/common/InputHandler.ts#L2441), we only reset the `fg` and `bg` but not the `extended` attribute.
- `\033]8;;\033\`: This trigger `_finishHyperlink()`, which resurrects the dirty extended attribute by calling `this._curAttrData.UpdateExtended()`.

This change fixes this by also resetting the `extended` attribute for 'CSI 0 m'. It also removes `_currentLinkId` from `InputHandler` and uses `_curAttrData.extended.urlId` directly so that we don't need to worry about keep them in sync any more.