### PR TITLE
Continually merge texture atlas pages

### DIFF
--- a/addons/xterm-addon-web-links/src/WebLinkProvider.ts
+++ b/addons/xterm-addon-web-links/src/WebLinkProvider.ts
@@ -47,6 +47,12 @@ export class LinkComputer {
 
     const [line, startLineIndex] = LinkComputer._translateBufferLineToStringWithWrap(y - 1, false, terminal);
 
+    // Don't try if the wrapped line if excessively large as the regex matching will block the main
+    // thread.
+    if (line.length > 1024) {
+      return [];
+    }
+
     let match;
     let stringIndex = -1;
     const result: ILink[] = [];

--- a/addons/xterm-addon-webgl/src/GlyphRenderer.ts
+++ b/addons/xterm-addon-webgl/src/GlyphRenderer.ts
@@ -119,7 +119,9 @@ export class GlyphRenderer extends Disposable {
     const gl = this._gl;
 
     if (TextureAtlas.maxAtlasPages === undefined) {
+      // Typically 8 or 16
       TextureAtlas.maxAtlasPages = throwIfFalsy(gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number | null);
+      // Almost all clients will support >= 4096
       TextureAtlas.maxTextureSize = throwIfFalsy(gl.getParameter(gl.MAX_TEXTURE_SIZE) as number | null);
     }
 

--- a/addons/xterm-addon-webgl/src/GlyphRenderer.ts
+++ b/addons/xterm-addon-webgl/src/GlyphRenderer.ts
@@ -120,6 +120,7 @@ export class GlyphRenderer extends Disposable {
 
     if (TextureAtlas.maxAtlasPages === undefined) {
       TextureAtlas.maxAtlasPages = throwIfFalsy(gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number | null);
+      TextureAtlas.maxTextureSize = throwIfFalsy(gl.getParameter(gl.MAX_TEXTURE_SIZE) as number | null);
     }
 
     this._program = throwIfFalsy(createProgram(gl, vertexShaderSource, createFragmentShaderSource(TextureAtlas.maxAtlasPages)));

--- a/addons/xterm-addon-webgl/src/GlyphRenderer.ts
+++ b/addons/xterm-addon-webgl/src/GlyphRenderer.ts
@@ -11,6 +11,7 @@ import { Terminal } from 'xterm';
 import { IRasterizedGlyph, IRenderDimensions, ITextureAtlas } from 'browser/renderer/shared/Types';
 import { Disposable, toDisposable } from 'common/Lifecycle';
 import { throwIfFalsy } from 'browser/renderer/shared/RendererUtils';
+import { TextureAtlas } from 'browser/renderer/shared/TextureAtlas';
 
 interface IVertices {
   attributes: Float32Array;
@@ -108,8 +109,6 @@ export class GlyphRenderer extends Disposable {
     ]
   };
 
-  private static _maxAtlasPages: number | undefined;
-
   constructor(
     private readonly _terminal: Terminal,
     private readonly _gl: IWebGL2RenderingContext,
@@ -119,11 +118,11 @@ export class GlyphRenderer extends Disposable {
 
     const gl = this._gl;
 
-    if (GlyphRenderer._maxAtlasPages === undefined) {
-      GlyphRenderer._maxAtlasPages = throwIfFalsy(gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number | null);
+    if (TextureAtlas.maxAtlasPages === undefined) {
+      TextureAtlas.maxAtlasPages = throwIfFalsy(gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number | null);
     }
 
-    this._program = throwIfFalsy(createProgram(gl, vertexShaderSource, createFragmentShaderSource(GlyphRenderer._maxAtlasPages)));
+    this._program = throwIfFalsy(createProgram(gl, vertexShaderSource, createFragmentShaderSource(TextureAtlas.maxAtlasPages)));
     this.register(toDisposable(() => gl.deleteProgram(this._program)));
 
     // Uniform locations
@@ -178,8 +177,8 @@ export class GlyphRenderer extends Disposable {
 
     // Setup static uniforms
     gl.useProgram(this._program);
-    const textureUnits = new Int32Array(GlyphRenderer._maxAtlasPages);
-    for (let i = 0; i < GlyphRenderer._maxAtlasPages; i++) {
+    const textureUnits = new Int32Array(TextureAtlas.maxAtlasPages);
+    for (let i = 0; i < TextureAtlas.maxAtlasPages; i++) {
       textureUnits[i] = i;
     }
     gl.uniform1iv(this._textureLocation, textureUnits);
@@ -188,7 +187,7 @@ export class GlyphRenderer extends Disposable {
     // Setup 1x1 red pixel textures for all potential atlas pages, if one of these invalid textures
     // is ever drawn it will show characters as red rectangles.
     this._atlasTextures = [];
-    for (let i = 0; i < GlyphRenderer._maxAtlasPages; i++) {
+    for (let i = 0; i < TextureAtlas.maxAtlasPages; i++) {
       const texture = throwIfFalsy(gl.createTexture());
       this.register(toDisposable(() => gl.deleteTexture(texture)));
       gl.activeTexture(gl.TEXTURE0 + i);

--- a/addons/xterm-addon-webgl/src/WebglAddon.ts
+++ b/addons/xterm-addon-webgl/src/WebglAddon.ts
@@ -21,6 +21,8 @@ export class WebglAddon extends Disposable implements ITerminalAddon {
   public readonly onChangeTextureAtlas = this._onChangeTextureAtlas.event;
   private readonly _onAddTextureAtlasCanvas = this.register(new EventEmitter<HTMLCanvasElement>());
   public readonly onAddTextureAtlasCanvas = this._onAddTextureAtlasCanvas.event;
+  private readonly _onRemoveTextureAtlasCanvas = this.register(new EventEmitter<HTMLCanvasElement>());
+  public readonly onRemoveTextureAtlasCanvas = this._onRemoveTextureAtlasCanvas.event;
   private readonly _onContextLoss = this.register(new EventEmitter<void>());
   public readonly onContextLoss = this._onContextLoss.event;
 
@@ -67,6 +69,7 @@ export class WebglAddon extends Disposable implements ITerminalAddon {
     this.register(forwardEvent(this._renderer.onContextLoss, this._onContextLoss));
     this.register(forwardEvent(this._renderer.onChangeTextureAtlas, this._onChangeTextureAtlas));
     this.register(forwardEvent(this._renderer.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas));
+    this.register(forwardEvent(this._renderer.onRemoveTextureAtlasCanvas, this._onRemoveTextureAtlasCanvas));
     renderService.setRenderer(this._renderer);
 
     this.register(toDisposable(() => {

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -271,7 +271,6 @@ export class WebglRenderer extends Disposable implements IRenderer {
       this._charAtlasDisposable?.dispose();
       this._onChangeTextureAtlas.fire(atlas.pages[0].canvas);
       this._charAtlasDisposable = getDisposeArrayDisposable([
-        atlas.onRequestRedrawViewport(() => this._requestRedrawViewport()),
         forwardEvent(atlas.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas),
         forwardEvent(atlas.onRemoveTextureAtlasCanvas, this._onRemoveTextureAtlasCanvas)
       ]);

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -53,6 +53,8 @@ export class WebglRenderer extends Disposable implements IRenderer {
   public readonly onChangeTextureAtlas = this._onChangeTextureAtlas.event;
   private readonly _onAddTextureAtlasCanvas = this.register(new EventEmitter<HTMLCanvasElement>());
   public readonly onAddTextureAtlasCanvas = this._onAddTextureAtlasCanvas.event;
+  private readonly _onRemoveTextureAtlasCanvas = this.register(new EventEmitter<HTMLCanvasElement>());
+  public readonly onRemoveTextureAtlasCanvas = this._onRemoveTextureAtlasCanvas.event;
   private readonly _onRequestRedraw = this.register(new EventEmitter<IRequestRedrawEvent>());
   public readonly onRequestRedraw = this._onRequestRedraw.event;
   private readonly _onContextLoss = this.register(new EventEmitter<void>());
@@ -270,7 +272,8 @@ export class WebglRenderer extends Disposable implements IRenderer {
       this._onChangeTextureAtlas.fire(atlas.pages[0].canvas);
       this._charAtlasDisposable = getDisposeArrayDisposable([
         atlas.onRequestRedrawViewport(() => this._requestRedrawViewport()),
-        forwardEvent(atlas.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas)
+        forwardEvent(atlas.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas),
+        forwardEvent(atlas.onRemoveTextureAtlasCanvas, this._onRemoveTextureAtlasCanvas)
       ]);
     }
     this._charAtlas = atlas;

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -279,6 +279,7 @@ function createTerminal(): void {
       setTextureAtlas(addons.webgl.instance.textureAtlas);
       addons.webgl.instance.onChangeTextureAtlas(e => setTextureAtlas(e));
       addons.webgl.instance.onAddTextureAtlasCanvas(e => appendTextureAtlas(e));
+      addons.webgl.instance.onRemoveTextureAtlasCanvas(e => removeTextureAtlas(e));
     }
   }, 0);
 
@@ -661,6 +662,9 @@ function setTextureAtlas(e: HTMLCanvasElement): void {
 function appendTextureAtlas(e: HTMLCanvasElement): void {
   styleAtlasPage(e);
   document.querySelector('#texture-atlas').appendChild(e);
+}
+function removeTextureAtlas(e: HTMLCanvasElement): void {
+  e.remove();
 }
 function styleAtlasPage(e: HTMLCanvasElement): void {
   e.style.width = `${e.width / window.devicePixelRatio}px`;

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -220,6 +220,7 @@ if (document.location.pathname === '/test') {
   document.getElementById('custom-glyph').addEventListener('click', writeCustomGlyphHandler);
   document.getElementById('load-test').addEventListener('click', loadTest);
   document.getElementById('print-cjk').addEventListener('click', addCjk);
+  document.getElementById('print-cjk-sgr').addEventListener('click', addCjkRandomSgr);
   document.getElementById('powerline-symbol-test').addEventListener('click', powerlineSymbolTest);
   document.getElementById('underline-test').addEventListener('click', underlineTest);
   document.getElementById('ansi-colors').addEventListener('click', ansiColorsTest);
@@ -987,6 +988,25 @@ function addCjk(): void {
   for (let i = 0x4E00; i < 0x9FCC; i++) {
     term.write(String.fromCharCode(i));
   }
+}
+
+/**
+ * Prints the 20977 characters from the CJK Unified Ideographs unicode block with randomized styles.
+ */
+function addCjkRandomSgr(): void {
+  term.write('\n\n\r');
+  for (let i = 0x4E00; i < 0x9FCC; i++) {
+    term.write(`\x1b[${getRandomSgr()}m${String.fromCharCode(i)}\x1b[0m`);
+  }
+}
+const randomSgrAttributes = [
+  '1', '2', '3', '4', '5', '6', '7', '9',
+  '21', '22', '23', '24', '25', '26', '27', '28', '29',
+  '30', '31', '32', '33', '34', '35', '36', '37', '38', '39',
+  '40', '41', '42', '43', '44', '45', '46', '47', '48', '49'
+];
+function getRandomSgr(): string {
+  return randomSgrAttributes[Math.floor(Math.random() * randomSgrAttributes.length)];
 }
 
 function addDecoration(): void {

--- a/demo/index.html
+++ b/demo/index.html
@@ -75,6 +75,7 @@
               <dt>Performance</dt>
               <dd><button id="load-test" title="Write several MB of data to simulate a lot of data coming from the process">Load test</button></dd>
               <dd><button id="print-cjk" title="Prints the 20977 characters from the CJK Unified Ideographs unicode block">CJK Unified Ideographs</button></dd>
+              <dd><button id="print-cjk-sgr" title="Prints the 20977 characters from the CJK Unified Ideographs unicode block with randomized SGR attributes">CJK Unified Ideographs (random SGR)</button></dd>
 
               <dt>Styles</dt>
               <dd><button id="custom-glyph" title="Write custom box drawing and block element characters to the terminal">Test custom glyphs</button></dd>

--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -69,6 +69,8 @@ export class TextureAtlas implements ITextureAtlas {
 
   private _textureSize: number = 512;
 
+  public static maxAtlasPages: number | undefined;
+
   private readonly _onAddTextureAtlasCanvas = new EventEmitter<HTMLCanvasElement>();
   public readonly onAddTextureAtlasCanvas = this._onAddTextureAtlasCanvas.event;
 
@@ -140,7 +142,7 @@ export class TextureAtlas implements ITextureAtlas {
     //   this._increaseTextureSize();
     // }
 
-    if (!this._hasMerged && this._pages.length === 6) {
+    if (!this._hasMerged && this._pages.length === TextureAtlas.maxAtlasPages) {
       this._hasMerged = true;
       console.log('try merge');
       console.time('merge');
@@ -172,22 +174,7 @@ export class TextureAtlas implements ITextureAtlas {
 
       // TODO: Splice other 3 pages, shifting all other texture page props
       for (let i = sortedMergingPagesIndexes.length - 1; i >= 1; i--) {
-        // TODO: Optimize, this is slow
-        const mergingPageIndex = sortedMergingPagesIndexes[i];
-
-        console.log('splice', mergingPageIndex);
-        this._pages.splice(mergingPageIndex, 1);
-        for (let j = mergingPageIndex; j < this._pages.length; j++) {
-          const adjustingPage = this._pages[j];
-          console.log('adjust', j);
-          // if (mergingPages.includes(adjustingPage)) {
-          //   continue;
-          // }
-          for (const g of adjustingPage.glyphs) {
-            g.texturePage--;
-          }
-          adjustingPage.hasCanvasChanged = true;
-        }
+        this._deletePage(sortedMergingPagesIndexes[i]);
       }
 
       this._onAddTextureAtlasCanvas.fire(mergedPage.canvas);
@@ -237,6 +224,17 @@ export class TextureAtlas implements ITextureAtlas {
       }
     }
     return mergedPage;
+  }
+
+  private _deletePage(pageIndex: number): void {
+    this._pages.splice(pageIndex, 1);
+    for (let j = pageIndex; j < this._pages.length; j++) {
+      const adjustingPage = this._pages[j];
+      for (const g of adjustingPage.glyphs) {
+        g.texturePage--;
+      }
+      adjustingPage.hasCanvasChanged = true;
+    }
   }
 
   /**

--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -78,8 +78,6 @@ export class TextureAtlas implements ITextureAtlas {
   public static maxAtlasPages: number | undefined;
   public static maxTextureSize: number | undefined;
 
-  private readonly _onRequestRedrawViewport = new EventEmitter<void>();
-  public readonly onRequestRedrawViewport = this._onRequestRedrawViewport.event;
   private readonly _onAddTextureAtlasCanvas = new EventEmitter<HTMLCanvasElement>();
   public readonly onAddTextureAtlasCanvas = this._onAddTextureAtlasCanvas.event;
   private readonly _onRemoveTextureAtlasCanvas = new EventEmitter<HTMLCanvasElement>();
@@ -106,7 +104,6 @@ export class TextureAtlas implements ITextureAtlas {
     for (const page of this.pages) {
       page.canvas.remove();
     }
-    this._onRequestRedrawViewport.dispose();
     this._onAddTextureAtlasCanvas.dispose();
   }
 

--- a/src/browser/renderer/shared/Types.d.ts
+++ b/src/browser/renderer/shared/Types.d.ts
@@ -91,6 +91,7 @@ export interface ITextureAtlas extends IDisposable {
 
   onRequestRedrawViewport: IEvent<void>;
   onAddTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
+  onRemoveTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 
   /**
    * Warm up the texture atlas, adding common glyphs to avoid slowing early frame.

--- a/src/browser/renderer/shared/Types.d.ts
+++ b/src/browser/renderer/shared/Types.d.ts
@@ -89,6 +89,7 @@ export interface IRenderer extends IDisposable {
 export interface ITextureAtlas extends IDisposable {
   readonly pages: { canvas: HTMLCanvasElement, hasCanvasChanged: boolean }[];
 
+  onRequestRedrawViewport: IEvent<void>;
   onAddTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 
   /**

--- a/src/browser/renderer/shared/Types.d.ts
+++ b/src/browser/renderer/shared/Types.d.ts
@@ -89,7 +89,6 @@ export interface IRenderer extends IDisposable {
 export interface ITextureAtlas extends IDisposable {
   readonly pages: { canvas: HTMLCanvasElement, hasCanvasChanged: boolean }[];
 
-  onRequestRedrawViewport: IEvent<void>;
   onAddTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
   onRemoveTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
 


### PR DESCRIPTION
When atlas pages are created beyond a certain threshold determined by the webgl maximum texture units, the 4 largest and most used atlas pages are merged (eg. 512x512 -> 1024x1024). This continues to happen up to a maximum of 4096x4096 (16mb). The merging happens in a microtask so the current render cycle finishes as changing the texture would result in corrupted rendering. Atlas pages 1024x1024 and above are all immutable intentionally to avoid uploading large texture more than once.

The canvas rendering works with merged atlas pages but no maximum page count is enforced so if the atlas is only used by a canvas rendering, no merging occurs.

Fixes #4243
Fixes #4245 - webgl texture capacity will typically hit before this happens which is very hard to actually hit even in the demo
Fixes #4246 

Here's an example of a 2048x2048 texture atlas page after running the CJK test button.

![image](https://user-images.githubusercontent.com/2193314/199719095-2125a448-e2d2-4f09-aa61-05180e2e73e7.png)

There's also another CJK test button which helps stress test the renderer:

![image](https://user-images.githubusercontent.com/2193314/199718617-664d2d55-865f-4d60-9cfb-d0a0ce131f7c.png)