### PR TITLE
Fix API facade memory leaks

### DIFF
--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-import { Terminal as ITerminalApi, IMarker, IDisposable, ILocalizableStrings, ITerminalAddon, IBufferNamespace as IBufferNamespaceApi, IParser, ILinkProvider, IUnicodeHandling, IModes, IDecorationOptions, IDecoration, IBufferElementProvider } from 'xterm';
+import { Terminal as ITerminalApi, IMarker, IDisposable, ILocalizableStrings, ITerminalAddon, IBufferNamespace as IBufferNamespaceApi, IParser, ILinkProvider, IUnicodeHandling, IModes, IDecorationOptions, IDecoration, IBufferElementProvider, ITerminalInitOnlyOptions } from 'xterm';
 import { IBufferRange, ITerminal } from 'browser/Types';
 import { Terminal as TerminalCore } from 'browser/Terminal';
 import * as Strings from 'browser/LocalizableStrings';
@@ -13,22 +13,25 @@ import { UnicodeApi } from 'common/public/UnicodeApi';
 import { AddonManager } from 'common/public/AddonManager';
 import { BufferNamespaceApi } from 'common/public/BufferNamespaceApi';
 import { ITerminalOptions } from 'common/Types';
+import { Disposable } from 'common/Lifecycle';
 
 /**
  * The set of options that only have an effect when set in the Terminal constructor.
  */
 const CONSTRUCTOR_ONLY_OPTIONS = ['cols', 'rows'];
 
-export class Terminal implements ITerminalApi {
+export class Terminal extends Disposable implements ITerminalApi {
   private _core: ITerminal;
   private _addonManager: AddonManager;
   private _parser: IParser | undefined;
   private _buffer: BufferNamespaceApi | undefined;
   private _publicOptions: Required<ITerminalOptions>;
 
-  constructor(options?: ITerminalOptions) {
-    this._core = new TerminalCore(options);
-    this._addonManager = new AddonManager();
+  constructor(options?: ITerminalOptions & ITerminalInitOnlyOptions) {
+    super();
+
+    this._core = this.register(new TerminalCore(options));
+    this._addonManager = this.register(new AddonManager());
 
     this._publicOptions = { ... this._core.options };
     const getter = (propName: string): any => {
@@ -92,7 +95,7 @@ export class Terminal implements ITerminalApi {
   public get cols(): number { return this._core.cols; }
   public get buffer(): IBufferNamespaceApi {
     if (!this._buffer) {
-      this._buffer = new BufferNamespaceApi(this._core);
+      this._buffer = this.register(new BufferNamespaceApi(this._core));
     }
     return this._buffer;
   }
@@ -189,8 +192,7 @@ export class Terminal implements ITerminalApi {
     this._core.selectLines(start, end);
   }
   public dispose(): void {
-    this._addonManager.dispose();
-    this._core.dispose();
+    super.dispose();
   }
   public scrollLines(amount: number): void {
     this._verifyIntegers(amount);

--- a/src/common/public/BufferNamespaceApi.ts
+++ b/src/common/public/BufferNamespaceApi.ts
@@ -7,15 +7,17 @@ import { IBuffer as IBufferApi, IBufferNamespace as IBufferNamespaceApi } from '
 import { BufferApiView } from 'common/public/BufferApiView';
 import { EventEmitter } from 'common/EventEmitter';
 import { ICoreTerminal } from 'common/Types';
+import { Disposable } from 'common/Lifecycle';
 
-export class BufferNamespaceApi implements IBufferNamespaceApi {
+export class BufferNamespaceApi extends Disposable implements IBufferNamespaceApi {
   private _normal: BufferApiView;
   private _alternate: BufferApiView;
 
-  private readonly _onBufferChange = new EventEmitter<IBufferApi>();
+  private readonly _onBufferChange = this.register(new EventEmitter<IBufferApi>());
   public readonly onBufferChange = this._onBufferChange.event;
 
   constructor(private _core: ICoreTerminal) {
+    super();
     this._normal = new BufferApiView(this._core.buffers.normal, 'normal');
     this._alternate = new BufferApiView(this._core.buffers.alt, 'alternate');
     this._core.buffers.onBufferActivate(() => this._onBufferChange.fire(this.active));


### PR DESCRIPTION
We need to register/dispose any event created in the facades, otherwise embedders need to dispose of the listeners manually.

Fixes #4645