### PR TITLE
Speed up clearing all markers, mass event listener dispose

### DIFF
--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -20,23 +20,18 @@ export interface IEventEmitter<T, U = void> {
 }
 
 export class EventEmitter<T, U = void> implements IEventEmitter<T, U> {
-  private _listeners: IListener<T, U>[] = [];
+  private _listeners: Set<IListener<T, U>> = new Set();
   private _event?: IEvent<T, U>;
   private _disposed: boolean = false;
 
   public get event(): IEvent<T, U> {
     if (!this._event) {
       this._event = (listener: (arg1: T, arg2: U) => any) => {
-        this._listeners.push(listener);
+        this._listeners.add(listener);
         const disposable = {
           dispose: () => {
             if (!this._disposed) {
-              for (let i = 0; i < this._listeners.length; i++) {
-                if (this._listeners[i] === listener) {
-                  this._listeners.splice(i, 1);
-                  return;
-                }
-              }
+              this._listeners.delete(listener);
             }
           }
         };
@@ -48,8 +43,8 @@ export class EventEmitter<T, U = void> implements IEventEmitter<T, U> {
 
   public fire(arg1: T, arg2: U): void {
     const queue: IListener<T, U>[] = [];
-    for (let i = 0; i < this._listeners.length; i++) {
-      queue.push(this._listeners[i]);
+    for (const l of this._listeners.values()) {
+      queue.push(l);
     }
     for (let i = 0; i < queue.length; i++) {
       queue[i].call(undefined, arg1, arg2);
@@ -63,7 +58,7 @@ export class EventEmitter<T, U = void> implements IEventEmitter<T, U> {
 
   public clearListeners(): void {
     if (this._listeners) {
-      this._listeners.length = 0;
+      this._listeners.clear();
     }
   }
 }

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -611,8 +611,8 @@ export class Buffer implements IBuffer {
     this._isClearing = true;
     for (let i = 0; i < this.markers.length; i++) {
       this.markers[i].dispose();
-      this.markers.splice(i--, 1);
     }
+    this.markers.length = 0;
     this._isClearing = false;
   }
 


### PR DESCRIPTION
Part of microsoft/vscode#213174
Part of microsoft/vscode#213304

Test: 1000 scrollback, decorations stress test

Before:

<img width="597" alt="Screenshot 2024-06-03 at 10 59 34 AM" src="https://github.com/xtermjs/xterm.js/assets/2193314/8abce6b7-aade-49b7-87f4-3fe578ed079d">

After:

<img width="373" alt="Screenshot 2024-06-03 at 11 42 41 AM" src="https://github.com/xtermjs/xterm.js/assets/2193314/cac07600-4ffd-49c2-b0a1-3e4443f56845">
