### PR TITLE
Fix bug in selection handling in dom renderer

### DIFF
--- a/src/browser/renderer/dom/DomRendererRowFactory.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.ts
@@ -166,11 +166,11 @@ export class DomRendererRowFactory {
           cellAmount
           && (
             (isInSelection && oldIsInSelection)
-            || (!isInSelection && cell.bg === oldBg)
+            || (!isInSelection && !oldIsInSelection && cell.bg === oldBg)
           )
           && (
             (isInSelection && oldIsInSelection && colors.selectionForeground)
-            || (!(isInSelection && oldIsInSelection && colors.selectionForeground) && cell.fg === oldFg)
+            || cell.fg === oldFg
           )
           && cell.extended.ext === oldExt
           && isLinkHover === oldLinkHover


### PR DESCRIPTION
If you use the dom renderer and make a selection, the visible selection extends to the end of the line.  This fixes that.

This also fixes a logic weirdo: `A || (!A && B)` should be simplified to `A || B`.