### PR TITLE
Add option scrollOnUserInput

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -995,7 +995,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey;
 
     if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
-      if (this.options.scrollOnKeypress && this.buffer.ybase !== this.buffer.ydisp) {
+      if (this.options.scrollOnUserInput && this.buffer.ybase !== this.buffer.ydisp) {
         this._bufferService.scrollToBottom();
       }
       return false;

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -995,7 +995,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey;
 
     if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
-      if (this.buffer.ybase !== this.buffer.ydisp) {
+      if (this.options.scrollOnKeypress && this.buffer.ybase !== this.buffer.ydisp) {
         this._bufferService.scrollToBottom();
       }
       return false;

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -68,7 +68,7 @@ export class CoreService extends Disposable implements ICoreService {
 
     // Input is being sent to the terminal, the terminal should focus the prompt.
     const buffer = this._bufferService.buffer;
-    if (wasUserInput && this._optionsService.rawOptions.scrollOnKeypress && buffer.ybase !== buffer.ydisp) {
+    if (wasUserInput && this._optionsService.rawOptions.scrollOnUserInput && buffer.ybase !== buffer.ydisp) {
       this._scrollToBottom!();
     }
 

--- a/src/common/services/CoreService.ts
+++ b/src/common/services/CoreService.ts
@@ -68,7 +68,7 @@ export class CoreService extends Disposable implements ICoreService {
 
     // Input is being sent to the terminal, the terminal should focus the prompt.
     const buffer = this._bufferService.buffer;
-    if (buffer.ybase !== buffer.ydisp) {
+    if (wasUserInput && this._optionsService.rawOptions.scrollOnKeypress && buffer.ybase !== buffer.ydisp) {
       this._scrollToBottom!();
     }
 

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -28,7 +28,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   linkHandler: null,
   logLevel: 'info',
   scrollback: 1000,
-  scrollOnKeypress: true,
+  scrollOnUserInput: true,
   scrollSensitivity: 1,
   screenReaderMode: false,
   smoothScrollDuration: 0,

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -28,6 +28,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   linkHandler: null,
   logLevel: 'info',
   scrollback: 1000,
+  scrollOnKeypress: true,
   scrollSensitivity: 1,
   screenReaderMode: false,
   smoothScrollDuration: 0,

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -87,7 +87,7 @@ export interface ICoreService {
    * @param data The data that is being emitted.
    * @param wasFromUser Whether the data originated from the user (as opposed to
    * resulting from parsing incoming data). When true this will also:
-   * - Scroll to the bottom of the buffer.s
+   * - Scroll to the bottom of the buffer if option scrollOnKeypress is true.
    * - Fire the `onUserInput` event (so selection can be cleared).
    */
   triggerDataEvent(data: string, wasUserInput?: boolean): void;
@@ -243,6 +243,7 @@ export interface ITerminalOptions {
   rows?: number;
   screenReaderMode?: boolean;
   scrollback?: number;
+  scrollOnKeypress?: boolean;
   scrollSensitivity?: number;
   smoothScrollDuration?: number;
   tabStopWidth?: number;

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -85,9 +85,9 @@ export interface ICoreService {
   /**
    * Triggers the onData event in the public API.
    * @param data The data that is being emitted.
-   * @param wasFromUser Whether the data originated from the user (as opposed to
+   * @param wasUserInput Whether the data originated from the user (as opposed to
    * resulting from parsing incoming data). When true this will also:
-   * - Scroll to the bottom of the buffer if option scrollOnKeypress is true.
+   * - Scroll to the bottom of the buffer if option scrollOnUserInput is true.
    * - Fire the `onUserInput` event (so selection can be cleared).
    */
   triggerDataEvent(data: string, wasUserInput?: boolean): void;
@@ -243,7 +243,7 @@ export interface ITerminalOptions {
   rows?: number;
   screenReaderMode?: boolean;
   scrollback?: number;
-  scrollOnKeypress?: boolean;
+  scrollOnUserInput?: boolean;
   scrollSensitivity?: number;
   smoothScrollDuration?: number;
   tabStopWidth?: number;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -194,6 +194,12 @@ declare module 'xterm' {
     scrollback?: number;
 
     /**
+     * Whether to scroll to the bottom whenever a key is pressed. The default is
+     * true.
+     */
+    scrollOnKeypress?: boolean;
+
+    /**
      * The scrolling speed multiplier used for adjusting normal scrolling speed.
      */
     scrollSensitivity?: number;

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -194,10 +194,10 @@ declare module 'xterm' {
     scrollback?: number;
 
     /**
-     * Whether to scroll to the bottom whenever a key is pressed. The default is
-     * true.
+     * Whether to scroll to the bottom whenever there is some user input. The
+     * default is true.
      */
-    scrollOnKeypress?: boolean;
+    scrollOnUserInput?: boolean;
 
     /**
      * The scrolling speed multiplier used for adjusting normal scrolling speed.


### PR DESCRIPTION
Note that we also change the existing behavior a bit: CoreService.triggerDataEvent() will not scroll to the bottom unless `wasUserInput` is also true. This actually seems to be the intended behavior according to the doc just above
ICoreService.triggerDataEvent().

Also see issue #1824