### PR TITLE
Lint API .d.ts files

### DIFF
--- a/.eslintrc.json.typings
+++ b/.eslintrc.json.typings
@@ -1,0 +1,104 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "jsdoc"
+  ],
+  "rules": {
+    "no-extra-semi": "error",
+    "@typescript-eslint/array-type": [
+      "warn",
+      {
+        "default": "array",
+        "readonly": "generic"
+      }
+    ],
+    "@typescript-eslint/explicit-function-return-type": [
+      "warn",
+      {
+        "allowExpressions": true
+      }
+    ],
+    "@typescript-eslint/indent": [
+      "warn",
+      2
+    ],
+    "@typescript-eslint/member-delimiter-style": [
+      "warn",
+      {
+        "multiline": {
+          "delimiter": "semi",
+          "requireLast": true
+        },
+        "singleline": {
+          "delimiter": "comma",
+          "requireLast": false
+        }
+      }
+    ],
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      { "selector": "typeLike", "format": ["PascalCase"] },
+      { "selector": "interface", "format": ["PascalCase"], "prefix": ["I"] }
+    ],
+    "@typescript-eslint/prefer-namespace-keyword": "warn",
+    "@typescript-eslint/type-annotation-spacing": "warn",
+    "@typescript-eslint/quotes": [
+      "warn",
+      "single",
+      { "allowTemplateLiterals": true }
+    ],
+    "@typescript-eslint/semi": [
+      "warn",
+      "always"
+    ],
+    "comma-dangle": [
+      "warn",
+      {
+        "objects": "never",
+        "arrays": "never",
+        "functions": "never"
+      }
+    ],
+    "curly": [
+      "warn",
+      "multi-line"
+    ],
+    "eol-last": "warn",
+    "eqeqeq": [
+      "warn",
+      "always"
+    ],
+    "jsdoc/check-alignment": 1,
+    "jsdoc/check-param-names": 1,
+    "keyword-spacing": "warn",
+    "max-len": [
+      "warn",
+      {
+        "code": 1000, // Don't enforce for code
+        "comments": 80,
+        "ignoreUrls": true,
+        "ignorePattern": "^ *(?<ps_description>\\* Ps=)"
+      }
+    ],
+    "no-irregular-whitespace": "warn",
+    "no-trailing-spaces": "warn",
+    "object-curly-spacing": [
+      "warn",
+      "always"
+    ],
+    "spaced-comment": [
+      "warn",
+      "always",
+      {
+        "markers": ["/"],
+        "exceptions": ["-"]
+      }
+    ]
+  }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,9 @@ jobs:
       exit $EXIT_CODE
     displayName: 'Unit tests'
   - script: yarn lint
-    displayName: 'Lint'
+    displayName: 'Lint code'
+  - script: yarn lint-api
+    displayName: 'Lint API'
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
@@ -58,7 +60,9 @@ jobs:
   - script: yarn test-unit --forbid-only
     displayName: 'Unit tests'
   - script: yarn lint
-    displayName: 'Lint'
+    displayName: 'Lint code'
+  - script: yarn lint-api
+    displayName: 'Lint API'
 
 - job: Windows
   pool:
@@ -78,7 +82,9 @@ jobs:
   - script: yarn test-unit --forbid-only
     displayName: 'Unit tests'
   - script: yarn lint
-    displayName: 'Lint'
+    displayName: 'Lint code'
+  - script: yarn lint-api
+    displayName: 'Lint API'
 
 - job: Linux_IntegrationTests
   pool:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start": "node demo/start",
     "start-debug": "node --inspect-brk demo/start",
     "lint": "eslint -c .eslintrc.json --max-warnings 0 --ext .ts src/ addons/",
