### PR TITLE
Cache ICoreBrowserService.isFocused per task

### DIFF
--- a/src/browser/services/CoreBrowserService.ts
+++ b/src/browser/services/CoreBrowserService.ts
@@ -8,10 +8,15 @@ import { ICoreBrowserService } from './Services';
 export class CoreBrowserService implements ICoreBrowserService {
   public serviceBrand: undefined;
 
+  private _isFocused = false;
+  private _cachedIsFocused: boolean | undefined = undefined;
+
   constructor(
     private _textarea: HTMLTextAreaElement,
     public readonly window: Window & typeof globalThis
   ) {
+    this._textarea.addEventListener('focus', () => this._isFocused = true);
+    this._textarea.addEventListener('blur', () => this._isFocused = false);
   }
 
   public get dpr(): number {
@@ -19,7 +24,10 @@ export class CoreBrowserService implements ICoreBrowserService {
   }
 
   public get isFocused(): boolean {
-    const docOrShadowRoot = this._textarea.getRootNode ? this._textarea.getRootNode() as Document | ShadowRoot : this._textarea.ownerDocument;
-    return docOrShadowRoot.activeElement === this._textarea && this._textarea.ownerDocument.hasFocus();
+    if (this._cachedIsFocused === undefined) {
+      this._cachedIsFocused = this._isFocused && this._textarea.ownerDocument.hasFocus();
+      queueMicrotask(() => this._cachedIsFocused = undefined);
+    }
+    return this._cachedIsFocused;
   }
 }


### PR DESCRIPTION
This is called for every selected cell when rendering which ends up consuming a bunch of CPU due to the DOM calls.

When selecting everything and dragging up, notice the 6x CPU throttle

Before

![image](https://user-images.githubusercontent.com/2193314/198418442-b4612286-c4cf-4f63-aaa0-1dde68f87fa2.png)

After

![image](https://user-images.githubusercontent.com/2193314/198418434-ac332530-45f4-4b78-a3d5-13dda99c66e7.png)
