### PR TITLE
Clear text area after finalizing composition

### DIFF
--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -58,7 +58,7 @@ describe('CompositionHelper', () => {
           // Second character 'ㅇ'
           compositionHelper.compositionstart();
           compositionHelper.compositionupdate({ data: 'ㅇ' });
-          textarea.value = 'ㅇㅇ';
+          textarea.value = 'ㅇ';
           setTimeout(() => { // wait for any textarea updates
             compositionHelper.compositionend();
             setTimeout(() => { // wait for any textarea updates
@@ -76,10 +76,11 @@ describe('CompositionHelper', () => {
       compositionHelper.compositionupdate({ data: 'ㅇ' });
       textarea.value = 'ㅇ';
       setTimeout(() => { // wait for any textarea updates
-        compositionHelper.compositionupdate({ data: '아' });
+        compositionHelper.compositionupdate({ data: 'ㅏ' });
         textarea.value = '아';
+        console.log(textarea.value);
         setTimeout(() => { // wait for any textarea updates
-          compositionHelper.compositionupdate({ data: '앙' });
+          compositionHelper.compositionupdate({ data: 'ㅇ' });
           textarea.value = '앙';
           setTimeout(() => { // wait for any textarea updates
             compositionHelper.compositionend();
@@ -88,13 +89,13 @@ describe('CompositionHelper', () => {
               // Second character '앙'
               compositionHelper.compositionstart();
               compositionHelper.compositionupdate({ data: 'ㅇ' });
-              textarea.value = '앙ㅇ';
+              textarea.value = 'ㅇ';
               setTimeout(() => { // wait for any textarea updates
-                compositionHelper.compositionupdate({ data: '아' });
-                textarea.value = '앙아';
+                compositionHelper.compositionupdate({ data: 'ㅏ' });
+                textarea.value = '아';
                 setTimeout(() => { // wait for any textarea updates
-                  compositionHelper.compositionupdate({ data: '앙' });
-                  textarea.value = '앙앙';
+                  compositionHelper.compositionupdate({ data: 'ㅇ' });
+                  textarea.value = '앙';
                   setTimeout(() => { // wait for any textarea updates
                     compositionHelper.compositionend();
                     setTimeout(() => { // wait for any textarea updates
@@ -116,22 +117,25 @@ describe('CompositionHelper', () => {
       compositionHelper.compositionupdate({ data: 'ㅇ' });
       textarea.value = 'ㅇ';
       setTimeout(() => { // wait for any textarea updates
-        compositionHelper.compositionupdate({ data: '아' });
+        compositionHelper.compositionupdate({ data: 'ㅏ' });
         textarea.value = '아';
         setTimeout(() => { // wait for any textarea updates
           // Start second character '아' in first character
-          compositionHelper.compositionupdate({ data: '앙' });
+          compositionHelper.compositionupdate({ data: 'ㅇ' });
           textarea.value = '앙';
           setTimeout(() => { // wait for any textarea updates
             compositionHelper.compositionend();
-            compositionHelper.compositionstart();
-            compositionHelper.compositionupdate({ data: '아' });
-            textarea.value = '아아';
-            setTimeout(() => { // wait for any textarea updates
-              compositionHelper.compositionend();
+            setTimeout(() => {
+              assert.equal(handledText, '앙');
+              compositionHelper.compositionstart();
+              compositionHelper.compositionupdate({ data: '아' });
+              textarea.value = '아';
               setTimeout(() => { // wait for any textarea updates
-                assert.equal(handledText, '아아');
-                done();
+                compositionHelper.compositionend();
+                setTimeout(() => { // wait for any textarea updates
+                  assert.equal(handledText, '앙아');
+                  done();
+                }, 0);
               }, 0);
             }, 0);
           }, 0);

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -169,6 +169,7 @@ export class CompositionHelper {
           }
           if (input.length > 0) {
             this._coreService.triggerDataEvent(input, true);
+            this._textarea.value = '';
           }
         }
       }, 0);


### PR DESCRIPTION
## Clear text area after finalizing composition
- Related issue: https://github.com/xtermjs/xterm.js/issues/4173

Previously stale text would display from text area in the composition helper when it heard the composition character. On some IMEs like GBoard this would manifest as the text propitiating after tapping delete, on others like the Samsung keyboard it would happen from tapping space. See attached videos for examples of before and after.

This PR clears the text area by setting `_textArea.value = ''` after finalizing the composition so when the composition is next started it does not contain the stale text and display it upon starting a new composition.

Previously I thought this change broke character composition, but after looking closer at `Compostionhelper.test.ts` and some additional manual testing to ensure everything works it seems the tests were checking for the presence of the uncleared `_textArea` text.

### Before

Gboard Example:

https://user-images.githubusercontent.com/3418052/201976368-f7215af3-a215-45b9-8aef-560f36b84418.mp4

Samsung Keyboard Example:

https://user-images.githubusercontent.com/3418052/201978752-ef45f952-e17b-4a79-ac77-28b91431dbe5.mp4

### After

Samsung Keyboard (kr):

https://user-images.githubusercontent.com/3418052/201982227-849909f2-6577-48eb-bdd5-1c0cc68fd1fd.mp4

Samsung Keyboard (en):

https://user-images.githubusercontent.com/3418052/201982181-934a24d5-4d47-42c7-b11c-bccb5ac33492.mp4



