### PR TITLE
Ignore EPIPE exception on Windows when reloading demo client

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -185,4 +185,12 @@ function startServer() {
   app.listen(port, host, 0);
 }
 
+// HACK: There is an EPIPE error thrown when reloading a page. This only seems to happen on Windows
+// and it's unclear why it happens. Suppressing the error here since this is just the demo server.
+process.on('uncaughtException', (error) => {
+  if (process.platform === 'win32' && error.message === 'read EPIPE') {
+    return;
+  }
+});
+
 module.exports = startServer;

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "deep-equal": "^2.0.5",
     "eslint": "^8.56.0",
     "eslint-plugin-jsdoc": "^46.9.1",
-    "express": "^4.17.1",
+    "express": "^4.19.2",
     "express-ws": "^5.0.2",
     "glob": "^7.2.0",
     "jsdom": "^18.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,7 +1951,7 @@ express-ws@^5.0.2:
   dependencies:
     ws "^7.4.6"
 
-express@^4.17.1:
+express@^4.19.2:
   version "4.19.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
   integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==


### PR DESCRIPTION
Whenever the demo is reloaded on Windows the demo server crashes. This just ignores the error as I tried logging and adding try/catch around all interactions with the websocket and couldn't narrow it down.