### PR TITLE
Restrict comments to 100 characters

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -159,6 +159,16 @@
     "jsdoc/check-param-names": 1,
     "jsdoc/no-multi-asterisks": 1,
     "keyword-spacing": "warn",
+    "max-len": [
+      "warn",
+      {
+        "code": 1000, // Don't enforce for code
+        "comments": 100,
+        "ignoreTrailingComments": true,
+        "ignoreUrls": true,
+        "ignorePattern": "^ *((?<vt_comment>(//|\\*) @vt)|(?<table_comment>\\* \\| )|(?<commented_code>//  ))"
+      }
+    ],
     "new-parens": "warn",
     "no-duplicate-imports": "warn",
     "no-else-return": [
@@ -225,7 +235,8 @@
     {
       "files": ["**/*.test.ts"],
       "rules": {
-        "object-curly-spacing": "off"
+        "object-curly-spacing": "off",
+        "max-len": "off"
       }
     }
   ]

--- a/addons/xterm-addon-image/src/IIPHeaderParser.ts
+++ b/addons/xterm-addon-image/src/IIPHeaderParser.ts
@@ -23,7 +23,8 @@ export interface IHeaderFields {
   height?: string;
   // Optional, defaults to 1 respecting aspect ratio (width takes precedence).
   preserveAspectRatio?: number;
-  // Optional, defaults to 0. If set to 1, the file will be displayed inline, else downloaded (download not supported).
+  // Optional, defaults to 0. If set to 1, the file will be displayed inline, else downloaded
+  // (download not supported).
   inline?: number;
 }
 

