### PR TITLE
Dispose blink state manager

### DIFF
--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -136,6 +136,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
       for (const l of this._renderLayers) {
         l.dispose();
       }
+      this._cursorBlinkStateManager?.dispose();
       this._canvas.parentElement?.removeChild(this._canvas);
       removeTerminalFromCache(this._terminal);
     }));

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -136,7 +136,6 @@ export class WebglRenderer extends Disposable implements IRenderer {
       for (const l of this._renderLayers) {
         l.dispose();
       }
-      this._cursorBlinkStateManager?.dispose();
       this._canvas.parentElement?.removeChild(this._canvas);
       removeTerminalFromCache(this._terminal);
     }));
@@ -366,9 +365,9 @@ export class WebglRenderer extends Disposable implements IRenderer {
   private _updateCursorBlink(): void {
     if (this._terminal.options.cursorBlink) {
       if (!this._cursorBlinkStateManager) {
-        this._cursorBlinkStateManager = new CursorBlinkStateManager(() => {
+        this._cursorBlinkStateManager = this.register(new CursorBlinkStateManager(() => {
           this._requestRedrawCursor();
-        }, this._coreBrowserService);
+        }, this._coreBrowserService));
       }
     } else {
       this._cursorBlinkStateManager?.dispose();


### PR DESCRIPTION
@Tyriar https://github.com/microsoft/vscode/issues/187082

I've verified that terminals with blinking cursor are retained before this patch, and this patch fixes it.