### PR TITLE
Remove unit tests with Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,40 +148,6 @@ jobs:
     - name: Unit tests
       run: yarn test-unit --forbid-only
 
-  test-unit:
-    needs: build
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        node-version: [16]
-        runs-on: [ubuntu, macos, windows]
-    runs-on: ${{ matrix.runs-on }}-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}.x
-        cache: 'yarn'
-    - name: Install dependencies
-      run: |
-        yarn --frozen-lockfile
-        yarn install-addons
-    - uses: actions/download-artifact@v3
-      with:
-        name: build-artifacts
-    - name: Unzip artifacts
-      shell: bash
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          pwsh -Command "7z x compressed-build.zip -aoa -o${{ github.workspace }}"
-        else
-          unzip -o compressed-build.zip
-        fi
-        ls -R
-    - name: Unit tests
-      run: yarn test-unit --forbid-only
-
   test-api-parallel:
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
They seem to be failing since Python 3.12 no longer ships with distutils and is being pushed as default. 