### PR TITLE
Fix server debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,11 +59,9 @@
       "request": "launch",
       "name": "Demo Server",
       "runtimeExecutable": "npm",
-      "runtimeArgs": [
-        "run",
-        "start-debug"
-      ],
-      "port": 9229,
+      "runtimeArgs": ["start"],
+      "stopOnEntry": true,
+      "runtimeVersion": "16",
       "serverReadyAction": {
         "action": "openExternally",
         "pattern": "App listening to (http://.*?:[0-9]+)"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "start": "node demo/start",
     "start-server-only": "node demo/start-server-only",
     "build-demo": "webpack --config ./demo/webpack.config.js",
-    "start-debug": "node --inspect-brk demo/start",
     "lint": "eslint -c .eslintrc.json --max-warnings 0 --ext .ts src/ addons/",
     "lint-api": "eslint --no-eslintrc -c .eslintrc.json.typings --max-warnings 0 --no-ignore --ext .d.ts typings/",
     "test": "npm run test-unit",


### PR DESCRIPTION
This broke somewhere along the way, the changes update from the legacy attach method of --inspect-brk to stopOnEntry and also updates for the introduction of .nvmrc.