### PR TITLE
Add measureParent flag to FitAdd.

### DIFF
--- a/addons/xterm-addon-fit/src/FitAddon.ts
+++ b/addons/xterm-addon-fit/src/FitAddon.ts
@@ -23,8 +23,11 @@ const MINIMUM_ROWS = 1;
 
 export class FitAddon implements ITerminalAddon {
   private _terminal: Terminal | undefined;
+  private _measureParent: boolean;
 
-  constructor() {}
+  constructor(measureParent: boolean = true) {
+    this._measureParent =  measureParent;
+  }
 
   public activate(terminal: Terminal): void {
     this._terminal = terminal;
@@ -68,9 +71,12 @@ export class FitAddon implements ITerminalAddon {
     const scrollbarWidth = this._terminal.options.scrollback === 0 ?
       0 : core.viewport.scrollBarWidth;
 
-    const parentElementStyle = window.getComputedStyle(this._terminal.element.parentElement);
-    const parentElementHeight = parseInt(parentElementStyle.getPropertyValue('height'));
-    const parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width')));
+    const measureElement = this._measureParent
+      ? this._terminal.element.parentElement
+      : this._terminal.element;
+    const measureElementStyle = window.getComputedStyle(measureElement);
+    const measureElementHeight = parseInt(measureElementStyle.getPropertyValue('height'));
+    const measureElementWidth = Math.max(0, parseInt(measureElementStyle.getPropertyValue('width')));
     const elementStyle = window.getComputedStyle(this._terminal.element);
     const elementPadding = {
       top: parseInt(elementStyle.getPropertyValue('padding-top')),
@@ -80,8 +86,8 @@ export class FitAddon implements ITerminalAddon {
     };
     const elementPaddingVer = elementPadding.top + elementPadding.bottom;
     const elementPaddingHor = elementPadding.right + elementPadding.left;
-    const availableHeight = parentElementHeight - elementPaddingVer;
-    const availableWidth = parentElementWidth - elementPaddingHor - scrollbarWidth;
+    const availableHeight = measureElementHeight - elementPaddingVer;
+    const availableWidth = measureElementWidth - elementPaddingHor - scrollbarWidth;
     const geometry = {
       cols: Math.max(MINIMUM_COLS, Math.floor(availableWidth / dims.css.cell.width)),
       rows: Math.max(MINIMUM_ROWS, Math.floor(availableHeight / dims.css.cell.height))


### PR DESCRIPTION
The default is true, which causes the 'fit' function to measure the xterm.element.parentElement (the old behavior); if the setting is false, the xterm.element itself is measured. One or the other may be preferable, depending on how xterm is embedded.

Background: I have added an option to [DomTerm](https://domterm.org) to use xterm.js for the terminal emulator (in places of DomTerm's native terminal emulator): [see here](https://github.com/PerBothner/DomTerm/blob/master/README-xtermjs.md).  DomTerm supports tabs and tiles, using [my fork of GoldenLayout](https://github.com/PerBothner/golden-layout),  The way these tiles are managed clashes with how the `FitAddon` checks the the size of the parent of the xterm element. The changes adds an optional boolean to the `FitAddon` constructor. The default (`true`) preserves the old behavior.  Passing `false` to the constructor fixes `fit`.

It is possible a default of `false` would make more sense, but that might break some embeddings. It is possible I am missing some fundamental assumtion that the xterm element is the only child of its parent - though I am hoping we can avoid that extra level of nesting.