### PR TITLE
Send correct code for ctrl+[alt+]+backspace

### DIFF
--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -106,6 +106,21 @@ describe('Keyboard', () => {
     it('should return \\x1b[5B for ctrl+down', () => {
       assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, keyCode: 40 }).key, '\x1b[1;5B'); // CSI 5 B
     });
+    it('should return \\x08 for ctrl+backspace', () => {
+      assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, keyCode: 8 }).key, '\x08');
+    });
+    it('should return \\x1b\\x7f for alt+backspace', () => {
+      assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 8 }).key, '\x1b\x7f');
+    });
+    it('should return \\x1b\\x08 for ctrl+alt+backspace', () => {
+      assert.equal(testEvaluateKeyboardEvent({ ctrlKey: true, altKey: true, keyCode: 8 }).key, '\x1b\x08');
+    });
+    it('should return \\x1b[3;2~ for shift+delete', () => {
+      assert.equal(testEvaluateKeyboardEvent({ shiftKey: true, keyCode: 46 }).key, '\x1b[3;2~');
+    });
+    it('should return \\x1b[3;3~ for alt+delete', () => {
+      assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 46 }).key, '\x1b[3;3~');
+    });
 
     describe('On non-macOS platforms', () => {
       // Evalueate alt + arrow key movement, which is a feature of terminal emulators but not VT100

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -83,11 +83,10 @@ export function evaluateKeyboardEvent(
       break;
     case 8:
       // backspace
+      result.key = ev.ctrlKey ? '\b' : C0.DEL; // ^H or ^?
       if (ev.altKey) {
-        result.key = C0.ESC + C0.DEL; // \e ^?
-        break;
+        result.key = C0.ESC + result.key;
       }
-      result.key = C0.DEL; // ^?
       break;
     case 9:
       // tab


### PR DESCRIPTION
We should send ^H (instead of ^?) for ctrl+backspace. This is what xterm and gnome-terminal do.