### PR TITLE
Clear whole cursor layer on Firefox

### DIFF
--- a/addons/xterm-addon-canvas/src/CursorRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/CursorRenderLayer.ts
@@ -13,6 +13,7 @@ import { IEventEmitter } from 'common/EventEmitter';
 import { ICoreBrowserService, IThemeService } from 'browser/services/Services';
 import { Terminal } from 'xterm';
 import { toDisposable } from 'common/Lifecycle';
+import { isFirefox } from 'common/Platform';
 
 interface ICursorState {
   x: number;
@@ -190,8 +191,9 @@ export class CursorRenderLayer extends BaseRenderLayer {
 
   private _clearCursor(): void {
     if (this._state) {
-      // Avoid potential rounding errors when device pixel ratio is less than 1
-      if (this._coreBrowserService.dpr < 1) {
+      // Avoid potential rounding errors when browser is Firefox (#4487) or device pixel ratio is
+      // less than 1
+      if (isFirefox || this._coreBrowserService.dpr < 1) {
         this._clearAll();
       } else {
         this._clearCells(this._state.x, this._state.y, this._state.width, 1);

--- a/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/CursorRenderLayer.ts
@@ -12,6 +12,7 @@ import { IEventEmitter } from 'common/EventEmitter';
 import { ICoreBrowserService, IThemeService } from 'browser/services/Services';
 import { ICoreService, IOptionsService } from 'common/services/Services';
 import { toDisposable } from 'common/Lifecycle';
+import { isFirefox } from 'common/Platform';
 
 interface ICursorState {
   x: number;
@@ -190,8 +191,9 @@ export class CursorRenderLayer extends BaseRenderLayer {
 
   private _clearCursor(): void {
     if (this._state) {
-      // Avoid potential rounding errors when device pixel ratio is less than 1
-      if (this._coreBrowserService.dpr < 1) {
+      // Avoid potential rounding errors when browser is Firefox (#4487) or device pixel ratio is
+      // less than 1
+      if (isFirefox || this._coreBrowserService.dpr < 1) {
         this._clearAll();
       } else {
         this._clearCells(this._state.x, this._state.y, this._state.width, 1);


### PR DESCRIPTION
Fixes #4487

I could not reproduce this but it should fix the problem.