### PR TITLE
Expose onWriteParsed on API

### DIFF
--- a/src/headless/public/Terminal.ts
+++ b/src/headless/public/Terminal.ts
@@ -80,6 +80,7 @@ export class Terminal extends Disposable implements ITerminalApi {
   public get onResize(): IEvent<{ cols: number, rows: number }> { return this._core.onResize; }
   public get onScroll(): IEvent<number> { return this._core.onScroll; }
   public get onTitleChange(): IEvent<string> { return this._core.onTitleChange; }
+  public get onWriteParsed(): IEvent<void> { return this._core.onWriteParsed; }
 
   public get parser(): IParser {
     this._checkProposedApi();

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -715,6 +715,17 @@ declare module '@xterm/headless' {
     onLineFeed: IEvent<void>;
 
     /**
+     * Adds an event listener for when data has been parsed by the terminal,
+     * after {@link write} is called. This event is useful to listen for any
+     * changes in the buffer.
+     *
+     * This fires at most once per frame, after data parsing completes. Note
+     * that this can fire when there are still writes pending if there is a lot
+     * of data.
+     */
+    onWriteParsed: IEvent<void>;
+
+    /**
      * Adds an event listener for when the terminal is resized. The event value
      * contains the new size.
      * @returns an `IDisposable` to stop listening.


### PR DESCRIPTION
Inconsistency with headless API