### PR TITLE
DOM Renderer: Render background separately

### DIFF
--- a/css/xterm.css
+++ b/css/xterm.css
@@ -160,6 +160,20 @@
     overflow: hidden;
 }
 
+.xterm .xterm-rows div {
+    position: relative;
+}
+
+.xterm .xterm-rows span {
+    position: relative;
+}
+
+.xterm .xterm-rows span.xterm-bg {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+}
+
 .xterm-dim {
     /* Dim should not apply to background, so the opacity of the foreground color is applied
      * explicitly in the generated class and reset to 1 here */

--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -127,23 +127,12 @@ export class DomRenderer extends Disposable implements IRenderer {
       element.style.width = `${this.dimensions.css.canvas.width}px`;
       element.style.height = `${this.dimensions.css.cell.height}px`;
       element.style.lineHeight = `${this.dimensions.css.cell.height}px`;
-      // Make sure rows don't overflow onto following row
-      element.style.overflow = 'hidden';
     }
 
     if (!this._dimensionsStyleElement) {
       this._dimensionsStyleElement = this._document.createElement('style');
       this._screenElement.appendChild(this._dimensionsStyleElement);
     }
-
-    const styles =
-      `${this._terminalSelector} .${ROW_CONTAINER_CLASS} span {` +
-      ` display: inline-block;` +   // TODO: find workaround for inline-block (creates ~20% render penalty)
-      ` height: 100%;` +
-      ` vertical-align: top;` +
-      `}`;
-
-    this._dimensionsStyleElement.textContent = styles;
 
     this._selectionContainer.style.height = this._viewportElement.style.height;
     this._screenElement.style.width = `${this.dimensions.css.canvas.width}px`;

--- a/src/browser/renderer/dom/DomRendererRowFactory.ts
+++ b/src/browser/renderer/dom/DomRendererRowFactory.ts
@@ -72,7 +72,8 @@ export class DomRendererRowFactory {
     linkEnd: number
   ): HTMLSpanElement[] {
 
-    const elements: HTMLSpanElement[] = [];
+    const charElements: HTMLSpanElement[] = [];
+    const backgroundElements: HTMLSpanElement[] = [];
     const joinedRanges = this._characterJoinerService.getJoinedCharacters(row);
     const colors = this._themeService.colors;
 
@@ -82,8 +83,10 @@ export class DomRendererRowFactory {
     }
 
     let charElement: HTMLSpanElement | undefined;
-    let cellAmount = 0;
-    let text = '';
+    let charCellAmount = 0;
+    let charText = '';
+    let backgroundElement: HTMLSpanElement | undefined;
+    let backgroundCellAmount = 0;
     let oldBg = 0;
     let oldFg = 0;
     let oldExt = 0;
@@ -149,312 +152,364 @@ export class DomRendererRowFactory {
       // lookup char render width and calc spacing
       spacing = width * cellWidth - widthCache.get(chars, cell.isBold(), cell.isItalic());
 
-      if (!charElement) {
-        charElement = this._document.createElement('span');
-      } else {
-        /**
-         * chars can only be merged on existing span if:
-         * - existing span only contains mergeable chars (cellAmount != 0)
-         * - bg did not change (or both are in selection)
-         * - fg did not change (or both are in selection and selection fg is set)
-         * - ext did not change
-         * - underline from hover state did not change
-         * - cell content renders to same letter-spacing
-         * - cell is not cursor
-         */
-        if (
-          cellAmount
-          && (
-            (isInSelection && oldIsInSelection)
-            || (!isInSelection && !oldIsInSelection && cell.bg === oldBg)
-          )
-          && (
-            (isInSelection && oldIsInSelection && colors.selectionForeground)
-            || cell.fg === oldFg
-          )
-          && cell.extended.ext === oldExt
-          && isLinkHover === oldLinkHover
-          && spacing === oldSpacing
-          && !isCursorCell
-          && !isJoined
-          && !isDecorated
-        ) {
-          // no span alterations, thus only account chars skipping all code below
-          if (cell.isInvisible()) {
-            text += WHITESPACE_CELL_CHAR;
-          } else {
-            text += chars;
+      /**
+       * chars can only be merged on existing span if:
+       * - existing span only contains mergeable chars (cellAmount != 0)
+       * - bg did not change (or both are in selection)
+       * - fg did not change (or both are in selection and selection fg is set)
+       * - ext did not change
+       * - underline from hover state did not change
+       * - cell content renders to same letter-spacing
+       * - cell is not cursor
+       * - cell characters are not joined
+       * - cell is not decorated
+       */
+      const canMergeCharacters = charElement
+        && charCellAmount
+        && (
+          (isInSelection && oldIsInSelection && colors.selectionForeground)
+          || cell.fg === oldFg
+        )
+        && cell.extended.ext === oldExt
+        && isLinkHover === oldLinkHover
+        && spacing === oldSpacing
+        && !isCursorCell
+        && !isJoined
+        && !isDecorated;
+
+      /**
+       * background can only be merged on existing span if:
+       * - existing span only contains mergeable chars (cellAmount != 0)
+       * - bg did not change (or both are in selection)
+       * - cell is not cursor
+       * - cell is not decorated
+       */
+      const canMergeBackground = backgroundElement
+        && backgroundCellAmount
+        && (
+          (isInSelection && oldIsInSelection)
+          || (!isInSelection && !oldIsInSelection && cell.bg === oldBg)
+        )
+        && !isCursorCell
+        && !isDecorated;
+
+      // if the background related cell attributes have not changed
+      // from the previous cell then we simply extend the existing span
+      if (canMergeBackground) {
+        backgroundCellAmount += width;
+      }
+
+      // if the character related cell attributes have not changed
+      // from the previous cell then we simply extend the existing span
+      if (canMergeCharacters) {
+        charText += chars;
+        charCellAmount++;
+      }
+
+      // character or background attributes have changed - we need to do more work
+      if (!canMergeCharacters || !canMergeBackground) {
+
+        // preserve conditions for next merger eval round
+        oldBg = cell.bg;
+        oldFg = cell.fg;
+        oldExt = cell.extended.ext;
+        oldLinkHover = isLinkHover;
+        oldSpacing = spacing;
+        oldIsInSelection = isInSelection;
+
+        let fg = cell.getFgColor();
+        let fgColorMode = cell.getFgColorMode();
+        let bg = cell.getBgColor();
+        let bgColorMode = cell.getBgColorMode();
+        const isInverse = !!cell.isInverse();
+        if (isInverse) {
+          const temp = fg;
+          fg = bg;
+          bg = temp;
+          const temp2 = fgColorMode;
+          fgColorMode = bgColorMode;
+          bgColorMode = temp2;
+        }
+
+        // Apply any decoration foreground/background overrides, this must happen after inverse has
+        // been applied
+        let bgOverride: IColor | undefined;
+        let fgOverride: IColor | undefined;
+        let isTop = false;
+        this._decorationService.forEachDecorationAtCell(x, row, undefined, d => {
+          if (d.options.layer !== 'top' && isTop) {
+            return;
           }
-          cellAmount++;
-          continue;
-        } else {
-          /**
-           * cannot merge:
-           * - apply left-over text to old span
-           * - create new span, reset state holders cellAmount & text
-           */
-          if (cellAmount) {
-            charElement.textContent = text;
+          if (d.backgroundColorRGB) {
+            bgColorMode = Attributes.CM_RGB;
+            bg = d.backgroundColorRGB.rgba >> 8 & 0xFFFFFF;
+            bgOverride = d.backgroundColorRGB;
+          }
+          if (d.foregroundColorRGB) {
+            fgColorMode = Attributes.CM_RGB;
+            fg = d.foregroundColorRGB.rgba >> 8 & 0xFFFFFF;
+            fgOverride = d.foregroundColorRGB;
+          }
+          isTop = d.options.layer === 'top';
+        });
+
+        // Apply selection
+        if (!isTop && isInSelection) {
+          // If in the selection, force the element to be above the selection to improve contrast and
+          // support opaque selections. The applies background is not actually needed here as
+          // selection is drawn in a seperate container, the main purpose of this to ensuring minimum
+          // contrast ratio
+          bgOverride = this._coreBrowserService.isFocused ? colors.selectionBackgroundOpaque : colors.selectionInactiveBackgroundOpaque;
+          bg = bgOverride.rgba >> 8 & 0xFFFFFF;
+          bgColorMode = Attributes.CM_RGB;
+          // Since an opaque selection is being rendered, the selection pretends to be a decoration to
+          // ensure text is drawn above the selection.
+          isTop = true;
+          // Apply selection foreground if applicable
+          if (colors.selectionForeground) {
+            fgColorMode = Attributes.CM_RGB;
+            fg = colors.selectionForeground.rgba >> 8 & 0xFFFFFF;
+            fgOverride = colors.selectionForeground;
+          }
+        }
+
+        // Background
+        let resolvedBg: IColor;
+        switch (bgColorMode) {
+          case Attributes.CM_P16:
+          case Attributes.CM_P256:
+            resolvedBg = colors.ansi[bg];
+            break;
+          case Attributes.CM_RGB:
+            resolvedBg = rgba.toColor(bg >> 16, bg >> 8 & 0xFF, bg & 0xFF);
+            break;
+          case Attributes.CM_DEFAULT:
+          default:
+            if (isInverse) {
+              resolvedBg = colors.foreground;
+            } else {
+              resolvedBg = colors.background;
+            }
+        }
+
+        // If there is no background override by now it's the original color, so apply dim if needed
+        if (!bgOverride) {
+          if (cell.isDim()) {
+            bgOverride = color.multiplyOpacity(resolvedBg, 0.5);
+          }
+        }
+
+        // create a new background span
+        if (!canMergeBackground) {
+          if (backgroundCellAmount) {
+            backgroundElement!.style.width = `${backgroundCellAmount * cellWidth}px`;
+          }
+          backgroundElement = this._document.createElement('span');
+          backgroundElement.classList.add('xterm-bg');
+          backgroundElement.style.left = `${cellWidth * x}px`;
+          backgroundCellAmount = 0;
+
+          switch (bgColorMode) {
+            case Attributes.CM_P16:
+            case Attributes.CM_P256:
+              backgroundElement.classList.add(`xterm-bg-${bg}`);
+              break;
+            case Attributes.CM_RGB:
+              backgroundElement.style.backgroundColor = `#${padStart((bg >>> 0).toString(16), '0', 6)}`;
+              break;
+            case Attributes.CM_DEFAULT:
+            default:
+              if (isInverse) {
+                backgroundElement.classList.add(`xterm-bg-${INVERTED_DEFAULT_COLOR}`);
+              }
+          }
+          // exclude conditions for cell merging - never merge these
+          if (!isCursorCell && !isDecorated) {
+            backgroundCellAmount += width;
+          } else {
+            backgroundElement.style.width = `${backgroundCellAmount * cellWidth}px`;
+          }
+          backgroundElements.push(backgroundElement);
+        }
+
+        // character span
+        if (!canMergeCharacters) {
+          console.log('create span', row, x, charCellAmount, charText, chars);
+          if (charCellAmount) {
+            charElement!.textContent = charText;
           }
           charElement = this._document.createElement('span');
-          cellAmount = 0;
-          text = '';
-        }
-      }
-      // preserve conditions for next merger eval round
-      oldBg = cell.bg;
-      oldFg = cell.fg;
-      oldExt = cell.extended.ext;
-      oldLinkHover = isLinkHover;
-      oldSpacing = spacing;
-      oldIsInSelection = isInSelection;
+          charCellAmount = 0;
+          charText = '';
 
-      if (isJoined) {
-        // The DOM renderer colors the background of the cursor but for ligatures all cells are
-        // joined. The workaround here is to show a cursor around the whole ligature so it shows up,
-        // the cursor looks the same when on any character of the ligature though
-        if (cursorX >= x && cursorX <= lastCharX) {
-          cursorX = x;
-        }
-      }
-
-      if (!this._coreService.isCursorHidden && isCursorCell && this._coreService.isCursorInitialized) {
-        classes.push(RowCss.CURSOR_CLASS);
-        if (this._coreBrowserService.isFocused) {
-          if (cursorBlink) {
-            classes.push(RowCss.CURSOR_BLINK_CLASS);
-          }
-          classes.push(
-            cursorStyle === 'bar'
-              ? RowCss.CURSOR_STYLE_BAR_CLASS
-              : cursorStyle === 'underline'
-                ? RowCss.CURSOR_STYLE_UNDERLINE_CLASS
-                : RowCss.CURSOR_STYLE_BLOCK_CLASS
-          );
-        } else {
-          if (cursorInactiveStyle) {
-            switch (cursorInactiveStyle) {
-              case 'outline':
-                classes.push(RowCss.CURSOR_STYLE_OUTLINE_CLASS);
-                break;
-              case 'block':
-                classes.push(RowCss.CURSOR_STYLE_BLOCK_CLASS);
-                break;
-              case 'bar':
-                classes.push(RowCss.CURSOR_STYLE_BAR_CLASS);
-                break;
-              case 'underline':
-                classes.push(RowCss.CURSOR_STYLE_UNDERLINE_CLASS);
-                break;
-              default:
-                break;
+          if (isJoined) {
+            // The DOM renderer colors the background of the cursor but for ligatures all cells are
+            // joined. The workaround here is to show a cursor around the whole ligature so it shows up,
+            // the cursor looks the same when on any character of the ligature though
+            if (cursorX >= x && cursorX <= lastCharX) {
+              cursorX = x;
             }
           }
-        }
-      }
 
-      if (cell.isBold()) {
-        classes.push(RowCss.BOLD_CLASS);
-      }
+          // If it's a top decoration, render above the selection
+          if (isTop) {
+            classes.push('xterm-decoration-top');
+          }
 
-      if (cell.isItalic()) {
-        classes.push(RowCss.ITALIC_CLASS);
-      }
+          if (!this._coreService.isCursorHidden && isCursorCell && this._coreService.isCursorInitialized) {
+            classes.push(RowCss.CURSOR_CLASS);
+            if (this._coreBrowserService.isFocused) {
+              if (cursorBlink) {
+                classes.push(RowCss.CURSOR_BLINK_CLASS);
+              }
+              classes.push(
+                cursorStyle === 'bar'
+                  ? RowCss.CURSOR_STYLE_BAR_CLASS
+                  : cursorStyle === 'underline'
+                    ? RowCss.CURSOR_STYLE_UNDERLINE_CLASS
+                    : RowCss.CURSOR_STYLE_BLOCK_CLASS
+              );
+            } else {
+              if (cursorInactiveStyle) {
+                switch (cursorInactiveStyle) {
+                  case 'outline':
+                    classes.push(RowCss.CURSOR_STYLE_OUTLINE_CLASS);
+                    break;
+                  case 'block':
+                    classes.push(RowCss.CURSOR_STYLE_BLOCK_CLASS);
+                    break;
+                  case 'bar':
+                    classes.push(RowCss.CURSOR_STYLE_BAR_CLASS);
+                    break;
+                  case 'underline':
+                    classes.push(RowCss.CURSOR_STYLE_UNDERLINE_CLASS);
+                    break;
+                  default:
+                    break;
+                }
+              }
+            }
+          }
 
-      if (cell.isDim()) {
-        classes.push(RowCss.DIM_CLASS);
-      }
+          if (cell.isBold()) {
+            classes.push(RowCss.BOLD_CLASS);
+          }
 
-      if (cell.isInvisible()) {
-        text = WHITESPACE_CELL_CHAR;
-      } else {
-        text = cell.getChars() || WHITESPACE_CELL_CHAR;
-      }
+          if (cell.isItalic()) {
+            classes.push(RowCss.ITALIC_CLASS);
+          }
 
-      if (cell.isUnderline()) {
-        classes.push(`${RowCss.UNDERLINE_CLASS}-${cell.extended.underlineStyle}`);
-        if (text === ' ') {
-          text = '\xa0'; // = &nbsp;
-        }
-        if (!cell.isUnderlineColorDefault()) {
-          if (cell.isUnderlineColorRGB()) {
-            charElement.style.textDecorationColor = `rgb(${AttributeData.toColorRGB(cell.getUnderlineColor()).join(',')})`;
+          if (cell.isDim()) {
+            classes.push(RowCss.DIM_CLASS);
+          }
+
+          if (cell.isInvisible()) {
+            charText = WHITESPACE_CELL_CHAR;
           } else {
-            let fg = cell.getUnderlineColor();
-            if (this._optionsService.rawOptions.drawBoldTextInBrightColors && cell.isBold() && fg < 8) {
-              fg += 8;
-            }
-            charElement.style.textDecorationColor = colors.ansi[fg].css;
+            charText = cell.getChars() || WHITESPACE_CELL_CHAR;
           }
-        }
-      }
 
-      if (cell.isOverline()) {
-        classes.push(RowCss.OVERLINE_CLASS);
-        if (text === ' ') {
-          text = '\xa0'; // = &nbsp;
-        }
-      }
+          if (cell.isUnderline()) {
+            classes.push(`${RowCss.UNDERLINE_CLASS}-${cell.extended.underlineStyle}`);
+            if (charText === ' ') {
+              charText = '\xa0'; // = &nbsp;
+            }
+            if (!cell.isUnderlineColorDefault()) {
+              if (cell.isUnderlineColorRGB()) {
+                charElement.style.textDecorationColor = `rgb(${AttributeData.toColorRGB(cell.getUnderlineColor()).join(',')})`;
+              } else {
+                let fg = cell.getUnderlineColor();
+                if (this._optionsService.rawOptions.drawBoldTextInBrightColors && cell.isBold() && fg < 8) {
+                  fg += 8;
+                }
+                charElement.style.textDecorationColor = colors.ansi[fg].css;
+              }
+            }
+          }
 
-      if (cell.isStrikethrough()) {
-        classes.push(RowCss.STRIKETHROUGH_CLASS);
-      }
+          if (cell.isOverline()) {
+            classes.push(RowCss.OVERLINE_CLASS);
+            if (charText === ' ') {
+              charText = '\xa0'; // = &nbsp;
+            }
+          }
 
-      // apply link hover underline late, effectively overrides any previous text-decoration
-      // settings
-      if (isLinkHover) {
-        charElement.style.textDecoration = 'underline';
-      }
+          if (cell.isStrikethrough()) {
+            classes.push(RowCss.STRIKETHROUGH_CLASS);
+          }
 
-      let fg = cell.getFgColor();
-      let fgColorMode = cell.getFgColorMode();
-      let bg = cell.getBgColor();
-      let bgColorMode = cell.getBgColorMode();
-      const isInverse = !!cell.isInverse();
-      if (isInverse) {
-        const temp = fg;
-        fg = bg;
-        bg = temp;
-        const temp2 = fgColorMode;
-        fgColorMode = bgColorMode;
-        bgColorMode = temp2;
-      }
+          // apply link hover underline late, effectively overrides any previous text-decoration
+          // settings
+          if (isLinkHover) {
+            charElement.style.textDecoration = 'underline';
+          }
 
-      // Apply any decoration foreground/background overrides, this must happen after inverse has
-      // been applied
-      let bgOverride: IColor | undefined;
-      let fgOverride: IColor | undefined;
-      let isTop = false;
-      this._decorationService.forEachDecorationAtCell(x, row, undefined, d => {
-        if (d.options.layer !== 'top' && isTop) {
-          return;
-        }
-        if (d.backgroundColorRGB) {
-          bgColorMode = Attributes.CM_RGB;
-          bg = d.backgroundColorRGB.rgba >> 8 & 0xFFFFFF;
-          bgOverride = d.backgroundColorRGB;
-        }
-        if (d.foregroundColorRGB) {
-          fgColorMode = Attributes.CM_RGB;
-          fg = d.foregroundColorRGB.rgba >> 8 & 0xFFFFFF;
-          fgOverride = d.foregroundColorRGB;
-        }
-        isTop = d.options.layer === 'top';
-      });
+          // Foreground
+          switch (fgColorMode) {
+            case Attributes.CM_P16:
+            case Attributes.CM_P256:
+              if (cell.isBold() && fg < 8 && this._optionsService.rawOptions.drawBoldTextInBrightColors) {
+                fg += 8;
+              }
+              if (!this._applyMinimumContrast(charElement, resolvedBg, colors.ansi[fg], cell, bgOverride, undefined)) {
+                classes.push(`xterm-fg-${fg}`);
+              }
+              break;
+            case Attributes.CM_RGB:
+              const color = rgba.toColor(
+                (fg >> 16) & 0xFF,
+                (fg >> 8) & 0xFF,
+                (fg) & 0xFF
+              );
+              if (!this._applyMinimumContrast(charElement, resolvedBg, color, cell, bgOverride, fgOverride)) {
+                charElement.style.color = `#${padStart(fg.toString(16), '0', 6)}`;
+              }
+              break;
+            case Attributes.CM_DEFAULT:
+            default:
+              if (!this._applyMinimumContrast(charElement, resolvedBg, colors.foreground, cell, bgOverride, fgOverride)) {
+                if (isInverse) {
+                  classes.push(`xterm-fg-${INVERTED_DEFAULT_COLOR}`);
+                }
+              }
+          }
 
-      // Apply selection
-      if (!isTop && isInSelection) {
-        // If in the selection, force the element to be above the selection to improve contrast and
-        // support opaque selections. The applies background is not actually needed here as
-        // selection is drawn in a seperate container, the main purpose of this to ensuring minimum
-        // contrast ratio
-        bgOverride = this._coreBrowserService.isFocused ? colors.selectionBackgroundOpaque : colors.selectionInactiveBackgroundOpaque;
-        bg = bgOverride.rgba >> 8 & 0xFFFFFF;
-        bgColorMode = Attributes.CM_RGB;
-        // Since an opaque selection is being rendered, the selection pretends to be a decoration to
-        // ensure text is drawn above the selection.
-        isTop = true;
-        // Apply selection foreground if applicable
-        if (colors.selectionForeground) {
-          fgColorMode = Attributes.CM_RGB;
-          fg = colors.selectionForeground.rgba >> 8 & 0xFFFFFF;
-          fgOverride = colors.selectionForeground;
-        }
-      }
+          // apply CSS classes
+          // slightly faster than using classList by omitting
+          // checks for doubled entries (code above should not have doublets)
+          if (classes.length) {
+            charElement.className = classes.join(' ');
+            classes.length = 0;
+          }
 
-      // If it's a top decoration, render above the selection
-      if (isTop) {
-        classes.push('xterm-decoration-top');
-      }
-
-      // Background
-      let resolvedBg: IColor;
-      switch (bgColorMode) {
-        case Attributes.CM_P16:
-        case Attributes.CM_P256:
-          resolvedBg = colors.ansi[bg];
-          classes.push(`xterm-bg-${bg}`);
-          break;
-        case Attributes.CM_RGB:
-          resolvedBg = rgba.toColor(bg >> 16, bg >> 8 & 0xFF, bg & 0xFF);
-          this._addStyle(charElement, `background-color:#${padStart((bg >>> 0).toString(16), '0', 6)}`);
-          break;
-        case Attributes.CM_DEFAULT:
-        default:
-          if (isInverse) {
-            resolvedBg = colors.foreground;
-            classes.push(`xterm-bg-${INVERTED_DEFAULT_COLOR}`);
+          // exclude conditions for cell merging - never merge these
+          if (!isCursorCell && !isJoined && !isDecorated) {
+            charCellAmount++;
           } else {
-            resolvedBg = colors.background;
+            charElement.textContent = charText;
           }
-      }
+          // apply letter-spacing rule
+          if (spacing !== this.defaultSpacing) {
+            charElement.style.letterSpacing = `${spacing}px`;
+          }
 
-      // If there is no background override by now it's the original color, so apply dim if needed
-      if (!bgOverride) {
-        if (cell.isDim()) {
-          bgOverride = color.multiplyOpacity(resolvedBg, 0.5);
+          charElements.push(charElement);
+          x = lastCharX;
         }
+
       }
 
-      // Foreground
-      switch (fgColorMode) {
-        case Attributes.CM_P16:
-        case Attributes.CM_P256:
-          if (cell.isBold() && fg < 8 && this._optionsService.rawOptions.drawBoldTextInBrightColors) {
-            fg += 8;
-          }
-          if (!this._applyMinimumContrast(charElement, resolvedBg, colors.ansi[fg], cell, bgOverride, undefined)) {
-            classes.push(`xterm-fg-${fg}`);
-          }
-          break;
-        case Attributes.CM_RGB:
-          const color = rgba.toColor(
-            (fg >> 16) & 0xFF,
-            (fg >>  8) & 0xFF,
-            (fg      ) & 0xFF
-          );
-          if (!this._applyMinimumContrast(charElement, resolvedBg, color, cell, bgOverride, fgOverride)) {
-            this._addStyle(charElement, `color:#${padStart(fg.toString(16), '0', 6)}`);
-          }
-          break;
-        case Attributes.CM_DEFAULT:
-        default:
-          if (!this._applyMinimumContrast(charElement, resolvedBg, colors.foreground, cell, bgOverride, fgOverride)) {
-            if (isInverse) {
-              classes.push(`xterm-fg-${INVERTED_DEFAULT_COLOR}`);
-            }
-          }
-      }
-
-      // apply CSS classes
-      // slightly faster than using classList by omitting
-      // checks for doubled entries (code above should not have doublets)
-      if (classes.length) {
-        charElement.className = classes.join(' ');
-        classes.length = 0;
-      }
-
-      // exclude conditions for cell merging - never merge these
-      if (!isCursorCell && !isJoined && !isDecorated) {
-        cellAmount++;
-      } else {
-        charElement.textContent = text;
-      }
-      // apply letter-spacing rule
-      if (spacing !== this.defaultSpacing) {
-        charElement.style.letterSpacing = `${spacing}px`;
-      }
-
-      elements.push(charElement);
-      x = lastCharX;
     }
 
     // postfix text of last merged span
-    if (charElement && cellAmount) {
-      charElement.textContent = text;
+    if (charElement && charCellAmount) {
+      charElement.textContent = charText;
+    }
+    if (backgroundElement && backgroundCellAmount) {
+      backgroundElement.style.width = `${backgroundCellAmount * cellWidth}px`;
     }
 
-    return elements;
+    return [...backgroundElements, ...charElements];
   }
 
   private _applyMinimumContrast(element: HTMLElement, bg: IColor, fg: IColor, cell: ICellData, bgOverride: IColor | undefined, fgOverride: IColor | undefined): boolean {


### PR DESCRIPTION
This PR attempts to resolve some rendering issues with the DOM renderer when a cell has a background color set.

It does so by creating separate spans for backgrounds. These background spans are positioned absolute and are added to the row div before any of the text spans (so the text spans will always be drawn above).

Text spans can now be merged even if the background color differs, so in many scenarios we won't even produce more spans than before.

As a little bonus, the text spans are now `display: inline` which should provide a little performance boost and might be beneficial when dealing with ligatures.

**TODO**

- [ ] Do not create background span if there is no background
- [ ] Remove selection layer and draw it as part of the background
- [ ] Make sure to handle cursor and decorations properly
- [ ] Adjust tests
- [ ] Analyze how performance differs to old DOM renderer