### PR TITLE
Improve rendering of dotted underlines

### DIFF
--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -587,7 +587,7 @@ export class TextureAtlas implements ITextureAtlas {
             );
             break;
           case UnderlineStyle.DOTTED:
-            this._tmpCtx.setLineDash([this._config.devicePixelRatio * 2, this._config.devicePixelRatio]);
+            this._tmpCtx.setLineDash([Math.round(lineWidth), Math.round(lineWidth)]);
             this._tmpCtx.moveTo(xChLeft, yTop);
             this._tmpCtx.lineTo(xChRight, yTop);
             break;


### PR DESCRIPTION
Fixes #4060

Moving the different rendering depending on x offset discussion into a new issue: 

New

1 dpr:

![image](https://user-images.githubusercontent.com/2193314/209409313-930ffc51-b71d-46fa-8394-e684d74a1483.png)
![image](https://user-images.githubusercontent.com/2193314/209409334-63b995e6-dc54-41ea-8924-0ad465d0093a.png)

1.5 dpr:

![image](https://user-images.githubusercontent.com/2193314/209409265-6992f900-5ed7-4365-9775-8db740be5057.png)
![image](https://user-images.githubusercontent.com/2193314/209409273-39bce9e5-378c-43cb-8754-dd220da32cff.png)

2 dpr:

![image](https://user-images.githubusercontent.com/2193314/209409348-bc590397-f8bb-4fac-baf2-ebde5e4b2aa8.png)
![image](https://user-images.githubusercontent.com/2193314/209409352-e2bfd77d-bf13-4a68-88cc-2357c32cfdfe.png)
