### PR TITLE
Send corresponding escape code for alt+space and ctrl+alt+space

### DIFF
--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -125,6 +125,12 @@ describe('Keyboard', () => {
       it('should return \\x1ba for alt+a', () => {
         assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 65 }, { isMac: false }).key, '\x1ba');
       });
+      it('should return \\x1b\\x20 for alt+space', () => {
+        assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 32 }, { isMac: false }).key, '\x1b\x20');
+      });
+      it('should return \\x1b\\x00 for ctrl+alt+space', () => {
+        assert.equal(testEvaluateKeyboardEvent({ altKey: true, ctrlKey: true, keyCode: 32 }, { isMac: false }).key, '\x1b\x00');
+      });
     });
 
     describe('On macOS platforms', () => {

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -360,6 +360,8 @@ export function evaluateKeyboardEvent(
             keyString = keyString.toUpperCase();
           }
           result.key = C0.ESC + keyString;
+        } else if (ev.keyCode === 32) {
+          result.key = C0.ESC + (ev.ctrlKey ? C0.NUL : ' ');
         } else if (ev.key === 'Dead' && ev.code.startsWith('Key')) {
           // Reference: https://github.com/xtermjs/xterm.js/issues/3725
           // Alt will produce a "dead key" (initate composition) with some


### PR DESCRIPTION
The previous behavior is that this combinations do nothing.