### PR TITLE
Adopt MutableDisposable for most usages of pattern `<var>?.dispose(); <var> = undefined`

### DIFF
--- a/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
@@ -74,7 +74,6 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
 
     this.register(toDisposable(() => {
       this._canvas.remove();
-      this._charAtlas?.dispose();
     }));
   }
 

--- a/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
+++ b/addons/xterm-addon-canvas/src/BaseRenderLayer.ts
@@ -3,24 +3,24 @@
  * @license MIT
  */
 
+import { ReadonlyColorSet } from 'browser/Types';
+import { CellColorResolver } from 'browser/renderer/shared/CellColorResolver';
 import { acquireTextureAtlas } from 'browser/renderer/shared/CharAtlasCache';
 import { TEXT_BASELINE } from 'browser/renderer/shared/Constants';
 import { tryDrawCustomChar } from 'browser/renderer/shared/CustomGlyphs';
 import { throwIfFalsy } from 'browser/renderer/shared/RendererUtils';
-import { IRasterizedGlyph, IRenderDimensions, ISelectionRenderModel, ITextureAtlas } from 'browser/renderer/shared/Types';
 import { createSelectionRenderModel } from 'browser/renderer/shared/SelectionRenderModel';
+import { IRasterizedGlyph, IRenderDimensions, ISelectionRenderModel, ITextureAtlas } from 'browser/renderer/shared/Types';
 import { ICoreBrowserService, IThemeService } from 'browser/services/Services';
-import { ReadonlyColorSet } from 'browser/Types';
+import { EventEmitter, forwardEvent } from 'common/EventEmitter';
+import { Disposable, MutableDisposable, toDisposable } from 'common/Lifecycle';
+import { isSafari } from 'common/Platform';
+import { ICellData } from 'common/Types';
 import { CellData } from 'common/buffer/CellData';
 import { WHITESPACE_CELL_CODE } from 'common/buffer/Constants';
 import { IBufferService, IDecorationService, IOptionsService } from 'common/services/Services';
-import { ICellData, IDisposable } from 'common/Types';
 import { Terminal } from 'xterm';
 import { IRenderLayer } from './Types';
