### PR TITLE
defer focus when accessibility buffer is active

### DIFF
--- a/src/browser/AccessibilityManager.ts
+++ b/src/browser/AccessibilityManager.ts
@@ -93,10 +93,16 @@ export class AccessibilityManager extends Disposable {
     this._accessiblityBuffer = document.createElement('textarea');
     this._accessiblityBuffer.ariaLabel = Strings.accessibilityBuffer;
     this._accessiblityBuffer.classList.add('xterm-accessibility-buffer');
+    this.register(addDisposableDomListener(this._accessiblityBuffer!, 'keydown', (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape' || ev.key === 'Tab') {
+        this._terminal?.textarea?.focus();
+      }}
+    ));
     this._accessiblityBuffer.addEventListener('focus', () => this._refreshAccessibilityBuffer());
     this._accessibilityTreeRoot.appendChild(this._accessiblityBuffer);
 
     this.register(this._renderRowsDebouncer);
+    this.register(this._terminal.onFocus(() => this._refreshAccessibilityBuffer()));
     this.register(this._terminal.onResize(e => this._handleResize(e.rows)));
     this.register(this._terminal.onRender(e => this._refreshRows(e.start, e.end)));
     this.register(this._terminal.onScroll(() => this._refreshRows()));
@@ -265,7 +271,7 @@ export class AccessibilityManager extends Disposable {
     // Only add the char if there is no control character.
     if (!/\p{Control}/u.test(keyChar)) {
       this._charsToConsume.push(keyChar);
-    }
+    } 
   }
 
   private _refreshRows(start?: number, end?: number): void {

--- a/src/browser/AccessibilityManager.ts
+++ b/src/browser/AccessibilityManager.ts
@@ -102,7 +102,6 @@ export class AccessibilityManager extends Disposable {
     this._accessibilityTreeRoot.appendChild(this._accessiblityBuffer);
 
     this.register(this._renderRowsDebouncer);
-    this.register(this._terminal.onFocus(() => this._refreshAccessibilityBuffer()));
     this.register(this._terminal.onResize(e => this._handleResize(e.rows)));
     this.register(this._terminal.onRender(e => this._refreshRows(e.start, e.end)));
     this.register(this._terminal.onScroll(() => this._refreshRows()));

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -259,6 +259,9 @@ export class Terminal extends CoreTerminal implements ITerminal {
    * Focus the terminal. Delegates focus handling to the terminal's DOM element.
    */
   public focus(): void {
+    if (document.querySelector('.xterm-accessibility-buffer:focus')) {
+      return;
+    }
     if (this.textarea) {
       this.textarea.focus({ preventScroll: true });
     }


### PR DESCRIPTION
When `escape` or `tab` is pressed, exit the accessibility buffer. Otherwise, disallow focusing of the terminal text area 

https://github.com/microsoft/vscode/issues/172200