### PR TITLE
Avoid triggering a reflow while rendering search decorations

### DIFF
--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -693,9 +693,6 @@ export class SearchAddon extends Disposable implements ITerminalAddon {
    * @returns
    */
   private _applyStyles(element: HTMLElement, borderColor: string | undefined, isActiveResult: boolean): void {
-    if (element.clientWidth <= 0) {
-      return;
-    }
     if (!element.classList.contains('xterm-find-result-decoration')) {
       element.classList.add('xterm-find-result-decoration');
       if (borderColor) {


### PR DESCRIPTION
It's making vcode terminal super slow while scrolling

![image](https://github.com/xtermjs/xterm.js/assets/25115070/328aceaa-e1bd-4c3c-9124-2b484eb65048)