-import { CellColorResolver } from 'browser/renderer/shared/CellColorResolver';
-import { Disposable, toDisposable } from 'common/Lifecycle';
-import { isSafari } from 'common/Platform';
-import { EventEmitter, forwardEvent } from 'common/EventEmitter';
 
 export abstract class BaseRenderLayer extends Disposable implements IRenderLayer {
   private _canvas: HTMLCanvasElement;
@@ -37,7 +37,7 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
   private _bitmapGenerator: (BitmapGenerator | undefined)[] = [];
 
   protected _charAtlas!: ITextureAtlas;
-  private _charAtlasDisposable?: IDisposable;
+  protected _charAtlasDisposable = this.register(new MutableDisposable());
 
   public get canvas(): HTMLCanvasElement { return this._canvas; }
   public get cacheCanvas(): HTMLCanvasElement { return this._charAtlas?.pages[0].canvas!; }
@@ -122,9 +122,8 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     if (this._deviceCharWidth <= 0 && this._deviceCharHeight <= 0) {
       return;
     }
-    this._charAtlasDisposable?.dispose();
     this._charAtlas = acquireTextureAtlas(this._terminal, this._optionsService.rawOptions, colorSet, this._deviceCellWidth, this._deviceCellHeight, this._deviceCharWidth, this._deviceCharHeight, this._coreBrowserService.dpr);
-    this._charAtlasDisposable = forwardEvent(this._charAtlas.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas);
+    this._charAtlasDisposable.value = forwardEvent(this._charAtlas.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas);
     this._charAtlas.warmUp();
     for (let i = 0; i < this._charAtlas.pages.length; i++) {
       this._bitmapGenerator[i] = new BitmapGenerator(this._charAtlas.pages[i].canvas);

--- a/addons/xterm-addon-image/src/ImageRenderer.ts
+++ b/addons/xterm-addon-image/src/ImageRenderer.ts
@@ -6,6 +6,7 @@
 import { toRGBA8888 } from 'sixel/lib/Colors';
 import { IDisposable } from 'xterm';
 import { ICellSize, ITerminalExt, IImageSpec, IRenderDimensions, IRenderService } from './Types';
+import { MutableDisposable } from 'common/Lifecycle';
 
 
 const PLACEHOLDER_LENGTH = 4096;
@@ -22,7 +23,7 @@ export class ImageRenderer implements IDisposable {
   private _ctx: CanvasRenderingContext2D | null | undefined;
   private _placeholder: HTMLCanvasElement | undefined;
   private _placeholderBitmap: ImageBitmap | undefined;
-  private _optionsRefresh: IDisposable | undefined;
+  private _optionsRefresh = new MutableDisposable();
   private _oldOpen: ((parent: HTMLElement) => void) | undefined;
   private _renderService: IRenderService | undefined;
   private _oldSetRenderer: ((renderer: any) => void) | undefined;
@@ -77,7 +78,7 @@ export class ImageRenderer implements IDisposable {
       this._open();
     }
     // hack to spot fontSize changes
-    this._optionsRefresh = this._terminal._core.optionsService.onOptionChange(option => {
+    this._optionsRefresh.value = this._terminal._core.optionsService.onOptionChange(option => {
       if (option === 'fontSize') {
         this.rescaleCanvas();
         this._renderService?.refreshRows(0, this._terminal.rows);
@@ -87,7 +88,6 @@ export class ImageRenderer implements IDisposable {
 
 
   public dispose(): void {
-    this._optionsRefresh?.dispose();
     this.removeLayerFromDom();
     if (this._terminal._core && this._oldOpen) {
       this._terminal._core.open = this._oldOpen;

--- a/addons/xterm-addon-webgl/src/WebglRenderer.ts
+++ b/addons/xterm-addon-webgl/src/WebglRenderer.ts
@@ -20,7 +20,7 @@ import { CellData } from 'common/buffer/CellData';
 import { Attributes, Content, NULL_CELL_CHAR, NULL_CELL_CODE } from 'common/buffer/Constants';
 import { traceCall } from 'common/services/LogService';
 import { ICoreService, IDecorationService, IOptionsService } from 'common/services/Services';
-import { IDisposable, Terminal } from 'xterm';
+import { Terminal } from 'xterm';
 import { GlyphRenderer } from './GlyphRenderer';
 import { RectangleRenderer } from './RectangleRenderer';
 import { COMBINED_CHAR_BIT_MASK, RENDER_MODEL_BG_OFFSET, RENDER_MODEL_EXT_OFFSET, RENDER_MODEL_FG_OFFSET, RENDER_MODEL_INDICIES_PER_CELL, RenderModel } from './RenderModel';
@@ -31,7 +31,7 @@ import { IRenderLayer } from './renderLayer/Types';
 export class WebglRenderer extends Disposable implements IRenderer {
   private _renderLayers: IRenderLayer[];
   private _cursorBlinkStateManager: MutableDisposable<CursorBlinkStateManager> = new MutableDisposable();
-  private _charAtlasDisposable: IDisposable | undefined;
+  private _charAtlasDisposable = this.register(new MutableDisposable());
   private _charAtlas: ITextureAtlas | undefined;
   private _devicePixelRatio: number;
 
@@ -247,8 +247,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
     // Update dimensions and acquire char atlas
     this.handleCharSizeChanged();
 
-    return [this._rectangleRenderer.value, this._glyphRenderer.value
-    ];
+    return [this._rectangleRenderer.value, this._glyphRenderer.value];
   }
 
   /**
@@ -272,9 +271,8 @@ export class WebglRenderer extends Disposable implements IRenderer {
       this._coreBrowserService.dpr
     );
     if (this._charAtlas !== atlas) {
-      this._charAtlasDisposable?.dispose();
       this._onChangeTextureAtlas.fire(atlas.pages[0].canvas);
-      this._charAtlasDisposable = getDisposeArrayDisposable([
+      this._charAtlasDisposable.value = getDisposeArrayDisposable([
         forwardEvent(atlas.onAddTextureAtlasCanvas, this._onAddTextureAtlasCanvas),
         forwardEvent(atlas.onRemoveTextureAtlasCanvas, this._onRemoveTextureAtlasCanvas)
       ]);
@@ -292,7 +290,7 @@ export class WebglRenderer extends Disposable implements IRenderer {
   private _clearModel(clearGlyphRenderer: boolean): void {
     this._model.clear();
     if (clearGlyphRenderer) {
-      this._glyphRenderer?.clear();
+      this._glyphRenderer.value?.clear();
     }
   }
 

--- a/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
+++ b/addons/xterm-addon-webgl/src/renderLayer/BaseRenderLayer.ts
@@ -49,7 +49,6 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     }));
     this.register(toDisposable(() => {
       this._canvas.remove();
-      this._charAtlas?.dispose();
     }));
   }
 

--- a/addons/xterm-addon-webgl/test/WebglRenderer.api.ts
+++ b/addons/xterm-addon-webgl/test/WebglRenderer.api.ts
@@ -1106,7 +1106,7 @@ describe('WebGL Renderer Integration Tests', async () => {
 
 async function getCellColor(col: number, row: number): Promise<number[]> {
   await page.evaluate(`
-    window.gl = window.term._core._renderService._renderer._gl;
+    window.gl = window.term._core._renderService._renderer.value._gl;
     window.result = new Uint8Array(4);
     window.d = window.term._core._renderService.dimensions;
     window.gl.readPixels(
@@ -1120,7 +1120,7 @@ async function getCellColor(col: number, row: number): Promise<number[]> {
 
 async function getCellPixels(col: number, row: number): Promise<number[]> {
   await page.evaluate(`
-    window.gl = window.term._core._renderService._renderer._gl;
+    window.gl = window.term._core._renderService._renderer.value._gl;
     window.result = new Uint8Array(window.d.device.cell.width * window.d.device.cell.height * 4);
     window.d = window.term._core._renderService.dimensions;
     window.gl.readPixels(

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -10,7 +10,7 @@ import { IRenderDebouncerWithCallback } from 'browser/Types';
 import { IRenderDimensions, IRenderer } from 'browser/renderer/shared/Types';
 import { ICharSizeService, ICoreBrowserService, IRenderService, IThemeService } from 'browser/services/Services';
 import { EventEmitter } from 'common/EventEmitter';
-import { Disposable } from 'common/Lifecycle';
+import { Disposable, MutableDisposable } from 'common/Lifecycle';
 import { DebouncedIdleTask } from 'common/TaskQueue';
 import { IBufferService, IDecorationService, IOptionsService } from 'common/services/Services';
 
@@ -23,7 +23,7 @@ interface ISelectionState {
 export class RenderService extends Disposable implements IRenderService {
   public serviceBrand: undefined;
 
-  private _renderer: IRenderer | undefined;
+  private _renderer: MutableDisposable<IRenderer> = this.register(new MutableDisposable());
   private _renderDebouncer: IRenderDebouncerWithCallback;
   private _screenDprMonitor: ScreenDprMonitor;
   private _pausedResizeTask = new DebouncedIdleTask();
@@ -49,7 +49,7 @@ export class RenderService extends Disposable implements IRenderService {
   private readonly _onRefreshRequest = this.register(new EventEmitter<{ start: number, end: number }>());
   public readonly onRefreshRequest = this._onRefreshRequest.event;
 
-  public get dimensions(): IRenderDimensions { return this._renderer!.dimensions; }
+  public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }
 
   constructor(
     private _rowCount: number,
@@ -63,8 +63,6 @@ export class RenderService extends Disposable implements IRenderService {
   ) {
     super();
 
-    this.register({ dispose: () => this._renderer?.dispose() });
-
     this._renderDebouncer = new RenderDebouncer(coreBrowserService.window, (start, end) => this._renderRows(start, end));
     this.register(this._renderDebouncer);
 
@@ -73,7 +71,7 @@ export class RenderService extends Disposable implements IRenderService {
     this.register(this._screenDprMonitor);
 
     this.register(bufferService.onResize(() => this._fullRefresh()));
-    this.register(bufferService.buffers.onBufferActivate(() => this._renderer?.clear()));
+    this.register(bufferService.buffers.onBufferActivate(() => this._renderer.value?.clear()));
     this.register(optionsService.onOptionChange(() => this._handleOptionsChanged()));
     this.register(this._charSizeService.onCharSizeChange(() => this.handleCharSizeChanged()));
 
@@ -148,7 +146,7 @@ export class RenderService extends Disposable implements IRenderService {
   }
 
   private _renderRows(start: number, end: number): void {
-    if (!this._renderer) {
+    if (!this._renderer.value) {
       return;
     }
 
@@ -159,11 +157,11 @@ export class RenderService extends Disposable implements IRenderService {
     end = Math.min(end, this._rowCount - 1);
 
     // Render
-    this._renderer.renderRows(start, end);
+    this._renderer.value.renderRows(start, end);
 
     // Update selection if needed
     if (this._needsSelectionRefresh) {
-      this._renderer.handleSelectionChanged(this._selectionState.start, this._selectionState.end, this._selectionState.columnSelectMode);
+      this._renderer.value.handleSelectionChanged(this._selectionState.start, this._selectionState.end, this._selectionState.columnSelectMode);
       this._needsSelectionRefresh = false;
     }
 
@@ -181,7 +179,7 @@ export class RenderService extends Disposable implements IRenderService {
   }
 
   private _handleOptionsChanged(): void {
-    if (!this._renderer) {
+    if (!this._renderer.value) {
       return;
     }
     this.refreshRows(0, this._rowCount - 1);
@@ -189,25 +187,23 @@ export class RenderService extends Disposable implements IRenderService {
   }
 
   private _fireOnCanvasResize(): void {
-    if (!this._renderer) {
+    if (!this._renderer.value) {
       return;
     }
     // Don't fire the event if the dimensions haven't changed
-    if (this._renderer.dimensions.css.canvas.width === this._canvasWidth && this._renderer.dimensions.css.canvas.height === this._canvasHeight) {
+    if (this._renderer.value.dimensions.css.canvas.width === this._canvasWidth && this._renderer.value.dimensions.css.canvas.height === this._canvasHeight) {
       return;
     }
-    this._onDimensionsChange.fire(this._renderer.dimensions);
+    this._onDimensionsChange.fire(this._renderer.value.dimensions);
   }
 
   public hasRenderer(): boolean {
-    return !!this._renderer;
+    return !!this._renderer.value;
   }
 
   public setRenderer(renderer: IRenderer): void {
-    // TODO: RenderService should be the only one to dispose the renderer
-    this._renderer?.dispose();
-    this._renderer = renderer;
-    this._renderer.onRequestRedraw(e => this.refreshRows(e.start, e.end, true));
+    this._renderer.value = renderer;
+    this._renderer.value.onRequestRedraw(e => this.refreshRows(e.start, e.end, true));
 
     // Force a refresh
     this._needsSelectionRefresh = true;
@@ -227,10 +223,10 @@ export class RenderService extends Disposable implements IRenderService {
   }
 
   public clearTextureAtlas(): void {
-    if (!this._renderer) {
+    if (!this._renderer.value) {
       return;
     }
-    this._renderer.clearTextureAtlas?.();
+    this._renderer.value.clearTextureAtlas?.();
     this._fullRefresh();
   }
 
@@ -239,50 +235,50 @@ export class RenderService extends Disposable implements IRenderService {
     // when devicePixelRatio changes
     this._charSizeService.measure();
 
-    if (!this._renderer) {
+    if (!this._renderer.value) {
       return;
     }
-    this._renderer.handleDevicePixelRatioChange();
+    this._renderer.value.handleDevicePixelRatioChange();
     this.refreshRows(0, this._rowCount - 1);
   }
 
   public handleResize(cols: number, rows: number): void {
-    if (!this._renderer) {
+    if (!this._renderer.value) {
       return;
     }
     if (this._isPaused) {
-      this._pausedResizeTask.set(() => this._renderer!.handleResize(cols, rows));
+      this._pausedResizeTask.set(() => this._renderer.value!.handleResize(cols, rows));
     } else {
-      this._renderer.handleResize(cols, rows);
+      this._renderer.value.handleResize(cols, rows);
     }
     this._fullRefresh();
   }
 
   // TODO: Is this useful when we have onResize?
   public handleCharSizeChanged(): void {
-    this._renderer?.handleCharSizeChanged();
+    this._renderer.value?.handleCharSizeChanged();
   }
 
   public handleBlur(): void {
-    this._renderer?.handleBlur();
+    this._renderer.value?.handleBlur();
   }
 
   public handleFocus(): void {
-    this._renderer?.handleFocus();
+    this._renderer.value?.handleFocus();
   }
 
   public handleSelectionChanged(start: [number, number] | undefined, end: [number, number] | undefined, columnSelectMode: boolean): void {
     this._selectionState.start = start;
     this._selectionState.end = end;
     this._selectionState.columnSelectMode = columnSelectMode;
-    this._renderer?.handleSelectionChanged(start, end, columnSelectMode);
+    this._renderer.value?.handleSelectionChanged(start, end, columnSelectMode);
   }
 
   public handleCursorMove(): void {
-    this._renderer?.handleCursorMove();
+    this._renderer.value?.handleCursorMove();
   }
 
   public clear(): void {
-    this._renderer?.clear();
+    this._renderer.value?.clear();
   }
 }


### PR DESCRIPTION
This helps us from making mistakes by registering the clearing of an optional disposable when it's created, instead of having to create and dispose in two separate spots.

This also fixes the following issues:

- Texture atlases were getting disposed when canvas and webgl renderers were being disposed which could cause issues when they're shared. The disposal of the texture atlas is the duty of `CharAtlasCache.removeTerminalFromCache`
- The following weren't being disposed of correctly before:
  - `Terminal._accessibilityManager`
  - `WebglRenderer._rectangleRenderer`
  - `WebglRenderer._glyphRenderer`