### PR TITLE
Fixed Visual bug with hovering links and scrolling

### DIFF
--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -304,7 +304,7 @@ export class Linkifier extends Disposable implements ILinkifier2 {
         // When start is 0 a scroll most likely occurred, make sure links above the fold also get
         // cleared.
         const start = e.start === 0 ? 0 : e.start + 1 + this._bufferService.buffer.ydisp;
-        const end = this._bufferService.buffer.ydisp + 1 + e.end;
+        const end = e.start === 0 ? this._bufferService.buffer.ybase + this._bufferService.rows: this._bufferService.buffer.ydisp + 1 + e.end;
         // Only clear the link if the viewport change happened on this line
         if (this._currentLink.link.range.start.y >= start && this._currentLink.link.range.end.y <= end) {
           this._clearCurrentLink(start, end);


### PR DESCRIPTION
Hello.

I managed to remove a visual bug with link hover underlines staying after scrolling upwards, as the link would not be refreshed when it went off-screen.
I used the assumption from the previous line (from the one where I made the change) where e.start is 0 if a scroll occurred.

I first encountered this bug on vscode.
It normally fixes microsoft/vscode#207956
I am unsure whether it fixes #4661 as I do not know how to check the change directly on vscode.

Thank you for your time and consideration.