### PR TITLE
Add logger delegate option

### DIFF
--- a/src/common/services/LogService.ts
+++ b/src/common/services/LogService.ts
@@ -57,30 +57,30 @@ export class LogService extends Disposable implements ILogService {
 
   private _log(type: LogType, message: string, optionalParams: any[]): void {
     this._evalLazyOptionalParams(optionalParams);
-    type.call(console, LOG_PREFIX + message, ...optionalParams);
+    type.call(console, (this._optionsService.options.logger ? '' : LOG_PREFIX) + message, ...optionalParams);
   }
 
   public debug(message: string, ...optionalParams: any[]): void {
     if (this.logLevel <= LogLevelEnum.DEBUG) {
-      this._log(console.log, message, optionalParams);
+      this._log(this._optionsService.options.logger?.debug ?? console.log, message, optionalParams);
     }
   }
 
   public info(message: string, ...optionalParams: any[]): void {
     if (this.logLevel <= LogLevelEnum.INFO) {
-      this._log(console.info, message, optionalParams);
+      this._log(this._optionsService.options.logger?.info ?? console.info, message, optionalParams);
     }
   }
 
   public warn(message: string, ...optionalParams: any[]): void {
     if (this.logLevel <= LogLevelEnum.WARN) {
-      this._log(console.warn, message, optionalParams);
+      this._log(this._optionsService.options.logger?.warn ?? console.warn, message, optionalParams);
     }
   }
 
   public error(message: string, ...optionalParams: any[]): void {
     if (this.logLevel <= LogLevelEnum.ERROR) {
-      this._log(console.error, message, optionalParams);
+      this._log(this._optionsService.options.logger?.error ?? console.error, message, optionalParams);
     }
   }
 }

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -27,6 +27,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   letterSpacing: 0,
   linkHandler: null,
   logLevel: 'info',
+  logger: null,
   scrollback: 1000,
   scrollOnUserInput: true,
   scrollSensitivity: 1,

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -7,7 +7,7 @@ import { IEvent, IEventEmitter } from 'common/EventEmitter';
 import { IBuffer, IBufferSet } from 'common/buffer/Types';
 import { IDecPrivateModes, ICoreMouseEvent, CoreMouseEncoding, ICoreMouseProtocol, CoreMouseEventType, ICharset, IWindowOptions, IModes, IAttributeData, ScrollSource, IDisposable, IColor, CursorStyle, IOscLinkData } from 'common/Types';
 import { createDecorator } from 'common/services/ServiceRegistry';
-import { IDecorationOptions, IDecoration, ILinkHandler, IWindowsPty } from 'xterm';
+import { IDecorationOptions, IDecoration, ILinkHandler, IWindowsPty, ILogger } from 'xterm';
 
 export const IBufferService = createDecorator<IBufferService>('BufferService');
 export interface IBufferService {
@@ -229,6 +229,7 @@ export interface ITerminalOptions {
   lineHeight?: number;
   linkHandler?: ILinkHandler | null;
   logLevel?: LogLevel;
+  logger?: ILogger | null;
   macOptionIsMeta?: boolean;
   macOptionClickForcesSelection?: boolean;
   minimumContrastRatio?: number;

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -108,6 +108,11 @@ declare module 'xterm-headless' {
     logLevel?: LogLevel;
 
     /**
+     * A logger to use instead of `console`.
+     */
+    logger?: ILogger | null;
+
+    /**
      * Whether to treat option as the meta key.
      */
     macOptionIsMeta?: boolean;
@@ -302,6 +307,32 @@ declare module 'xterm-headless' {
      * The Windows build version (eg. 19045)
      */
     buildNumber?: number;
+  }
+
+  /**
+   * A replacement logger for `console`.
+   */
+  export interface ILogger {
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * debug.
+     */
+    debug(message: string, ...args: any[]): void;
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * info or below.
+     */
+    info(message: string, ...args: any[]): void;
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * warn or below.
+     */
+    warn(message: string, ...args: any[]): void;
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * error or below.
+     */
+    error(message: string | Error, ...args: any[]): void;
   }
 
   /**

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -153,6 +153,11 @@ declare module 'xterm' {
     logLevel?: LogLevel;
 
     /**
+     * A logger to use instead of `console`.
+     */
+    logger?: ILogger | null;
+
+    /**
      * Whether to treat option as the meta key.
      */
     macOptionIsMeta?: boolean;
@@ -363,6 +368,32 @@ declare module 'xterm' {
      * The Windows build version (eg. 19045)
      */
     buildNumber?: number;
+  }
+
+  /**
+   * A replacement logger for `console`.
+   */
+  export interface ILogger {
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * debug.
+     */
+    debug(message: string, ...args: any[]): void;
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * info or below.
+     */
+    info(message: string, ...args: any[]): void;
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * warn or below.
+     */
+    warn(message: string, ...args: any[]): void;
+    /**
+     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
+     * error or below.
+     */
+    error(message: string | Error, ...args: any[]): void;
   }
 
   /**


### PR DESCRIPTION
This allows embedders to route the logs where ever they want, when this is set the xterm.js prefix is excluded.

![image](https://github.com/xtermjs/xterm.js/assets/2193314/0fb27e92-860b-4043-913a-32af659e9cd4)
