### PR TITLE
Fix transparent foreground color

### DIFF
--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -298,7 +298,7 @@ export class TextureAtlas implements ITextureAtlas {
       case Attributes.CM_DEFAULT:
       default:
         if (inverse) {
-          result = this._config.colors.foreground;
+          result = color.opaque(this._config.colors.foreground);
         } else {
           result = this._config.colors.background;
         }

--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -277,7 +277,7 @@ export class TextureAtlas implements ITextureAtlas {
   }
 
   private _getBackgroundColor(bgColorMode: number, bgColor: number, inverse: boolean, dim: boolean): IColor {
-    if (this._config.allowTransparency) {
+    if (this._config.allowTransparency || (inverse && !color.isOpaque(this._config.colors.foreground))) {
       // The background color might have some transparency, so we need to render it as fully
       // transparent in the atlas. Otherwise we'd end up drawing the transparent background twice
       // around the anti-aliased edges of the glyph, and it would look too dark.

--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -277,7 +277,7 @@ export class TextureAtlas implements ITextureAtlas {
   }
 
   private _getBackgroundColor(bgColorMode: number, bgColor: number, inverse: boolean, dim: boolean): IColor {
-    if (this._config.allowTransparency || (inverse && !color.isOpaque(this._config.colors.foreground))) {
+    if (this._config.allowTransparency) {
       // The background color might have some transparency, so we need to render it as fully
       // transparent in the atlas. Otherwise we'd end up drawing the transparent background twice
       // around the anti-aliased edges of the glyph, and it would look too dark.

--- a/src/browser/services/ThemeService.ts
+++ b/src/browser/services/ThemeService.ts
@@ -122,7 +122,8 @@ export class ThemeService extends Disposable implements IThemeService {
    */
   private _setTheme(theme: ITheme = {}): void {
     const colors = this._colors;
-    colors.foreground = parseColor(theme.foreground, DEFAULT_FOREGROUND);
+    colors.foreground = color.opaque(parseColor(theme.foreground, DEFAULT_FOREGROUND));
+    console.warn("xterm.js is not fully support foreground colors with transparent, so it will the foreground colors alpha channel to 255.")
     colors.background = parseColor(theme.background, DEFAULT_BACKGROUND);
     colors.cursor = parseColor(theme.cursor, DEFAULT_CURSOR);
     colors.cursorAccent = parseColor(theme.cursorAccent, DEFAULT_CURSOR_ACCENT);

--- a/src/browser/services/ThemeService.ts
+++ b/src/browser/services/ThemeService.ts
@@ -122,8 +122,7 @@ export class ThemeService extends Disposable implements IThemeService {
    */
   private _setTheme(theme: ITheme = {}): void {
     const colors = this._colors;
-    colors.foreground = color.opaque(parseColor(theme.foreground, DEFAULT_FOREGROUND));
-    console.warn("xterm.js is not fully support foreground colors with transparent, so it will the foreground colors alpha channel to 255.")
+    colors.foreground = parseColor(theme.foreground, DEFAULT_FOREGROUND);
     colors.background = parseColor(theme.background, DEFAULT_BACKGROUND);
     colors.cursor = parseColor(theme.cursor, DEFAULT_CURSOR);
     colors.cursorAccent = parseColor(theme.cursorAccent, DEFAULT_CURSOR_ACCENT);


### PR DESCRIPTION
fix: #4408 

Description: 

I found this transparent foreground color will affect some text when the foreground is background
And  inside the `TextureAtlas`, there are already exist some check for background transparent
So I put another check foreground transparent 

Hope this make scenes

Any feedbacks is welcome, thanks

---

Screenshot: 

For local test, I change the xtermjsTheme foreground color with transparent
```
// demo/client.ts
const xtermjsTheme = {
  foreground: '#F8F8F8CC'
}
```
And the when no doing anything, it looks like:
<img width="965" alt="截圖 2023-08-12 上午12 25 04" src="https://github.com/xtermjs/xterm.js/assets/49616195/8c92239c-d9b1-4bbc-bd66-a108b370fc76">

After change:
<img width="980" alt="截圖 2023-08-12 上午12 25 59" src="https://github.com/xtermjs/xterm.js/assets/49616195/6a97cbc6-0f28-4696-b0b7-90e13396168e">



