### PR TITLE
Escape Unsafe HTML Characters in addon-serialize

### DIFF
--- a/addons/addon-serialize/src/SerializeAddon.test.ts
+++ b/addons/addon-serialize/src/SerializeAddon.test.ts
@@ -139,13 +139,13 @@ describe('SerializeAddon', () => {
     });
 
     it('basic terminal with html unsafe chars', async () => {
-      await writeP(terminal, ' <script>alert("&pi; = 3.14")</script> ');
-      terminal.select(1, 0, 37);
+      await writeP(terminal, ' <a>&pi; ');
+      terminal.select(1, 0, 7);
 
       const output = serializeAddon.serializeAsHTML({
         onlySelection: true
       });
-      assert.equal((output.match(/<div><span>&lt;script>alert("&amp;pi; = 3.14")&lt;\/script><\/span><\/div>/g) || []).length, 1, output);
+      assert.equal((output.match(/<div><span>&lt;a>&amp;pi;<\/span><\/div>/g) || []).length, 1, output);
     });
 
     it('cells with bold styling', async () => {

--- a/addons/addon-serialize/src/SerializeAddon.test.ts
+++ b/addons/addon-serialize/src/SerializeAddon.test.ts
@@ -138,6 +138,16 @@ describe('SerializeAddon', () => {
       assert.equal((output.match(/<div><span>terminal<\/span><\/div>/g) || []).length, 1, output);
     });
 
+    it('basic terminal with html unsafe chars', async () => {
+      await writeP(terminal, ' <script>alert("&pi; = 3.14")</script> ');
+      terminal.select(1, 0, 37);
+
+      const output = serializeAddon.serializeAsHTML({
+        onlySelection: true
+      });
+      assert.equal((output.match(/<div><span>&lt;script>alert("&amp;pi; = 3.14")&lt;\/script><\/span><\/div>/g) || []).length, 1, output);
+    });
+
     it('cells with bold styling', async () => {
       await writeP(terminal, ' ' + sgr('1') + 'terminal' + sgr('22') + ' ');
 

--- a/addons/addon-serialize/src/SerializeAddon.ts
+++ b/addons/addon-serialize/src/SerializeAddon.ts
@@ -14,6 +14,14 @@ function constrain(value: number, low: number, high: number): number {
   return Math.max(low, Math.min(value, high));
 }
 
+function escapeHtmlChar(c: string): string {
+  switch (c) {
+    case '&': return '&amp;';
+    case '<': return '&lt;';
+  }
+  return c;
+}
+
 // TODO: Refine this template class later
 abstract class BaseSerializeHandler {
   constructor(
@@ -669,7 +677,7 @@ export class HTMLSerializeHandler extends BaseSerializeHandler {
     if (isEmptyCell) {
       this._currentRow += ' ';
     } else {
-      this._currentRow += cell.getChars();
+      this._currentRow += escapeHtmlChar(cell.getChars());
     }
   }
 

--- a/addons/addon-serialize/src/SerializeAddon.ts
+++ b/addons/addon-serialize/src/SerializeAddon.ts
@@ -14,7 +14,7 @@ function constrain(value: number, low: number, high: number): number {
   return Math.max(low, Math.min(value, high));
 }
 
-function escapeHtmlChar(c: string): string {
+function escapeHTMLChar(c: string): string {
   switch (c) {
     case '&': return '&amp;';
     case '<': return '&lt;';
@@ -677,7 +677,7 @@ export class HTMLSerializeHandler extends BaseSerializeHandler {
     if (isEmptyCell) {
       this._currentRow += ' ';
     } else {
-      this._currentRow += escapeHtmlChar(cell.getChars());
+      this._currentRow += escapeHTMLChar(cell.getChars());
     }
   }
 


### PR DESCRIPTION
I was testing the addon-serialize serializeAsHTML functionality and noticed that it can produce invalid/unsafe html because it isn't escaping "<" and "&" characters in the output spans.  Wrote a quick patch that escapes those two dangerous characters in the output.

Note that a lot of functions/libraries want to escape other characters (like quotes, greater than, etc.).  These are only necessary to escape unless you are also worried about attribute values.  These characters do not need to be escaped when you are only dealing with characters between tags (text content) which is the case here.

I added a test (which passes), but didn't put the more canonical "<script>alert("hello")</script>" test in because the test terminal only has 10 columns.  All of the other serialize tests continue to pass.