### PR TITLE
Log a warning if task queues exceed deadline by 20ms

### DIFF
--- a/src/common/TaskQueue.ts
+++ b/src/common/TaskQueue.ts
@@ -79,8 +79,8 @@ abstract class TaskQueue implements ITaskQueue {
       if (longestTask * 1.5 > deadlineRemaining) {
         // Warn when the time exceeding the deadline is over 20ms, if this happens in practice the
         // task should be split into sub-tasks to ensure the UI remains responsive.
-        if (lastDeadlineRemaining - taskDuration < -5) {
-          console.warn(`task queue exceeded allotted deadline by ${Math.abs(Math.round(lastDeadlineRemaining - taskDuration))}ms`, { stacktrace: new Error().stack });
+        if (lastDeadlineRemaining - taskDuration < -20) {
+          console.warn(`task queue exceeded allotted deadline by ${Math.abs(Math.round(lastDeadlineRemaining - taskDuration))}ms`);
         }
         this._start();
         return;

--- a/src/common/TaskQueue.ts
+++ b/src/common/TaskQueue.ts
@@ -66,6 +66,8 @@ abstract class TaskQueue implements ITaskQueue {
     this._idleCallback = undefined;
     let taskDuration = 0;
     let longestTask = 0;
+    let lastDeadlineRemaining = deadline.timeRemaining();
+    let deadlineRemaining = 0;
     while (this._i < this._tasks.length) {
       taskDuration = performance.now();
       this._tasks[this._i++]();
@@ -73,10 +75,17 @@ abstract class TaskQueue implements ITaskQueue {
       longestTask = Math.max(taskDuration, longestTask);
       // Guess the following task will take a similar time to the longest task in this batch, allow
       // additional room to try avoid exceeding the deadline
-      if (longestTask * 1.5 > deadline.timeRemaining()) {
+      deadlineRemaining = deadline.timeRemaining();
+      if (longestTask * 1.5 > deadlineRemaining) {
+        // Warn when the time exceeding the deadline is over 20ms, if this happens in practice the
+        // task should be split into sub-tasks to ensure the UI remains responsive.
+        if (lastDeadlineRemaining - taskDuration < -5) {
+          console.warn(`task queue exceeded allotted deadline by ${Math.abs(Math.round(lastDeadlineRemaining - taskDuration))}ms`, { stacktrace: new Error().stack });
+        }
         this._start();
         return;
       }
+      lastDeadlineRemaining = deadlineRemaining;
     }
     this.clear();
   }


### PR DESCRIPTION
Fixes #4292

---

This shouldn't happen in practice if we do good, the idea is for these warnings to get reported back to us so we can split tasks up further.

Here's a simulation I did to test it by tweaking the number to 5ms and changing the texture atlas warmup to perform in a single callback:

![image](https://user-images.githubusercontent.com/2193314/206034088-8b3504e9-c2a9-42bc-9357-495b013b7adb.png)
![image](https://user-images.githubusercontent.com/2193314/206034054-d42c5893-e096-4ca9-91e6-6f24d6ffdb7c.png)

When profiling you don't get a full trace, but this is what it looks like normally (at least in dev):

![image](https://user-images.githubusercontent.com/2193314/206034163-929cb433-d830-4963-a8bb-56e460f3928f.png)
