### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**SourceLair**](https://www.sourcelair.com/): In-browser IDE that provides its users with fully-featured Linux terminals based on xterm.js.
 - [**Microsoft Visual Studio Code**](http://code.visualstudio.com/): Modern, versatile, and powerful open source code editor that provides an integrated terminal based on xterm.js.
 - [**ttyd**](https://github.com/tsl0922/ttyd): A command-line tool for sharing terminal over the web, with fully-featured terminal emulation based on xterm.js.
-- [**Katacoda**](https://www.katacoda.com/): Katacoda is an Interactive Learning Platform for software developers, covering the latest Cloud Native technologies.
 - [**Eclipse Che**](http://www.eclipse.org/che): Developer workspace server, cloud IDE, and Eclipse next-generation IDE.
 - [**Codenvy**](http://www.codenvy.com): Cloud workspaces for development teams.
 - [**CoderPad**](https://coderpad.io): Online interviewing platform for programmers. Run code in many programming languages, with results displayed by xterm.js.


### PR DESCRIPTION
Removes Katacoda from the real-world uses. That platform has been shutdown by O'Reilly, and Katacoda.com redirects to a "thank you to the community" page.

https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html
https://katacoda.com/