+    "lint-api": "eslint --no-eslintrc -c .eslintrc.json.typings --max-warnings 0 --no-ignore --ext .d.ts typings/",
     "test": "npm run test-unit",
     "posttest": "npm run lint",
     "test-api": "npm run test-api-chromium",

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -19,7 +19,8 @@ declare module 'xterm-headless' {
   export interface ITerminalOptions {
     /**
      * Whether to allow the use of proposed API. When false, any usage of APIs
-     * marked as experimental/proposed will throw an error. The default is false.
+     * marked as experimental/proposed will throw an error. The default is
+     * false.
      */
     allowProposedApi?: boolean;
 
@@ -63,13 +64,13 @@ declare module 'xterm-headless' {
     cursorWidth?: number;
 
     /**
-     * Whether to draw custom glyphs for block element and box drawing characters instead of using
-     * the font. This should typically result in better rendering with continuous lines, even when
-     * line height and letter spacing is used. Note that this doesn't work with the DOM renderer
-     * which renders all characters using the font. The default is true.
+     * Whether to draw custom glyphs for block element and box drawing
+     * characters instead of using the font. This should typically result in
+     * better rendering with continuous lines, even when line height and letter
+     * spacing is used. Note that this doesn't work with the DOM renderer which
+     * renders all characters using the font. The default is true.
      */
     customGlyphs?: boolean;
-
     /**
      * Whether input should be disabled.
      */
@@ -217,9 +218,9 @@ declare module 'xterm-headless' {
     windowsPty?: IWindowsPty;
 
     /**
-     * A string containing all characters that are considered word separated by the
-     * double click to select work logic.
-    */
+     * A string containing all characters that are considered word separated by
+     * the double click to select work logic.
+     */
     wordSeparator?: string;
 
     /**
@@ -314,23 +315,23 @@ declare module 'xterm-headless' {
    */
   export interface ILogger {
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * debug.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to debug.
      */
     debug(message: string, ...args: any[]): void;
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * info or below.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to info or below.
      */
     info(message: string, ...args: any[]): void;
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * warn or below.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to warn or below.
      */
     warn(message: string, ...args: any[]): void;
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * error or below.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to error or below.
      */
     error(message: string | Error, ...args: any[]): void;
   }
@@ -362,22 +363,25 @@ declare module 'xterm-headless' {
     readonly id: number;
 
     /**
-     * Whether this marker is disposed.
-     */
-    readonly isDisposed: boolean;
-
-    /**
      * The actual line index in the buffer at this point in time. This is set to
      * -1 if the marker has been disposed.
      */
     readonly line: number;
+  }
 
+  /**
+   * Represents a disposable that tracks is disposed state.
+   */
+  export interface IDisposableWithEvent extends IDisposable {
     /**
-     * Event listener to get notified when the marker gets disposed. Automatic disposal
-     * might happen for a marker, that got invalidated by scrolling out or removal of
-     * a line from the buffer.
+     * Event listener to get notified when this gets disposed.
      */
     onDispose: IEvent<void>;
+
+    /**
+     * Whether this is disposed.
+     */
+    readonly isDisposed: boolean;
   }
 
   /**
@@ -397,7 +401,8 @@ declare module 'xterm-headless' {
   }
 
   /**
-   * Enable various window manipulation and report features (CSI Ps ; Ps ; Ps t).
+   * Enable various window manipulation and report features
+   * (`CSI Ps ; Ps ; Ps t`).
    *
    * Most settings have no default implementation, as they heavily rely on
    * the embedding environment.
@@ -417,10 +422,10 @@ declare module 'xterm-headless' {
    *
    * Note on security:
    * Most features are meant to deal with some information of the host machine
-   * where the terminal runs on. This is seen as a security risk possibly leaking
-   * sensitive data of the host to the program in the terminal. Therefore all options
-   * (even those without a default implementation) are guarded by the boolean flag
-   * and disabled by default.
+   * where the terminal runs on. This is seen as a security risk possibly
+   * leaking sensitive data of the host to the program in the terminal.
+   * Therefore all options (even those without a default implementation) are
+   * guarded by the boolean flag and disabled by default.
    */
   export interface IWindowOptions {
     /**
@@ -601,23 +606,36 @@ declare module 'xterm-headless' {
     readonly modes: IModes;
 
     /**
-     * Gets or sets the terminal options. This supports setting multiple options.
+     * Gets or sets the terminal options. This supports setting multiple
+     * options.
      *
      * @example Get a single option
-     * ```typescript
+     * ```ts
      * console.log(terminal.options.fontSize);
      * ```
      *
-     * @example Set a single option
-     * ```typescript
+     * @example Set a single option:
+     * ```ts
      * terminal.options.fontSize = 12;
+     * ```
+     * Note that for options that are object, a new object must be used in order
+     * to take effect as a reference comparison will be done:
+     * ```ts
+     * const newValue = terminal.options.theme;
+     * newValue.background = '#000000';
+     *
+     * // This won't work
+     * terminal.options.theme = newValue;
+     *
+     * // This will work
+     * terminal.options.theme = { ...newValue };
      * ```
      *
      * @example Set multiple options
-     * ```typescript
+     * ```ts
      * terminal.options = {
      *   fontSize: 12,
-     *   fontFamily: 'Courier New',
+     *   fontFamily: 'Courier New'
      * };
      * ```
      */
@@ -1282,6 +1300,6 @@ declare module 'xterm-headless' {
     /**
      * Auto-Wrap Mode (DECAWM): `CSI ? 7 h`
      */
-    readonly wraparoundMode: boolean
+    readonly wraparoundMode: boolean;
   }
 }

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -26,7 +26,8 @@ declare module 'xterm' {
   export interface ITerminalOptions {
     /**
      * Whether to allow the use of proposed API. When false, any usage of APIs
-     * marked as experimental/proposed will throw an error. The default is false.
+     * marked as experimental/proposed will throw an error. The default is
+     * false.
      */
     allowProposedApi?: boolean;
 
@@ -75,10 +76,11 @@ declare module 'xterm' {
     cursorInactiveStyle?: 'outline' | 'block' | 'bar' | 'underline' | 'none';
 
     /**
-     * Whether to draw custom glyphs for block element and box drawing characters instead of using
-     * the font. This should typically result in better rendering with continuous lines, even when
-     * line height and letter spacing is used. Note that this doesn't work with the DOM renderer
-     * which renders all characters using the font. The default is true.
+     * Whether to draw custom glyphs for block element and box drawing
+     * characters instead of using the font. This should typically result in
+     * better rendering with continuous lines, even when line height and letter
+     * spacing is used. Note that this doesn't work with the DOM renderer which
+     * renders all characters using the font. The default is true.
      */
     customGlyphs?: boolean;
 
@@ -280,9 +282,9 @@ declare module 'xterm' {
     windowsPty?: IWindowsPty;
 
     /**
-     * A string containing all characters that are considered word separated by the
-     * double click to select work logic.
-    */
+     * A string containing all characters that are considered word separated by
+     * the double click to select work logic.
+     */
     wordSeparator?: string;
 
     /**
@@ -330,7 +332,10 @@ declare module 'xterm' {
     selectionBackground?: string;
     /** The selection foreground color */
     selectionForeground?: string;
-    /** The selection background color when the terminal does not have focus (can be transparent) */
+    /**
+     * The selection background color when the terminal does not have focus (can
+     * be transparent)
+     */
     selectionInactiveBackground?: string;
     /** ANSI black (eg. `\x1b[30m`) */
     black?: string;
@@ -387,23 +392,23 @@ declare module 'xterm' {
    */
   export interface ILogger {
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * debug.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to debug.
      */
     debug(message: string, ...args: any[]): void;
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * info or below.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to info or below.
      */
     info(message: string, ...args: any[]): void;
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * warn or below.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to warn or below.
      */
     warn(message: string, ...args: any[]): void;
     /**
-     * Log a debug message, this will only be called if {@link ITerminalOptions.logLevel} is set to
-     * error or below.
+     * Log a debug message, this will only be called if
+     * {@link ITerminalOptions.logLevel} is set to error or below.
      */
     error(message: string | Error, ...args: any[]): void;
   }
@@ -443,8 +448,6 @@ declare module 'xterm' {
 
   /**
    * Represents a disposable that tracks is disposed state.
-   * @param onDispose event listener and
-   * @param isDisposed property.
    */
   export interface IDisposableWithEvent extends IDisposable {
     /**
@@ -459,7 +462,8 @@ declare module 'xterm' {
   }
 
   /**
-   * Represents a decoration in the terminal that is associated with a particular marker and DOM element.
+   * Represents a decoration in the terminal that is associated with a
+   * particular marker and DOM element.
    */
   export interface IDecoration extends IDisposableWithEvent {
     /*
@@ -482,9 +486,9 @@ declare module 'xterm' {
     element: HTMLElement | undefined;
 
     /**
-     * The options for the overview ruler that can be updated.
-     * This will only take effect when {@link IDecorationOptions.overviewRulerOptions}
-     * were provided initially.
+     * The options for the overview ruler that can be updated. This will only
+     * take effect when {@link IDecorationOptions.overviewRulerOptions} were
+     * provided initially.
      */
     options: Pick<IDecorationOptions, 'overviewRulerOptions'>;
   }
@@ -531,24 +535,26 @@ declare module 'xterm' {
     readonly height?: number;
 
     /**
-     * The background color of the cell(s). When 2 decorations both set the foreground color the
-     * last registered decoration will be used. Only the `#RRGGBB` format is supported.
+     * The background color of the cell(s). When 2 decorations both set the
+     * foreground color the last registered decoration will be used. Only the
+     * `#RRGGBB` format is supported.
      */
     readonly backgroundColor?: string;
 
     /**
-     * The foreground color of the cell(s). When 2 decorations both set the foreground color the
-     * last registered decoration will be used. Only the `#RRGGBB` format is supported.
+     * The foreground color of the cell(s). When 2 decorations both set the
+     * foreground color the last registered decoration will be used. Only the
+     * `#RRGGBB` format is supported.
      */
     readonly foregroundColor?: string;
 
     /**
      * What layer to render the decoration at when {@link backgroundColor} or
-     * {@link foregroundColor} are used. `'bottom'` will render under the selection, `'top`' will
-     * render above the selection\*.
+     * {@link foregroundColor} are used. `'bottom'` will render under the
+     * selection, `'top`' will render above the selection\*.
      *
-     * *\* The selection will render on top regardless of layer on the canvas renderer due to how
-     * it renders selection separately.*
+     * *\* The selection will render on top regardless of layer on the canvas
+     * renderer due to how it renders selection separately.*
      */
     readonly layer?: 'bottom' | 'top';
 
@@ -559,7 +565,7 @@ declare module 'xterm' {
      * @param color The color of the decoration.
      * @param position The position of the decoration.
      */
-    overviewRulerOptions?: IDecorationOverviewRulerOptions
+    overviewRulerOptions?: IDecorationOverviewRulerOptions;
   }
 
   /**
@@ -579,7 +585,8 @@ declare module 'xterm' {
   }
 
   /**
-   * Enable various window manipulation and report features (CSI Ps ; Ps ; Ps t).
+   * Enable various window manipulation and report features
+   * (`CSI Ps ; Ps ; Ps t`).
    *
    * Most settings have no default implementation, as they heavily rely on
    * the embedding environment.
@@ -599,10 +606,10 @@ declare module 'xterm' {
    *
    * Note on security:
    * Most features are meant to deal with some information of the host machine
-   * where the terminal runs on. This is seen as a security risk possibly leaking
-   * sensitive data of the host to the program in the terminal. Therefore all options
-   * (even those without a default implementation) are guarded by the boolean flag
-   * and disabled by default.
+   * where the terminal runs on. This is seen as a security risk possibly
+   * leaking sensitive data of the host to the program in the terminal.
+   * Therefore all options (even those without a default implementation) are
+   * guarded by the boolean flag and disabled by default.
    */
   export interface IWindowOptions {
     /**
@@ -870,9 +877,9 @@ declare module 'xterm' {
     onData: IEvent<string>;
 
     /**
-     * Adds an event listener for when a key is pressed. The event value contains the
-     * string that will be sent in the data event as well as the DOM event that
-     * triggered it.
+     * Adds an event listener for when a key is pressed. The event value
+     * contains the string that will be sent in the data event as well as the
+     * DOM event that triggered it.
      * @returns an `IDisposable` to stop listening.
      */
     onKey: IEvent<{ key: string, domEvent: KeyboardEvent }>;
@@ -1040,10 +1047,11 @@ declare module 'xterm' {
 
     /**
      * (EXPERIMENTAL) Adds a decoration to the terminal using
-     *  @param decorationOptions, which takes a marker and an optional anchor,
-     *  width, height, and x offset from the anchor. Returns the decoration or
-     *  undefined if the alt buffer is active or the marker has already been disposed of.
-     *  @throws when options include a negative x offset.
+     * @param decorationOptions, which takes a marker and an optional anchor,
+     * width, height, and x offset from the anchor. Returns the decoration or
+     * undefined if the alt buffer is active or the marker has already been
+     * disposed of.
+     * @throws when options include a negative x offset.
      */
     registerDecoration(decorationOptions: IDecorationOptions): IDecoration | undefined;
 
@@ -1149,7 +1157,8 @@ declare module 'xterm' {
     writeln(data: string | Uint8Array, callback?: () => void): void;
 
     /**
-     * Writes text to the terminal, performing the necessary transformations for pasted text.
+     * Writes text to the terminal, performing the necessary transformations for
+     * pasted text.
      * @param data The text to write to the terminal.
      */
     paste(data: string): void;
@@ -1163,10 +1172,10 @@ declare module 'xterm' {
     refresh(start: number, end: number): void;
 
     /**
-     * Clears the texture atlas of the canvas renderer if it's active. Doing this will force a
-     * redraw of all glyphs which can workaround issues causing the texture to become corrupt, for
-     * example Chromium/Nvidia has an issue where the texture gets messed up when resuming the OS
-     * from sleep.
+     * Clears the texture atlas of the canvas renderer if it's active. Doing
+     * this will force a redraw of all glyphs which can workaround issues
+     * causing the texture to become corrupt, for example Chromium/Nvidia has an
+     * issue where the texture gets messed up when resuming the OS from sleep.
      */
     clearTextureAtlas(): void;
 
@@ -1237,32 +1246,34 @@ declare module 'xterm' {
      * @param text The text of the link.
      * @param range The buffer range of the link.
      */
-     activate(event: MouseEvent, text: string, range: IBufferRange): void;
+    activate(event: MouseEvent, text: string, range: IBufferRange): void;
 
-     /**
-      * Called when the mouse hovers the link. To use this to create a DOM-based hover tooltip,
-      * create the hover element within `Terminal.element` and add the `xterm-hover` class to it,
-      * that will cause mouse events to not fall through and activate other links.
-      * @param event The mouse event triggering the callback.
-      * @param text The text of the link.
-      * @param range The buffer range of the link.
-      */
-     hover?(event: MouseEvent, text: string, range: IBufferRange): void;
+    /**
+     * Called when the mouse hovers the link. To use this to create a DOM-based
+     * hover tooltip, create the hover element within `Terminal.element` and
+     * add the `xterm-hover` class to it, that will cause mouse events to not
+     * fall through and activate other links.
+     * @param event The mouse event triggering the callback.
+     * @param text The text of the link.
+     * @param range The buffer range of the link.
+     */
+    hover?(event: MouseEvent, text: string, range: IBufferRange): void;
 
-     /**
-      * Called when the mouse leaves the link.
-      * @param event The mouse event triggering the callback.
-      * @param text The text of the link.
-      * @param range The buffer range of the link.
-      */
-     leave?(event: MouseEvent, text: string, range: IBufferRange): void;
+    /**
+     * Called when the mouse leaves the link.
+     * @param event The mouse event triggering the callback.
+     * @param text The text of the link.
+     * @param range The buffer range of the link.
+     */
+    leave?(event: MouseEvent, text: string, range: IBufferRange): void;
 
-     /**
-      * Whether to receive non-HTTP URLs from LinkProvider. When false, any usage of non-HTTP URLs
-      * will be ignored. Enabling this option without proper protection in `activate` function
-      * may cause security issues such as XSS.
-      */
-     allowNonHttpProtocols?: boolean;
+    /**
+     * Whether to receive non-HTTP URLs from LinkProvider. When false, any
+     * usage of non-HTTP URLs will be ignored. Enabling this option without
+     * proper protection in `activate` function may cause security issues such
+     * as XSS.
+     */
+    allowNonHttpProtocols?: boolean;
   }
 
   /**
@@ -1294,9 +1305,9 @@ declare module 'xterm' {
     text: string;
 
     /**
-     * What link decorations to show when hovering the link, this property is tracked and changes
-     * made after the link is provided will trigger changes. If not set, all decroations will be
-     * enabled.
+     * What link decorations to show when hovering the link, this property is
+     * tracked and changes made after the link is provided will trigger changes.
+     * If not set, all decroations will be enabled.
      */
     decorations?: ILinkDecorations;
 
@@ -1308,9 +1319,10 @@ declare module 'xterm' {
     activate(event: MouseEvent, text: string): void;
 
     /**
-     * Called when the mouse hovers the link. To use this to create a DOM-based hover tooltip,
-     * create the hover element within `Terminal.element` and add the `xterm-hover` class to it,
-     * that will cause mouse events to not fall through and activate other links.
+     * Called when the mouse hovers the link. To use this to create a DOM-based
+     * hover tooltip, create the hover element within `Terminal.element` and add
+     * the `xterm-hover` class to it, that will cause mouse events to not fall
+     * through and activate other links.
      * @param event The mouse event triggering the callback.
      * @param text The text of the link.
      */
@@ -1434,7 +1446,8 @@ declare module 'xterm' {
 
   export interface IBufferElementProvider {
     /**
-     * Provides a document fragment or HTMLElement containing the buffer elements.
+     * Provides a document fragment or HTMLElement containing the buffer
+     * elements.
      */
     provideBufferElements(): DocumentFragment | HTMLElement;
   }
@@ -1681,43 +1694,43 @@ declare module 'xterm' {
   export interface IParser {
     /**
      * Adds a handler for CSI escape sequences.
-     * @param id Specifies the function identifier under which the callback
-     * gets registered, e.g. {final: 'm'} for SGR.
+     * @param id Specifies the function identifier under which the callback gets
+     * registered, e.g. {final: 'm'} for SGR.
      * @param callback The function to handle the sequence. The callback is
-     * called with the numerical params. If the sequence has subparams the
-     * array will contain subarrays with their numercial values.
-     * Return `true` if the sequence was handled, `false` if the parser should try
-     * a previous handler. The most recently added handler is tried first.
+     * called with the numerical params. If the sequence has subparams the array
+     * will contain subarrays with their numercial values. Return `true` if the
+     * sequence was handled, `false` if the parser should try a previous
+     * handler. The most recently added handler is tried first.
      * @returns An IDisposable you can call to remove this handler.
      */
     registerCsiHandler(id: IFunctionIdentifier, callback: (params: (number | number[])[]) => boolean | Promise<boolean>): IDisposable;
 
     /**
      * Adds a handler for DCS escape sequences.
-     * @param id Specifies the function identifier under which the callback
-     * gets registered, e.g. {intermediates: '$' final: 'q'} for DECRQSS.
+     * @param id Specifies the function identifier under which the callback gets
+     * registered, e.g. {intermediates: '$' final: 'q'} for DECRQSS.
      * @param callback The function to handle the sequence. Note that the
      * function will only be called once if the sequence finished sucessfully.
      * There is currently no way to intercept smaller data chunks, data chunks
-     * will be stored up until the sequence is finished. Since DCS sequences
-     * are not limited by the amount of data this might impose a problem for
-     * big payloads. Currently xterm.js limits DCS payload to 10 MB
-     * which should give enough room for most use cases.
-     * The function gets the payload and numerical parameters as arguments.
-     * Return `true` if the sequence was handled, `false` if the parser should try
-     * a previous handler. The most recently added handler is tried first.
+     * will be stored up until the sequence is finished. Since DCS sequences are
+     * not limited by the amount of data this might impose a problem for big
+     * payloads. Currently xterm.js limits DCS payload to 10 MB which should
+     * give enough room for most use cases. The function gets the payload and
+     * numerical parameters as arguments. Return `true` if the sequence was
+     * handled, `false` if the parser should try a previous handler. The most
+     * recently added handler is tried first.
      * @returns An IDisposable you can call to remove this handler.
      */
     registerDcsHandler(id: IFunctionIdentifier, callback: (data: string, param: (number | number[])[]) => boolean | Promise<boolean>): IDisposable;
 
     /**
      * Adds a handler for ESC escape sequences.
-     * @param id Specifies the function identifier under which the callback
-     * gets registered, e.g. {intermediates: '%' final: 'G'} for
-     * default charset selection.
+     * @param id Specifies the function identifier under which the callback gets
+     * registered, e.g. {intermediates: '%' final: 'G'} for default charset
+     * selection.
      * @param callback The function to handle the sequence.
-     * Return `true` if the sequence was handled, `false` if the parser should try
-     * a previous handler. The most recently added handler is tried first.
+     * Return `true` if the sequence was handled, `false` if the parser should
+     * try a previous handler. The most recently added handler is tried first.
      * @returns An IDisposable you can call to remove this handler.
      */
     registerEscHandler(id: IFunctionIdentifier, handler: () => boolean | Promise<boolean>): IDisposable;
@@ -1728,13 +1741,13 @@ declare module 'xterm' {
      * @param callback The function to handle the sequence. Note that the
      * function will only be called once if the sequence finished sucessfully.
      * There is currently no way to intercept smaller data chunks, data chunks
-     * will be stored up until the sequence is finished. Since OSC sequences
-     * are not limited by the amount of data this might impose a problem for
-     * big payloads. Currently xterm.js limits OSC payload to 10 MB
-     * which should give enough room for most use cases.
-     * The callback is called with OSC data string.
-     * Return `true` if the sequence was handled, `false` if the parser should try
-     * a previous handler. The most recently added handler is tried first.
+     * will be stored up until the sequence is finished. Since OSC sequences are
+     * not limited by the amount of data this might impose a problem for big
+     * payloads. Currently xterm.js limits OSC payload to 10 MB which should
+     * give enough room for most use cases. The callback is called with OSC data
+     * string. Return `true` if the sequence was handled, `false` if the parser
+     * should try a previous handler. The most recently added handler is tried
+     * first.
      * @returns An IDisposable you can call to remove this handler.
      */
     registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>): IDisposable;
@@ -1820,6 +1833,6 @@ declare module 'xterm' {
     /**
      * Auto-Wrap Mode (DECAWM): `CSI ? 7 h`
      */
-    readonly wraparoundMode: boolean
+    readonly wraparoundMode: boolean;
   }
 }


### PR DESCRIPTION
Similar to #4668, this brings linting to the API files with a cut down set of rules. One of the bigger ones is comment length is restricted to 80, this was done as opposed to 100 for regular code to reduce the chance of wrapping or API going off screen regardless of resolution or window/browser size