### PR TITLE
Add allowNonHttpProtocols option to ILinkHandler

### DIFF
--- a/src/browser/OscLinkProvider.ts
+++ b/src/browser/OscLinkProvider.ts
@@ -69,8 +69,13 @@ export class OscLinkProvider implements ILinkProvider {
 
           let ignoreLink = false;
           if (!linkHandler?.allowNonHttpProtocols) {
-            const parsed = new URL(text);
-            if (!['http:', 'https:'].includes(parsed.protocol)) {
+            try {
+              const parsed = new URL(text);
+              if (!['http:', 'https:'].includes(parsed.protocol)) {
+                ignoreLink = true;
+              }
+            } catch (e) {
+              // Ignore invalid URLs to prevent unexpected behaviors
               ignoreLink = true;
             }
           }

--- a/src/browser/OscLinkProvider.ts
+++ b/src/browser/OscLinkProvider.ts
@@ -66,14 +66,25 @@ export class OscLinkProvider implements ILinkProvider {
               y
             }
           };
-          // OSC links always use underline and pointer decorations
-          result.push({
-            text,
-            range,
-            activate: (e, text) => (linkHandler ? linkHandler.activate(e, text, range) : defaultActivate(e, text)),
-            hover: (e, text) => linkHandler?.hover?.(e, text, range),
-            leave: (e, text) => linkHandler?.leave?.(e, text, range)
-          });
+
+          let ignoreLink = false;
+          if (!linkHandler?.allowNonHttpProtocols) {
+            const parsed = new URL(text);
+            if (!['http:', 'https:'].includes(parsed.protocol)) {
+              ignoreLink = true;
+            }
+          }
+
+          if (!ignoreLink) {
+            // OSC links always use underline and pointer decorations
+            result.push({
+              text,
+              range,
+              activate: (e, text) => (linkHandler ? linkHandler.activate(e, text, range) : defaultActivate(e, text)),
+              hover: (e, text) => linkHandler?.hover?.(e, text, range),
+              leave: (e, text) => linkHandler?.leave?.(e, text, range)
+            });
+          }
         }
         finishLink = false;
 

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -1181,9 +1181,9 @@ declare module 'xterm' {
      leave?(event: MouseEvent, text: string, range: IBufferRange): void;
     
      /**
-      * Whether to allow the use of non HTTP URLs in OscLinkProvider. When false, any usage of non
-      * HTTP URLs will be ignored. Enabling this option without proper protection in activate function
-      * may allow XSS.
+      * Whether to receive non HTTP URLs from LinkProvider. When false, any usage of non HTTP URLs
+      * will be ignored. Enabling this option without proper protection in `activate` function
+      * may cause security issues such as XSS.
       */
      allowNonHttpProtocols?: boolean;
   }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -1181,7 +1181,7 @@ declare module 'xterm' {
      leave?(event: MouseEvent, text: string, range: IBufferRange): void;
     
      /**
-      * Whether to receive non HTTP URLs from LinkProvider. When false, any usage of non HTTP URLs
+      * Whether to receive non-HTTP URLs from LinkProvider. When false, any usage of non-HTTP URLs
       * will be ignored. Enabling this option without proper protection in `activate` function
       * may cause security issues such as XSS.
       */

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -1179,6 +1179,13 @@ declare module 'xterm' {
       * @param range The buffer range of the link.
       */
      leave?(event: MouseEvent, text: string, range: IBufferRange): void;
+    
+     /**
+      * Whether to allow the use of non HTTP URLs in OscLinkProvider. When false, any usage of non
+      * HTTP URLs will be ignored. Enabling this option without proper protection in activate function
+      * may allow XSS.
+      */
+     allowNonHttpProtocols?: boolean;
   }
 
   /**


### PR DESCRIPTION
This pull request adds an option called `allowNonHttpProtocols` to `ILinkHandler`.
When this option is false, all non-HTTP URLs will be ignored in OscLinkProvider.