### PR TITLE
Added macOptionIsEscape according to #4904

### DIFF
--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -1007,7 +1007,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
     }
 
     // Ignore composing with Alt key on Mac when macOptionIsMeta is enabled
-    const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && event.altKey;
+    const shouldIgnoreComposition = this.browser.isMac && this.options.macOptionIsMeta && this.options.macOptionIsEscape && event.altKey;
 
     if (!shouldIgnoreComposition && !this._compositionHelper!.keydown(event)) {
       if (this.options.scrollOnUserInput && this.buffer.ybase !== this.buffer.ydisp) {
@@ -1020,7 +1020,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
       this._unprocessedDeadKey = true;
     }
 
-    const result = evaluateKeyboardEvent(event, this.coreService.decPrivateModes.applicationCursorKeys, this.browser.isMac, this.options.macOptionIsMeta);
+    const result = evaluateKeyboardEvent(event, this.coreService.decPrivateModes.applicationCursorKeys, this.browser.isMac, this.options.macOptionIsMeta, this.options.macOptionIsEscape);
 
     this.updateCursorStyle(event);
 
@@ -1084,7 +1084,7 @@ export class Terminal extends CoreTerminal implements ITerminal {
 
   private _isThirdLevelShift(browser: IBrowser, ev: KeyboardEvent): boolean {
     const thirdLevelKey =
-      (browser.isMac && !this.options.macOptionIsMeta && ev.altKey && !ev.ctrlKey && !ev.metaKey) ||
+      (browser.isMac && !this.options.macOptionIsMeta && !this.options.macOptionIsEscape && ev.altKey && !ev.ctrlKey && !ev.metaKey) ||
       (browser.isWindows && ev.altKey && ev.ctrlKey && !ev.metaKey) ||
       (browser.isWindows && ev.getModifierState('AltGraph'));
 

--- a/src/common/input/Keyboard.test.ts
+++ b/src/common/input/Keyboard.test.ts
@@ -20,6 +20,7 @@ function testEvaluateKeyboardEvent(partialEvent: {
   applicationCursorMode?: boolean;
   isMac?: boolean;
   macOptionIsMeta?: boolean;
+  macOptionIsEscape?: boolean;
 } = {}): IKeyboardResult {
   const event: IKeyboardEvent = {
     altKey: partialEvent.altKey || false,
@@ -34,9 +35,10 @@ function testEvaluateKeyboardEvent(partialEvent: {
   const options = {
     applicationCursorMode: partialOptions.applicationCursorMode || false,
     isMac: partialOptions.isMac || false,
-    macOptionIsMeta: partialOptions.macOptionIsMeta || false
+    macOptionIsMeta: partialOptions.macOptionIsMeta || false,
+    macOptionIsEscape: partialOptions.macOptionIsEscape || false
   };
-  return evaluateKeyboardEvent(event, options.applicationCursorMode, options.isMac, options.macOptionIsMeta);
+  return evaluateKeyboardEvent(event, options.applicationCursorMode, options.isMac, options.macOptionIsMeta, options.macOptionIsEscape);
 }
 
 describe('Keyboard', () => {
@@ -173,6 +175,15 @@ describe('Keyboard', () => {
 
       it('should return \\x1b\\x1b for alt+enter', () => {
         assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 13 }, { isMac: true, macOptionIsMeta: true }).key, '\x1b\r');
+      });
+    });
+    describe('with macOptionIsEscape', () => {
+      it('should return \\x80 for alt+@', () => {
+        assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 64 }, { isMac: true, macOptionIsEscape: true }).key, '\x80');
+      });
+
+      it('should return \\x9F for alt+_', () => {
+        assert.equal(testEvaluateKeyboardEvent({ altKey: true, keyCode: 95 }, { isMac: true, macOptionIsEscape: true }).key, '\x9F');
       });
     });
 

--- a/src/common/input/Keyboard.ts
+++ b/src/common/input/Keyboard.ts
@@ -39,7 +39,8 @@ export function evaluateKeyboardEvent(
   ev: IKeyboardEvent,
   applicationCursorMode: boolean,
   isMac: boolean,
-  macOptionIsMeta: boolean
+  macOptionIsMeta: boolean,
+  macOptionIsEscape: boolean
 ): IKeyboardResult {
   const result: IKeyboardResult = {
     type: KeyboardResultType.SEND_KEY,
@@ -346,11 +347,15 @@ export function evaluateKeyboardEvent(
         } else if (ev.keyCode === 221) {
           result.key = C0.GS;
         }
-      } else if ((!isMac || macOptionIsMeta) && ev.altKey && !ev.metaKey) {
+      } else if ((!isMac || macOptionIsMeta || macOptionIsEscape) && ev.altKey && !ev.metaKey) {
         // On macOS this is a third level shift when !macOptionIsMeta. Use <Esc> instead.
         const keyMapping = KEYCODE_KEY_MAPPINGS[ev.keyCode];
         const key = keyMapping?.[!ev.shiftKey ? 0 : 1];
-        if (key) {
+        if (macOptionIsEscape && ev.keyCode >= 64 && ev.keyCode <= 95) {
+          result.key = String.fromCharCode(128 + ev.keyCode - 64);
+          console.log(12);
+        }
+        else if (key) {
           result.key = C0.ESC + key;
         } else if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           const keyCode = ev.ctrlKey ? ev.keyCode - 64 : ev.keyCode + 32;

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -36,6 +36,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   scrollSensitivity: 1,
   screenReaderMode: false,
   smoothScrollDuration: 0,
+  macOptionIsEscape: false,
   macOptionIsMeta: false,
   macOptionClickForcesSelection: false,
   minimumContrastRatio: 1,


### PR DESCRIPTION
Added the option to use the `option` key on MacOS for Escape-Codes according to [https://en.wikipedia.org/wiki/C0_and_C1_control_codes](url). The user input <input> is converted to ESC+<input> as shown in the first column of the **ISO/IEC 6429 and RFC 1345 C1 control codes** table.

I might have misinterpreted what the issue meant by "[using] the option key on MacOS for Escape-Codes", so if that is the case, let me know and I will make the changes. 