### PR TITLE
Correct graphemes addon readme and typings

### DIFF
--- a/addons/xterm-addon-unicode-graphemes/README.md
+++ b/addons/xterm-addon-unicode-graphemes/README.md
@@ -16,9 +16,9 @@ npm install --save xterm-addon-unicode-graphemes
 
 ```ts
 import { Terminal } from 'xterm';
-import { UnicodeGraphemeAddon } from 'xterm-addon-unicode-graphemes';
+import { UnicodeGraphemesAddon } from 'xterm-addon-unicode-graphemes';
 
 const terminal = new Terminal();
-const unicodeGraphemeAddon = new UnicodeGraphemeAddon();
-terminal.loadAddon(unicodeGraphemeAddon);
+const unicodeGraphemesAddon = new UnicodeGraphemesAddon();
+terminal.loadAddon(unicodeGraphemesAddon);
 ```

--- a/addons/xterm-addon-unicode-graphemes/typings/xterm-addon-unicode-graphemes.d.ts
+++ b/addons/xterm-addon-unicode-graphemes/typings/xterm-addon-unicode-graphemes.d.ts
@@ -6,7 +6,7 @@
 import { Terminal, ITerminalAddon } from 'xterm';
 
 declare module 'xterm-addon-unicode-graphemes' {
-  export class Unicode11Addon implements ITerminalAddon {
+  export class UnicodeGraphemesAddon implements ITerminalAddon {
     constructor();
     public activate(terminal: Terminal): void;
     public dispose(): void;


### PR DESCRIPTION
Small copy-paste fix for the typings file and readme file in the new graphemes addon. 