### PR TITLE
Speed up insertion and deletion of values in SortedList by batching and deferring to idle task

### DIFF
--- a/demo/client.ts
+++ b/demo/client.ts
@@ -44,7 +44,7 @@ if ('WebAssembly' in window) {
 
 // Pulling in the module's types relies on the <reference> above, it's looks a
 // little weird here as we're importing "this" module
-import { Terminal as TerminalType, ITerminalOptions } from '@xterm/xterm';
+import { Terminal as TerminalType, ITerminalOptions, type IDisposable } from '@xterm/xterm';
 
 export interface IWindowWithTerminal extends Window {
   term: TerminalType;
@@ -255,6 +255,7 @@ if (document.location.pathname === '/test') {
   document.getElementById('add-grapheme-clusters').addEventListener('click', addGraphemeClusters);
   document.getElementById('add-decoration').addEventListener('click', addDecoration);
   document.getElementById('add-overview-ruler').addEventListener('click', addOverviewRuler);
+  document.getElementById('decoration-stress-test').addEventListener('click', decorationStressTest);
   document.getElementById('weblinks-test').addEventListener('click', testWeblinks);
   document.getElementById('bce').addEventListener('click', coloredErase);
   addVtButtons();
@@ -1168,6 +1169,33 @@ function addOverviewRuler(): void {
   term.registerDecoration({ marker: term.registerMarker(7), overviewRulerOptions: { color: '#729fcf', position: 'right' } });
   term.registerDecoration({ marker: term.registerMarker(10), overviewRulerOptions: { color: '#8ae234', position: 'center' } });
   term.registerDecoration({ marker: term.registerMarker(10), overviewRulerOptions: { color: '#ffffff80', position: 'full' } });
+}
+
+let decorationStressTestDecorations: IDisposable[] | undefined;
+function decorationStressTest(): void {
+  if (decorationStressTestDecorations) {
+    for (const d of decorationStressTestDecorations) {
+      d.dispose();
+    }
+    decorationStressTestDecorations = undefined;
+  } else {
+    const t = term as Terminal;
+    const buffer = t.buffer.active;
+    const cursorY = buffer.baseY + buffer.cursorY;
+    decorationStressTestDecorations = [];
+    for (const x of [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95]) {
+      for (let y = 0; y < t.buffer.active.length; y++) {
+        const cursorOffsetY = y - cursorY;
+        decorationStressTestDecorations.push(t.registerDecoration({
+          marker: t.registerMarker(cursorOffsetY),
+          x,
+          width: 4,
+          backgroundColor: '#FF0000',
+          overviewRulerOptions: { color: '#FF0000' }
+        }));
+      }
+    }
+  }
 }
 
 (console as any).image = (source: ImageData | HTMLCanvasElement, scale: number = 1) => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -102,6 +102,7 @@
               <dt>Decorations</dt>
               <dd><button id="add-decoration" title="Add a decoration to the terminal">Decoration</button></dd>
               <dd><button id="add-overview-ruler" title="Add an overview ruler to the terminal">Add Overview Ruler</button></dd>
+              <dd><button id="decoration-stress-test" title="Toggle between adding and removing a decoration to each line">Stress Test</button></dd>
 
               <dt>Weblinks Addon</dt>
               <dd><button id="weblinks-test" title="Various url conditions from demo data, hover&click to test">Test URLs</button></dd>

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -20,6 +20,8 @@ import { IBufferNamespace as IBufferNamespaceApi, IDecoration, IDecorationOption
  */
 const CONSTRUCTOR_ONLY_OPTIONS = ['cols', 'rows'];
 
+let $value = 0;
+
 export class Terminal extends Disposable implements ITerminalApi {
   private _core: ITerminal;
   private _addonManager: AddonManager;
@@ -249,16 +251,16 @@ export class Terminal extends Disposable implements ITerminalApi {
   }
 
   private _verifyIntegers(...values: number[]): void {
-    for (const value of values) {
-      if (value === Infinity || isNaN(value) || value % 1 !== 0) {
+    for ($value of values) {
+      if ($value === Infinity || isNaN($value) || $value % 1 !== 0) {
         throw new Error('This API only accepts integers');
       }
     }
   }
 
   private _verifyPositiveIntegers(...values: number[]): void {
-    for (const value of values) {
-      if (value && (value === Infinity || isNaN(value) || value % 1 !== 0 || value < 0)) {
+    for ($value of values) {
+      if ($value && ($value === Infinity || isNaN($value) || $value % 1 !== 0 || $value < 0)) {
         throw new Error('This API only accepts positive integers');
       }
     }

--- a/src/common/SortedList.ts
+++ b/src/common/SortedList.ts
@@ -49,7 +49,7 @@ export class SortedList<T> {
   }
 
   private _flushInserted(): void {
-    const sortedAddedValues = Array.from(this._insertedValues).sort((a, b) => this._getKey(a) - this._getKey(b));
+    const sortedAddedValues = this._insertedValues.sort((a, b) => this._getKey(a) - this._getKey(b));
     let sortedAddedValuesIndex = 0;
     let arrayIndex = 0;
 
@@ -104,7 +104,7 @@ export class SortedList<T> {
 
   private _flushDeleted(): void {
     this._isFlushingDeleted = true;
-    const sortedDeletedIndices = Array.from(this._deletedIndices).sort((a, b) => a - b);
+    const sortedDeletedIndices = this._deletedIndices.sort((a, b) => a - b);
     let sortedDeletedIndicesIndex = 0;
     const newArray = new Array(this._array.length - sortedDeletedIndices.length);
     let newArrayIndex = 0;

--- a/src/common/SortedList.ts
+++ b/src/common/SortedList.ts
@@ -9,9 +9,10 @@ import { IdleTaskQueue } from 'common/TaskQueue';
 let i = 0;
 
 /**
- * A generic list that is maintained in sorted order and allows values with duplicate keys. This
- * list is based on binary search and as such locating a key will take O(log n) amortized, this
- * includes the by key iterator.
+ * A generic list that is maintained in sorted order and allows values with duplicate keys. Deferred
+ * batch insertion and deletion is used to significantly reduce the time it takes to insert and
+ * delete a large amount of items in succession. This list is based on binary search and as such
+ * locating a key will take O(log n) amortized, this includes the by key iterator.
  */
 export class SortedList<T> {
   private _array: T[] = [];

--- a/src/common/SortedList.ts
+++ b/src/common/SortedList.ts
@@ -22,7 +22,7 @@ export class SortedList<T> {
 
   private readonly _deletedIndices: Set<number> = new Set();
   private readonly _flushDeletedTask = new IdleTaskQueue();
-  private _isflushingDeleted = false;
+  private _isFlushingDeleted = false;
 
   constructor(
     private readonly _getKey: (value: T) => number
@@ -33,7 +33,7 @@ export class SortedList<T> {
     this._array.length = 0;
     this._deletedIndices.clear();
     this._flushDeletedTask.clear();
-    this._isflushingDeleted = false;
+    this._isFlushingDeleted = false;
   }
 
   public insert(value: T): void {
@@ -65,7 +65,7 @@ export class SortedList<T> {
   }
 
   private _flushCleanupInserted(): void {
-    if (!this._isFlushingInserted) {
+    if (!this._isFlushingInserted && this._insertedValues.size > 0) {
       this._flushInsertedTask.flush();
     }
   }
@@ -99,7 +99,7 @@ export class SortedList<T> {
   }
 
   private _flushDeleted(): void {
-    this._isflushingDeleted = true;
+    this._isFlushingDeleted = true;
     const sortedDeletedIndices = Array.from(this._deletedIndices).sort((a, b) => a - b);
     let sortedDeletedIndicesIndex = 0;
     const newArray = new Array(this._array.length - sortedDeletedIndices.length);
@@ -113,11 +113,11 @@ export class SortedList<T> {
     }
     this._array = newArray;
     this._deletedIndices.clear();
-    this._isflushingDeleted = false;
+    this._isFlushingDeleted = false;
   }
 
   private _flushCleanupDeleted(): void {
-    if (!this._isflushingDeleted) {
+    if (!this._isFlushingDeleted && this._deletedIndices.size > 0) {
       this._flushDeletedTask.flush();
     }
   }

--- a/src/common/SortedList.ts
+++ b/src/common/SortedList.ts
@@ -56,7 +56,7 @@ export class SortedList<T> {
     const newArray = new Array(this._array.length + this._insertedValues.length);
 
     for (let newArrayIndex = 0; newArrayIndex < newArray.length; newArrayIndex++) {
-      if (arrayIndex >= this._array.length || this._getKey(sortedAddedValues[sortedAddedValuesIndex]) === this._getKey(this._array[arrayIndex])) {
+      if (arrayIndex >= this._array.length || this._getKey(sortedAddedValues[sortedAddedValuesIndex]) <= this._getKey(this._array[arrayIndex])) {
         newArray[newArrayIndex] = sortedAddedValues[sortedAddedValuesIndex];
         sortedAddedValuesIndex++;
       } else {

--- a/src/common/services/DecorationService.ts
+++ b/src/common/services/DecorationService.ts
@@ -45,7 +45,8 @@ export class DecorationService extends Disposable implements IDecorationService 
     const decoration = new Decoration(options);
     if (decoration) {
       const markerDispose = decoration.marker.onDispose(() => decoration.dispose());
-      decoration.onDispose(() => {
+      const listener = decoration.onDispose(() => {
+        listener.dispose();
         if (decoration) {
           if (this._decorations.delete(decoration)) {
             this._onDecorationRemoved.fire(decoration);


### PR DESCRIPTION
Fixes #4911

Test setup:

- 10000 scrollback filled
- Decoration stress test button
- ~10000 * 20 = ~200,000 decorations

Before:

Insert ~4s
Delete ~4s

![image](https://github.com/xtermjs/xterm.js/assets/2193314/a1723f54-0304-4d35-9d1b-c4317c55f3e1)

After:

Insert ~330ms
Delete ~93ms

There's still a decent amount of GC happening on insert, but a lot of it has to happen due to the variables being used in callbacks. It's reasonable when you consider it's 200000 decorations.

![image](https://github.com/xtermjs/xterm.js/assets/2193314/70acdd4b-91cb-4197-9a94-e3cb81ac1639)
