### PR TITLE
DOM: Render selection color instead of cell bg

### DIFF
--- a/src/browser/TestUtils.test.ts
+++ b/src/browser/TestUtils.test.ts
@@ -529,6 +529,8 @@ export class MockThemeService implements IThemeService{
       css.toColor('#ad7fa8'),
       css.toColor('#34e2e2'),
       css.toColor('#eeeeec')
-    ]
+    ],
+    selectionBackgroundOpaque: css.toColor('#ff0000'),
+    selectionInactiveBackgroundOpaque: css.toColor('#00ff00')
   } as any;
 }

--- a/src/browser/renderer/dom/DomRendererRowFactory.test.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.test.ts
@@ -309,7 +309,7 @@ describe('DomRendererRowFactory', () => {
         rowFactory.handleSelectionChanged([1, 0], [2, 0], false);
         const spans = rowFactory.createRow(lineData, 0, false, undefined, undefined, 0, false, 5, EMPTY_WIDTH, -1, -1);
         assert.equal(extractHtml(spans),
-          '<span>a</span><span class="xterm-decoration-top">b</span>'
+          '<span>a</span><span style="background-color:#ff0000;" class="xterm-decoration-top">b</span>'
         );
       });
       it('should force whitespace cells to be rendered above the background', () => {
@@ -317,7 +317,7 @@ describe('DomRendererRowFactory', () => {
         rowFactory.handleSelectionChanged([0, 0], [2, 0], false);
         const spans = rowFactory.createRow(lineData, 0, false, undefined, undefined, 0, false, 5, EMPTY_WIDTH, -1, -1);
         assert.equal(extractHtml(spans),
-          '<span class="xterm-decoration-top"> </span><span class="xterm-decoration-top">a</span>'
+          '<span style="background-color:#ff0000;" class="xterm-decoration-top"> a</span>'
         );
       });
     });


### PR DESCRIPTION
Summary:

- Selection cell reuse has been added to the DOM renderer
- Selection bg override is now correctly set correctly
- Selection elements 'pretend' to be a decoration in order to render bg

Fixes #4097

![image](https://github.com/xtermjs/xterm.js/assets/2193314/5ee12bbe-3551-49f2-b89a-8fbb19a6d38d)
![image](https://github.com/xtermjs/xterm.js/assets/2193314/af071a4d-7446-4eda-8bd8-f113a51c42cd)
