### PR TITLE
Revert "SerializeAsHTML(): Fallback to default ansi colors when running headless terminal"

### DIFF
--- a/addons/xterm-addon-serialize/src/SerializeAddon.test.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.test.ts
@@ -74,7 +74,7 @@ describe('xterm-addon-serialize', () => {
     terminal = new Terminal({ cols: 10, rows: 2, allowProposedApi: true });
     terminal.loadAddon(serializeAddon);
 
-    (terminal as any)._core._themeService = new ThemeService((terminal as any)._core.optionsService);
+    (terminal as any)._core._themeService = new ThemeService(new OptionsService({}));
     (terminal as any)._core._selectionService = new TestSelectionService((terminal as any)._core._bufferService);
   });
 
@@ -204,26 +204,6 @@ describe('xterm-addon-serialize', () => {
         includeGlobalBackground: true
       });
       assert.equal((output.match(/color: #ffffff; background-color: #000000; font-family: courier-new, courier, monospace; font-size: 15px;/g) || []).length, 1, output);
-    });
-
-    it('cells with custom color styling', async () => {
-      terminal.options.theme.black = '#ffa500';
-      terminal.options.theme = { ... terminal.options.theme };
-
-      await writeP(terminal, ' ' + sgr('38;5;0') + 'terminal' + sgr('39') + ' ');
-
-      const output = serializeAddon.serializeAsHTML();
-      assert.equal((output.match(/<span style='color: #ffa500;'>terminal<\/span>/g) || []).length, 1, output);
-    });
-
-    it('cells with color styling - xterm headless', async () => {
-      // a headless terminal doesn't have a themeservice
-      (terminal as any)._core._themeService = undefined;
-
-      await writeP(terminal, ' ' + sgr('38;5;46') + 'terminal' + sgr('39') + ' ');
-
-      const output = serializeAddon.serializeAsHTML();
-      assert.equal((output.match(/<span style='color: #00ff00;'>terminal<\/span>/g) || []).length, 1, output);
     });
   });
 });

--- a/addons/xterm-addon-serialize/src/SerializeAddon.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.ts
@@ -7,8 +7,7 @@
 
 import { Terminal, ITerminalAddon, IBuffer, IBufferCell, IBufferRange } from 'xterm';
 import { IColorSet } from 'browser/Types';
-import { IAttributeData, IColor } from 'common/Types';
-import { DEFAULT_ANSI_COLORS } from 'browser/services/ThemeService';
+import { IAttributeData } from 'common/Types';
 
 function constrain(value: number, low: number, high: number): number {
   return Math.max(low, Math.min(value, high));
@@ -535,7 +534,7 @@ export class HTMLSerializeHandler extends BaseSerializeHandler {
 
   private _htmlContent = '';
 
-  private _ansiColors: Readonly<IColor[]>;
+  private _colors: IColorSet;
 
   constructor(
     buffer: IBuffer,
@@ -544,13 +543,8 @@ export class HTMLSerializeHandler extends BaseSerializeHandler {
   ) {
     super(buffer);
 
-    // For xterm headless: fallback to ansi colors
-    if ((_terminal as any)._core._themeService) {
-      this._ansiColors = (_terminal as any)._core._themeService.colors.ansi;
-    }
-    else {
-      this._ansiColors = DEFAULT_ANSI_COLORS;
-    }
+    // https://github.com/xtermjs/xterm.js/issues/3601
+    this._colors = (_terminal as any)._core._themeService.colors;
   }
 
   private _padStart(target: string, targetLength: number, padString: string): string {
@@ -606,7 +600,7 @@ export class HTMLSerializeHandler extends BaseSerializeHandler {
       return rgb.map(x => this._padStart(x.toString(16), 2, '0')).join('');
     }
     if (isFg ? cell.isFgPalette() : cell.isBgPalette()) {
-      return this._ansiColors[color].css;
+      return this._colors.ansi[color].css;
     }
     return undefined;
   }


### PR DESCRIPTION
Reverts xtermjs/xterm.js#4196

This caused an issue when packaging v5.1:

```
assets by status 10.3 KiB [cached] 1 asset
./out/SerializeAddon.js 22.5 KiB [built] [code generated]

ERROR in ./out/SerializeAddon.js 4:23-63
Module not found: Error: Can't resolve 'browser/services/ThemeService' in '/home/vsts/work/1/s/addons/xterm-addon-serialize/out'
resolve 'browser/services/ThemeService' in '/home/vsts/work/1/s/addons/xterm-addon-serialize/out'
  Parsed request is a module
  using description file: /home/vsts/work/1/s/addons/xterm-addon-serialize/package.json (relative path: ./out)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /home/vsts/work/1/s/addons/xterm-addon-serialize/out/node_modules doesn't exist or is not a directory
      /home/vsts/work/1/s/addons/xterm-addon-serialize/node_modules doesn't exist or is not a directory
      /home/vsts/work/1/s/addons/node_modules doesn't exist or is not a directory
      looking for modules in /home/vsts/work/1/s/node_modules
        /home/vsts/work/1/s/node_modules/browser doesn't exist
      /home/vsts/work/1/node_modules doesn't exist or is not a directory
      looking for modules in /home/vsts/work/node_modules
        /home/vsts/work/node_modules/browser doesn't exist
      /home/vsts/node_modules doesn't exist or is not a directory
      /home/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory

webpack 5.61.0 compiled with 1 error in 747 ms
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! xterm-addon-serialize@0.9.0 package: `../../node_modules/.bin/webpack`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the xterm-addon-serialize@0.9.0 package script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/vsts/.npm/_logs/2022-12-19T18_07_51_333Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! xterm-addon-serialize@0.9.0 prepublishOnly: `npm run package`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the xterm-addon-serialize@0.9.0 prepublishOnly script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/vsts/.npm/_logs/2022-12-19T18_07_51_363Z-debug.log
Spawn exited with code 1
##[error]Bash exited with code '1'.
```