### PR TITLE
DomRenderer: fix touch scrolling starting from text

### DIFF
--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -143,6 +143,7 @@ export class DomRenderer extends Disposable implements IRenderer {
       ` display: inline-block;` +   // TODO: find workaround for inline-block (creates ~20% render penalty)
       ` height: 100%;` +
       ` vertical-align: top;` +
+      ` pointer-events: none;` +
       `}`;
 
     this._dimensionsStyleElement.textContent = styles;


### PR DESCRIPTION
When scrolling with touchscreen starting from text, as soon as touch leaves the text span, the touch event stops, making touch-scrolling able to scroll one row only.

This fixes it by setting `pointer-events: none` to text spans, excluding them from hit-testing so that touch events won't be constrained to them.

Fixes #3613