### PR TITLE
Enable the webgl renderer on safari 16 and above

### DIFF
--- a/addons/xterm-addon-webgl/src/WebglAddon.ts
+++ b/addons/xterm-addon-webgl/src/WebglAddon.ts
@@ -7,7 +7,7 @@ import { ICharacterJoinerService, ICharSizeService, ICoreBrowserService, IRender
 import { ITerminal } from 'browser/Types';
 import { EventEmitter, forwardEvent } from 'common/EventEmitter';
 import { Disposable, toDisposable } from 'common/Lifecycle';
-import { isSafari } from 'common/Platform';
+import { getSafariVersion, isSafari } from 'common/Platform';
 import { ICoreService, IDecorationService, IOptionsService } from 'common/services/Services';
 import { ICoreTerminal } from 'common/Types';
 import { ITerminalAddon, Terminal } from 'xterm';
@@ -33,8 +33,8 @@ export class WebglAddon extends Disposable implements ITerminalAddon {
   }
 
   public activate(terminal: Terminal): void {
-    if (isSafari) {
-      throw new Error('Webgl is not currently supported on Safari');
+    if (isSafari && getSafariVersion() < 16) {
+      throw new Error('Webgl2 is only supported on Safari 16 and above');
     }
 
     const core = (terminal as any)._core as ITerminal;

--- a/src/common/Platform.ts
+++ b/src/common/Platform.ts
@@ -20,6 +20,16 @@ const platform = (isNode) ? 'node' : navigator.platform;
 export const isFirefox = userAgent.includes('Firefox');
 export const isLegacyEdge = userAgent.includes('Edge');
 export const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent);
+export function getSafariVersion(): number {
+  if (!isSafari) {
+    return 0;
+  }
+  const majorVersion = userAgent.match(/Version\/(\d+)/);
+  if (majorVersion === null || majorVersion.length < 2) {
+    return 0;
+  }
+  return parseInt(majorVersion[1]);
+}
 
 // Find the users platform. We use this to interpret the meta key
 // and ISO third level shifts.


### PR DESCRIPTION
This does not fix the issue where webkit browsers cannot use it, I looked at webkit versions in safari and was a bit confused. The wikipedia page for safari shows v15 having webkit v612+ but I have safari v16 and it's webkit v605, so trying to detect it based on webkit version is a risky change.

Note that webgl2 shipped in safari 15, but it didn't work in webgl until safari 16.

Fixes #3357
Related #3575
Related microsoft/vscode#165416