### PR TITLE
Fix regression in force mouse selection

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -729,10 +729,8 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
       if (!(events & CoreMouseEventType.UP)) {
         this._document!.removeEventListener('mouseup', requestedEvents.mouseup!);
-        el.removeEventListener('mouseup', requestedEvents.mouseup!);
         requestedEvents.mouseup = null;
       } else if (!requestedEvents.mouseup) {
-        el.addEventListener('mouseup', eventListeners.mouseup);
         requestedEvents.mouseup = eventListeners.mouseup;
       }
 


### PR DESCRIPTION
Shift+left click is means to force terminal selection and not passthrough any mouse events, even if a mouse mode is enabled. The change this is reverting from #4583 caused this feature to break by always installing a global listener on Terminal.element so the SelectionService never got a chance to cancel is.

Fixes #4781

@jerch FYI, we may need to reopen https://github.com/xtermjs/xterm.js/issues/4582