### PR TITLE
Add getRasterizedGlyph null and undefined check

### DIFF
--- a/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
@@ -369,7 +369,7 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     const chars = cell.getChars();
     this._cellColorResolver.resolve(cell, x, this._bufferService.buffer.ydisp + y);
 
-    if (this._charAtlas === undefined || this._charAtlas === null) {
+    if (!this._charAtlas) {
       return;
     }
 

--- a/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
@@ -368,6 +368,11 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
   protected _drawChars(cell: ICellData, x: number, y: number): void {
     const chars = cell.getChars();
     this._cellColorResolver.resolve(cell, x, this._bufferService.buffer.ydisp + y);
+
+    if (this._charAtlas === undefined || this._charAtlas === null) {
+      return;
+    }
+
     let glyph: IRasterizedGlyph;
     if (chars && chars.length > 1) {
       glyph = this._charAtlas.getRasterizedGlyphCombinedChar(chars, this._cellColorResolver.result.bg, this._cellColorResolver.result.fg, this._cellColorResolver.result.ext);


### PR DESCRIPTION
Ensures that the `charAtlas` object is not undefined or null before getRasterizedGlyph is invoked.

This PR fixes https://github.com/xtermjs/xterm.js/issues/4560