### PR TITLE
Fix 'npm run package' in addon-unicode-graphemes

### DIFF
--- a/addons/addon-unicode-graphemes/webpack.config.js
+++ b/addons/addon-unicode-graphemes/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
     modules: ['./node_modules'],
     extensions: [ '.js' ],
     alias: {
-      common: path.resolve('../../out/common')
+      common: path.resolve('../../out/common'),
+      vs: path.resolve('../../out/vs')
     }
   },
   output: {


### PR DESCRIPTION
If you `cd addons/addon-unicode-graphemes` and then do:
```
npm run package
```
you get:
```
ERROR in ../../out/common/services/UnicodeService.js 5:16-47
Module not found: Error: Can't resolve 'vs/base/common/event' in '/home/bothner/Software/xterm.js/out/common/services'
```
This fixes it.