### PR TITLE
Fix for issue #4944.

### DIFF
--- a/src/common/InputHandler.ts
+++ b/src/common/InputHandler.ts
@@ -2972,7 +2972,7 @@ export class InputHandler extends Disposable implements IInputHandler {
    * feedback. Use `OSC 8 ; ; BEL` to finish the current hyperlink.
    */
   public setHyperlink(data: string): boolean {
-    const args = data.split(';');
+    const args = data.match(/^([^;]*);(.*)$/)?.slice(1) ?? [];
     if (args.length < 2) {
       return false;
     }


### PR DESCRIPTION
Original code performed a simple `data.split(';')` which split on every ";" in the string.  This new version treats the first ";" as the only split character, ensuring that params are properly separated from the URI.