### PR TITLE
Add helix editor playground project to real world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**graSSHopper**](https://grasshopper.coding.kiwi): A simple SSH client with file explorer, history and many more features.
 - [**DomTerm**](https://domterm.org/xtermjs.html): Tiles and tabs. Detachable sessions (like tmux). [Remote connections](https://domterm.org/Remoting-over-ssh.html) using a nice ssh wrapper with predictive echo. Qt, Electron, Tauri/Wry, or desktop browser front-ends. Choose between xterm.js engine (faster) or native DomTerm (more functionality and graphics) - or both.
 - [**Cloudtutor.io**](https://cloudtutor.io): innovative online learning platform that offers users access to an interactive lab.
+- [**Helix Editor Playground**](https://github.com/tomgroenwoldt/helix-editor-playground): Online playground for the terminal based helix editor.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Note: Please add any new contributions to the end of the list only.


### PR DESCRIPTION
Hey :) I recently worked on a [small project](https://github.com/tomgroenwoldt/helix-editor-playground) which starts an instance of the [helix](https://helix-editor.com/) text editor on my backend and connects via the attach addon to xterm.js. It would be awesome to be mentioned in the `README`!

Thanks for the efforts, working with xterm.js was straightforward!