--- a/addons/xterm-addon-search/src/SearchAddon.ts
+++ b/addons/xterm-addon-search/src/SearchAddon.ts
@@ -440,7 +440,8 @@ export class SearchAddon extends Disposable implements ITerminalAddon {
   }
 
   /**
-   * A found substring is a whole word if it doesn't have an alphanumeric character directly adjacent to it.
+   * A found substring is a whole word if it doesn't have an alphanumeric character directly
+   * adjacent to it.
    * @param searchIndex starting indext of the potential whole word substring
    * @param line entire string in which the potential whole word was found
    * @param term the substring that starts at searchIndex
@@ -451,14 +452,15 @@ export class SearchAddon extends Disposable implements ITerminalAddon {
   }
 
   /**
-   * Searches a line for a search term. Takes the provided terminal line and searches the text line, which may contain
-   * subsequent terminal lines if the text is wrapped. If the provided line number is part of a wrapped text line that
-   * started on an earlier line then it is skipped since it will be properly searched when the terminal line that the
-   * text starts on is searched.
+   * Searches a line for a search term. Takes the provided terminal line and searches the text line,
+   * which may contain subsequent terminal lines if the text is wrapped. If the provided line number
+   * is part of a wrapped text line that started on an earlier line then it is skipped since it will
+   * be properly searched when the terminal line that the text starts on is searched.
    * @param term The search term.
    * @param searchPosition The position to start the search.
    * @param searchOptions Search options.
-   * @param isReverseSearch Whether the search should start from the right side of the terminal and search to the left.
+   * @param isReverseSearch Whether the search should start from the right side of the terminal and
+   * search to the left.
    * @returns The search result if it was found.
    */
   protected _findInLine(term: string, searchPosition: ISearchPosition, searchOptions: ISearchOptions = {}, isReverseSearch: boolean = false): ISearchResult | undefined {
@@ -526,7 +528,8 @@ export class SearchAddon extends Disposable implements ITerminalAddon {
         return;
       }
 
-      // Adjust the row number and search index if needed since a "line" of text can span multiple rows
+      // Adjust the row number and search index if needed since a "line" of text can span multiple
+      // rows
       let startRowOffset = 0;
       while (startRowOffset < offsets.length - 1 && resultIndex >= offsets[startRowOffset + 1]) {
         startRowOffset++;

--- a/addons/xterm-addon-serialize/src/SerializeAddon.ts
+++ b/addons/xterm-addon-serialize/src/SerializeAddon.ts
@@ -131,7 +131,8 @@ class StringSerializeHandler extends BaseSerializeHandler {
   private _thisRowLastSecondChar: IBufferCell = this._buffer.getNullCell();
   private _nextRowFirstChar: IBufferCell = this._buffer.getNullCell();
   protected _rowEnd(row: number, isLastRow: boolean): void {
-    // if there is colorful empty cell at line end, whe must pad it back, or the the color block will missing
+    // if there is colorful empty cell at line end, whe must pad it back, or the the color block
+    // will missing
     if (this._nullCellCount > 0 && !equalBg(this._cursorStyle, this._backgroundCell)) {
       // use clear right to set background.
       this._currentRow += `\u001b[${this._nullCellCount}X`;
@@ -292,7 +293,8 @@ class StringSerializeHandler extends BaseSerializeHandler {
 
     const sgrSeq = this._diffStyle(cell, this._cursorStyle);
 
-    // the empty cell style is only assumed to be changed when background changed, because foreground is always 0.
+    // the empty cell style is only assumed to be changed when background changed, because
+    // foreground is always 0.
     const styleChanged = isEmptyCell ? !equalBg(this._cursorStyle, cell) : sgrSeq.length > 0;
 
     /**

--- a/src/browser/Linkifier2.ts
+++ b/src/browser/Linkifier2.ts
@@ -109,7 +109,8 @@ export class Linkifier2 extends Disposable implements ILinkifier2 {
   }
 
   private _handleHover(position: IBufferCellPosition): void {
-    // TODO: This currently does not cache link provider results across wrapped lines, activeLine should be something like `activeRange: {startY, endY}`
+    // TODO: This currently does not cache link provider results across wrapped lines, activeLine
+    //       should be something like `activeRange: {startY, endY}`
     // Check if we need to clear the link
     if (this._activeLine !== position.y || this._wasResized) {
       this._clearCurrentLink();

--- a/src/browser/OscLinkProvider.ts
+++ b/src/browser/OscLinkProvider.ts
@@ -104,7 +104,8 @@ export class OscLinkProvider implements ILinkProvider {
       }
     }
 
-    // TODO: Handle fetching and returning other link ranges to underline other links with the same id
+    // TODO: Handle fetching and returning other link ranges to underline other links with the same
+    //       id
     callback(result);
   }
 }

--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -65,8 +65,8 @@ export class Viewport extends Disposable implements IViewport {
     super();
 
     // Measure the width of the scrollbar. If it is 0 we can assume it's an OSX overlay scrollbar.
-    // Unfortunately the overlay scrollbar would be hidden underneath the screen element in that case,
-    // therefore we account for a standard amount to make it visible
+    // Unfortunately the overlay scrollbar would be hidden underneath the screen element in that
+    // case, therefore we account for a standard amount to make it visible
     this.scrollBarWidth = (this._viewportElement.offsetWidth - this._scrollArea.offsetWidth) || FALLBACK_SCROLL_BAR_WIDTH;
     this.register(addDisposableDomListener(this._viewportElement, 'scroll', this._handleScroll.bind(this)));
 

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -389,7 +389,8 @@ export class DomRenderer extends Disposable implements IRenderer {
   public clear(): void {
     for (const e of this._rowElements) {
       /**
-       * NOTE: This used to be `e.innerText = '';` but that doesn't work when using `jsdom` and `@testing-library/react`
+       * NOTE: This used to be `e.innerText = '';` but that doesn't work when using `jsdom` and
+       * `@testing-library/react`
        *
        * references:
        * - https://github.com/testing-library/react-testing-library/issues/1146

--- a/src/browser/renderer/dom/DomRendererRowFactory.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.ts
@@ -285,7 +285,8 @@ export class DomRendererRowFactory {
         classes.push(RowCss.STRIKETHROUGH_CLASS);
       }
 
-      // apply link hover underline late, effectively overrides any previous text-decoration settings
+      // apply link hover underline late, effectively overrides any previous text-decoration
+      // settings
       if (isLinkHover) {
         charElement.style.textDecoration = 'underline';
       }

--- a/src/browser/renderer/shared/Constants.ts
+++ b/src/browser/renderer/shared/Constants.ts
@@ -8,7 +8,7 @@ import { isFirefox, isLegacyEdge } from 'common/Platform';
 export const INVERTED_DEFAULT_COLOR = 257;
 
 export const DIM_OPACITY = 0.5;
-// The text baseline is set conditionally by browser. Using 'ideographic' for Firefox or Legacy Edge would
-// result in truncated text (Issue 3353). Using 'bottom' for Chrome would result in slightly
+// The text baseline is set conditionally by browser. Using 'ideographic' for Firefox or Legacy Edge
+// would result in truncated text (Issue 3353). Using 'bottom' for Chrome would result in slightly
 // unaligned Powerline fonts (PR 3356#issuecomment-850928179).
 export const TEXT_BASELINE: CanvasTextBaseline = isFirefox || isLegacyEdge ? 'bottom' : 'ideographic';

--- a/src/browser/renderer/shared/CustomGlyphs.ts
+++ b/src/browser/renderer/shared/CustomGlyphs.ts
@@ -349,7 +349,8 @@ const enum VectorType {
  * not been patched with powerline characters and also to get pixel perfect rendering as rendering
  * issues can occur around AA/SPAA.
  *
- * The line variants draw beyond the cell and get clipped to ensure the end of the line is not visible.
+ * The line variants draw beyond the cell and get clipped to ensure the end of the line is not
+ * visible.
  *
  * Original symbols defined in https://github.com/powerline/fontpatcher
  */

--- a/src/browser/renderer/shared/TextureAtlas.ts
+++ b/src/browser/renderer/shared/TextureAtlas.ts
@@ -466,8 +466,8 @@ export class TextureAtlas implements ITextureAtlas {
 
     // draw the background
     const backgroundColor = this._getBackgroundColor(bgColorMode, bgColor, inverse, dim);
-    // Use a 'copy' composite operation to clear any existing glyph out of _tmpCtxWithAlpha, regardless of
-    // transparency in backgroundColor
+    // Use a 'copy' composite operation to clear any existing glyph out of _tmpCtxWithAlpha,
+    // regardless of transparency in backgroundColor
     this._tmpCtx.globalCompositeOperation = 'copy';
     this._tmpCtx.fillStyle = backgroundColor.css;
     this._tmpCtx.fillRect(0, 0, this._tmpCanvas.width, this._tmpCanvas.height);
@@ -559,7 +559,8 @@ export class TextureAtlas implements ITextureAtlas {
             const clipRegion = new Path2D();
             clipRegion.rect(xChLeft, yTop, this._config.deviceCellWidth, yBot - yTop);
             this._tmpCtx.clip(clipRegion);
-            // Start 1/2 cell before and end 1/2 cells after to ensure a smooth curve with other cells
+            // Start 1/2 cell before and end 1/2 cells after to ensure a smooth curve with other
+            // cells
             this._tmpCtx.moveTo(xChLeft - this._config.deviceCellWidth / 2, yMid);
             this._tmpCtx.bezierCurveTo(
               xChLeft - this._config.deviceCellWidth / 2, yCurlyTop,

--- a/src/browser/services/CharSizeService.ts
+++ b/src/browser/services/CharSizeService.ts
@@ -60,7 +60,8 @@ interface IMeasureResult {
   height: number;
 }
 
-// TODO: For supporting browsers we should also provide a CanvasCharDimensionsProvider that uses ctx.measureText
+// TODO: For supporting browsers we should also provide a CanvasCharDimensionsProvider that uses
+// ctx.measureText
 class DomMeasureStrategy implements IMeasureStrategy {
   private _result: IMeasureResult = { width: 0, height: 0 };
   private _measureElement: HTMLElement;

--- a/src/common/Color.ts
+++ b/src/common/Color.ts
@@ -106,7 +106,8 @@ export namespace color {
 }
 
 /**
- * Helper functions where the source type is "css" (string: '#rgb', '#rgba', '#rrggbb', '#rrggbbaa').
+ * Helper functions where the source type is "css" (string: '#rgb', '#rgba', '#rrggbb',
+ * '#rrggbbaa').
  */
 export namespace css {
   let $ctx: CanvasRenderingContext2D | undefined;

--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -416,11 +416,11 @@ export class InputHandler extends Disposable implements IInputHandler {
    * - undefined (void):
    *   all handlers were sync, no stack save, continue normally with next chunk
    * - Promise\<boolean\>:
-   *   execution stopped at async handler, stack saved, continue with
-   *   same chunk and the promise resolve value as `promiseResult` until the method returns `undefined`
+   *   execution stopped at async handler, stack saved, continue with same chunk and the promise
+   *   resolve value as `promiseResult` until the method returns `undefined`
    *
-   * Note: This method should only be called by `Terminal.write` to ensure correct execution order and
-   * proper continuation of async parser handlers.
+   * Note: This method should only be called by `Terminal.write` to ensure correct execution order
+   * and proper continuation of async parser handlers.
    */
   public parse(data: string | Uint8Array, promiseResult?: boolean): void | Promise<boolean> {
     let result: void | Promise<boolean>;
@@ -787,12 +787,13 @@ export class InputHandler extends Disposable implements IInputHandler {
         // find last taken cell - last cell can have 3 different states:
         // - hasContent(true) + hasWidth(1): narrow char - we are done
         // - hasWidth(0): second part of wide char - we are done
-        // - hasContent(false) + hasWidth(1): empty cell due to early wrapping wide char, go one cell further back
+        // - hasContent(false) + hasWidth(1): empty cell due to early wrapping wide char, go one
+        //   cell further back
         const line = this._activeBuffer.lines.get(this._activeBuffer.ybase + this._activeBuffer.y)!;
         if (line.hasWidth(this._activeBuffer.x) && !line.hasContent(this._activeBuffer.x)) {
           this._activeBuffer.x--;
-          // We do this only once, since width=1 + hasContent=false currently happens only once before
-          // early wrapping of a wide char.
+          // We do this only once, since width=1 + hasContent=false currently happens only once
+          // before early wrapping of a wide char.
           // This needs to be fixed once we support graphemes taking more than 2 cells.
         }
       }
@@ -1147,8 +1148,8 @@ export class InputHandler extends Disposable implements IInputHandler {
   }
 
   /**
-   * Helper method to reset cells in a terminal row.
-   * The cell gets replaced with the eraseChar of the terminal and the isWrapped property is set to false.
+   * Helper method to reset cells in a terminal row. The cell gets replaced with the eraseChar of
+   * the terminal and the isWrapped property is set to false.
    * @param y row index
    */
   private _resetBufferLine(y: number, respectProtect: boolean = false): void {
@@ -1345,8 +1346,9 @@ export class InputHandler extends Disposable implements IInputHandler {
    * Insert Ps (Blank) Character(s) (default = 1) (ICH).
    *
    * @vt: #Y CSI ICH  "Insert Characters"   "CSI Ps @"  "Insert `Ps` (blank) characters (default = 1)."
-   * The ICH sequence inserts `Ps` blank characters. The cursor remains at the beginning of the blank characters.
-   * Text between the cursor and right margin moves to the right. Characters moved past the right margin are lost.
+   * The ICH sequence inserts `Ps` blank characters. The cursor remains at the beginning of the
+   * blank characters. Text between the cursor and right margin moves to the right. Characters moved
+   * past the right margin are lost.
    *
    *
    * FIXME: check against xterm - should not work outside of scroll margins (see VT520 manual)
@@ -1371,8 +1373,9 @@ export class InputHandler extends Disposable implements IInputHandler {
    * Delete Ps Character(s) (default = 1) (DCH).
    *
    * @vt: #Y CSI DCH   "Delete Character"  "CSI Ps P"  "Delete `Ps` characters (default=1)."
-   * As characters are deleted, the remaining characters between the cursor and right margin move to the left.
-   * Character attributes move with the characters. The terminal adds blank characters at the right margin.
+   * As characters are deleted, the remaining characters between the cursor and right margin move to
+   * the left. Character attributes move with the characters. The terminal adds blank characters at
+   * the right margin.
    *
    *
    * FIXME: check against xterm - should not work outside of scroll margins (see VT520 manual)
@@ -1497,9 +1500,9 @@ export class InputHandler extends Disposable implements IInputHandler {
    * Insert Ps Column(s) (default = 1) (DECIC), VT420 and up.
    *
    * @vt: #Y CSI DECIC "Insert Columns"  "CSI Ps ' }"  "Insert `Ps` columns at cursor position."
-   * DECIC inserts `Ps` times blank columns at the cursor position for all lines with the scroll margins,
-   * moving content to the right. Content at the right margin is lost.
-   * DECIC has no effect outside the scrolling margins.
+   * DECIC inserts `Ps` times blank columns at the cursor position for all lines with the scroll
+   * margins, moving content to the right. Content at the right margin is lost. DECIC has no effect
+   * outside the scrolling margins.
    */
   public insertColumns(params: IParams): boolean {
     if (this._activeBuffer.y > this._activeBuffer.scrollBottom || this._activeBuffer.y < this._activeBuffer.scrollTop) {
@@ -1580,12 +1583,12 @@ export class InputHandler extends Disposable implements IInputHandler {
    *    - wrap around is respected
    *    - any valid sequence resets the carried forward char
    *
-   * Note: To get reset on a valid sequence working correctly without much runtime penalty,
-   * the preceding codepoint is stored on the parser in `this.print` and reset during `parser.parse`.
+   * Note: To get reset on a valid sequence working correctly without much runtime penalty, the
+   * preceding codepoint is stored on the parser in `this.print` and reset during `parser.parse`.
    *
    * @vt: #Y CSI REP   "Repeat Preceding Character"    "CSI Ps b"  "Repeat preceding character `Ps` times (default=1)."
-   * REP repeats the previous character `Ps` times advancing the cursor, also wrapping if DECAWM is set.
-   * REP has no effect if the sequence does not follow a printable ASCII character
+   * REP repeats the previous character `Ps` times advancing the cursor, also wrapping if DECAWM is
+   * set. REP has no effect if the sequence does not follow a printable ASCII character
    * (NOOP for any other sequence in between or NON ASCII characters).
    */
   public repeatPrecedingCharacter(params: IParams): boolean {
@@ -2446,7 +2449,8 @@ export class InputHandler extends Disposable implements IInputHandler {
    * | 5      | Dashed underline.                                             | #Y      |
    * | other  | Single underline. Same as `SGR 4 m`.                          | #Y      |
    *
-   * Extended colors are supported for foreground (Ps=38), background (Ps=48) and underline (Ps=58) as follows:
+   * Extended colors are supported for foreground (Ps=38), background (Ps=48) and underline (Ps=58)
+   * as follows:
    *
    * | Ps + 1 | Meaning                                                       | Support |
    * | ------ | ------------------------------------------------------------- | ------- |
@@ -2656,8 +2660,9 @@ export class InputHandler extends Disposable implements IInputHandler {
    * http://vt100.net/docs/vt220-rm/table4-10.html
    *
    * @vt: #Y CSI DECSTR  "Soft Terminal Reset"   "CSI ! p"   "Reset several terminal attributes to initial state."
-   * There are two terminal reset sequences - RIS and DECSTR. While RIS performs almost a full terminal bootstrap,
-   * DECSTR only resets certain attributes. For most needs DECSTR should be sufficient.
+   * There are two terminal reset sequences - RIS and DECSTR. While RIS performs almost a full
+   * terminal bootstrap, DECSTR only resets certain attributes. For most needs DECSTR should be
+   * sufficient.
    *
    * The following terminal attributes are reset to default values:
    * - IRM is reset (dafault = false)
@@ -2882,7 +2887,8 @@ export class InputHandler extends Disposable implements IInputHandler {
    * Icon name is not supported. For Window Title see below.
    *
    * @vt: #Y     OSC    2   "Set Windows Title"  "OSC 2 ; Pt BEL"  "Set window title."
-   * xterm.js does not manipulate the title directly, instead exposes changes via the event `Terminal.onTitleChange`.
+   * xterm.js does not manipulate the title directly, instead exposes changes via the event
+   * `Terminal.onTitleChange`.
    */
   public setTitle(data: string): boolean {
     this._windowTitle = data;
@@ -2903,9 +2909,10 @@ export class InputHandler extends Disposable implements IInputHandler {
    * OSC 4; <num> ; <text> ST (set ANSI color <num> to <text>)
    *
    * @vt: #Y    OSC    4    "Set ANSI color"   "OSC 4 ; c ; spec BEL" "Change color number `c` to the color specified by `spec`."
-   * `c` is the color index between 0 and 255. The color format of `spec` is derived from `XParseColor` (see OSC 10 for supported formats).
-   * There may be multipe `c ; spec` pairs present in the same instruction.
-   * If `spec` contains `?` the terminal returns a sequence with the currently set color.
+   * `c` is the color index between 0 and 255. The color format of `spec` is derived from
+   * `XParseColor` (see OSC 10 for supported formats). There may be multipe `c ; spec` pairs present
+   * in the same instruction. If `spec` contains `?` the terminal returns a sequence with the
+   * currently set color.
    */
   public setOrReportIndexedColor(data: string): boolean {
     const event: IColorEvent = [];
@@ -2945,9 +2952,10 @@ export class InputHandler extends Disposable implements IInputHandler {
    *
    * @vt: #Y    OSC    8    "Create hyperlink"   "OSC 8 ; params ; uri BEL" "Create a hyperlink to `uri` using `params`."
    * `uri` is a hyperlink starting with `http://`, `https://`, `ftp://`, `file://` or `mailto://`. `params` is an
-   * optional list of key=value assignments, separated by the : character. Example: `id=xyz123:foo=bar:baz=quux`.
-   * Currently only the id key is defined. Cells that share the same ID and URI share hover feedback.
-   * Use `OSC 8 ; ; BEL` to finish the current hyperlink.
+   * optional list of key=value assignments, separated by the : character.
+   * Example: `id=xyz123:foo=bar:baz=quux`.
+   * Currently only the id key is defined. Cells that share the same ID and URI share hover
+   * feedback. Use `OSC 8 ; ; BEL` to finish the current hyperlink.
    */
   public setHyperlink(data: string): boolean {
     const args = data.split(';');
@@ -3334,8 +3342,8 @@ export class InputHandler extends Disposable implements IInputHandler {
    *   Response: DECRPSS (https://vt100.net/docs/vt510-rm/DECRPSS.html)
    *
    * @vt: #P[Limited support, see below.]  DCS   DECRQSS   "Request Selection or Setting"  "DCS $ q Pt ST"   "Request several terminal settings."
-   * Response is in the form `ESC P 1 $ r Pt ST` for valid requests, where `Pt` contains the corresponding CSI string,
-   * `ESC P 0 ST` for invalid requests.
+   * Response is in the form `ESC P 1 $ r Pt ST` for valid requests, where `Pt` contains the
+   * corresponding CSI string, `ESC P 0 ST` for invalid requests.
    *
    * Supported requests and responses:
    *

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -270,8 +270,8 @@ export class Buffer implements IBuffer {
   private _batchedMemoryCleanup(): boolean {
     let normalRun = true;
     if (this._memoryCleanupPosition >= this.lines.length) {
-      // cleanup made it once through all lines, thus rescan in loop below to also catch shifted lines,
-      // which should finish rather quick if there are no more cleanups pending
+      // cleanup made it once through all lines, thus rescan in loop below to also catch shifted
+      // lines, which should finish rather quick if there are no more cleanups pending
       this._memoryCleanupPosition = 0;
       normalRun = false;
     }

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -380,7 +380,8 @@ export function evaluateKeyboardEvent(
           result.type = KeyboardResultType.SELECT_ALL;
         }
       } else if (ev.key && !ev.ctrlKey && !ev.altKey && !ev.metaKey && ev.keyCode >= 48 && ev.key.length === 1) {
-        // Include only keys that that result in a _single_ character; don't include num lock, volume up, etc.
+        // Include only keys that that result in a _single_ character; don't include num lock,
+        // volume up, etc.
         result.key = ev.key;
       } else if (ev.key && ev.ctrlKey) {
         if (ev.key === '_') { // ^_

--- a/src/common/input/TextDecoder.ts
+++ b/src/common/input/TextDecoder.ts
@@ -28,8 +28,8 @@ export function utf32ToString(data: Uint32Array, start: number = 0, end: number 
   for (let i = start; i < end; ++i) {
     let codepoint = data[i];
     if (codepoint > 0xFFFF) {
-      // JS strings are encoded as UTF16, thus a non BMP codepoint gets converted into a surrogate pair
-      // conversion rules:
+      // JS strings are encoded as UTF16, thus a non BMP codepoint gets converted into a surrogate
+      // pair conversion rules:
       //  - subtract 0x10000 from code point, leaving a 20 bit number
       //  - add high 10 bits to 0xD800  --> first surrogate
       //  - add low 10 bits to 0xDC00   --> second surrogate

--- a/src/common/input/WriteBuffer.ts
+++ b/src/common/input/WriteBuffer.ts
@@ -181,9 +181,10 @@ export class WriteBuffer extends Disposable {
 
         /**
          * If a promise takes long to resolve, we should schedule continuation behind setTimeout.
-         * This might already be too late, if our .then enters really late (executor + prev thens took very long).
-         * This cannot be solved here for the handler itself (it is the handlers responsibility to slice hard work),
-         * but we can at least schedule a screen update as we gain control.
+         * This might already be too late, if our .then enters really late (executor + prev thens
+         * took very long). This cannot be solved here for the handler itself (it is the handlers
+         * responsibility to slice hard work), but we can at least schedule a screen update as we
+         * gain control.
          */
         const continuation: (r: boolean) => void = (r: boolean) => Date.now() - startTime >= WRITE_TIMEOUT_MS
           ? setTimeout(() => this._innerWrite(0, r))

--- a/src/common/parser/EscapeSequenceParser.ts
+++ b/src/common/parser/EscapeSequenceParser.ts
@@ -532,9 +532,9 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
       } else {
         if (promiseResult === undefined || this._parseStack.state === ParserStackType.FAIL) {
           /**
-           * Reject further parsing on improper continuation after pausing.
-           * This is a really bad condition with screwed up execution order and prolly messed up
-           * terminal state, therefore we exit hard with an exception and reject any further parsing.
+           * Reject further parsing on improper continuation after pausing. This is a really bad
+           * condition with screwed up execution order and prolly messed up terminal state,
+           * therefore we exit hard with an exception and reject any further parsing.
            *
            * Note: With `Terminal.write` usage this exception should never occur, as the top level
            * calls are guaranteed to handle async conditions properly. If you ever encounter this
@@ -542,9 +542,9 @@ export class EscapeSequenceParser extends Disposable implements IEscapeSequenceP
            * `InputHandler.parse` or `EscapeSequenceParser.parse` synchronously without waiting for
            * continuation of a running async handler.
            *
-           * It is possible to get rid of this error by calling `reset`. But dont rely on that,
-           * as the pending async handler still might mess up the terminal later. Instead fix the faulty
-           * async handling, so this error will not be thrown anymore.
+           * It is possible to get rid of this error by calling `reset`. But dont rely on that, as
+           * the pending async handler still might mess up the terminal later. Instead fix the
+           * faulty async handling, so this error will not be thrown anymore.
            */
           this._parseStack.state = ParserStackType.FAIL;
           throw new Error('improper continuation due to previous async handler, giving up parsing');

--- a/src/common/services/BufferService.ts
+++ b/src/common/services/BufferService.ts
@@ -43,7 +43,8 @@ export class BufferService extends Disposable implements IBufferService {
     this.cols = cols;
     this.rows = rows;
     this.buffers.resize(cols, rows);
-    // TODO: This doesn't fire when scrollback changes - add a resize event to BufferSet and forward event
+    // TODO: This doesn't fire when scrollback changes - add a resize event to BufferSet and forward
+    //       event
     this._onResize.fire({ cols, rows });
   }
 


### PR DESCRIPTION
This is a rule I try enforce in PR but it's a bit of a hassle, this will give a lint warning when it happens resulting in:

- Yellow underline in supported editors when eslint is installed
- Compilation will succeed since it's a warning not an error
- CI will fail as it does not allow lint warnings

Special case comments are ignored which includes @vt comments, table comments and commented out code.