### PR TITLE
Disable image addon publishing

### DIFF
--- a/bin/publish.js
+++ b/bin/publish.js
@@ -30,7 +30,7 @@ const addonPackageDirs = [
   path.resolve(__dirname, '../addons/xterm-addon-attach'),
   path.resolve(__dirname, '../addons/xterm-addon-canvas'),
   path.resolve(__dirname, '../addons/xterm-addon-fit'),
-  path.resolve(__dirname, '../addons/xterm-addon-image'),
+  // path.resolve(__dirname, '../addons/xterm-addon-image'),
   path.resolve(__dirname, '../addons/xterm-addon-ligatures'),
   path.resolve(__dirname, '../addons/xterm-addon-search'),
   path.resolve(__dirname, '../addons/xterm-addon-serialize'),


### PR DESCRIPTION
@jerch FYI image addon publishing isn't working atm:

https://github.com/xtermjs/xterm.js/actions/runs/6113142541/job/16592044020