### PR TITLE
Fix resize in demo

### DIFF
--- a/demo/client.ts
+++ b/demo/client.ts
@@ -615,10 +615,8 @@ function addDomListener(element: HTMLElement, type: string, handler: (...args: a
 }
 
 function updateTerminalSize(): void {
-  const cols = parseInt((document.getElementById(`opt-cols`) as HTMLInputElement).value, 10);
-  const rows = parseInt((document.getElementById(`opt-rows`) as HTMLInputElement).value, 10);
-  const width = (cols * term._core._renderService.dimensions.css.cell.width + term._core.viewport.scrollBarWidth).toString() + 'px';
-  const height = (rows * term._core._renderService.dimensions.css.cell.height).toString() + 'px';
+  const width = (term._core._renderService.dimensions.css.canvas.width + term._core.viewport.scrollBarWidth).toString() + 'px';
+  const height = (term._core._renderService.dimensions.css.canvas.height).toString() + 'px';
   terminalContainer.style.width = width;
   terminalContainer.style.height = height;
   addons.fit.instance.fit();


### PR DESCRIPTION
A double resize could happen due to the mismatch in canvas vs device pixel widths

Fixes #4113