### PR TITLE
AccessibilityManager's handleKey should be triggered by onData, not onKey

### DIFF
--- a/src/browser/AccessibilityManager.ts
+++ b/src/browser/AccessibilityManager.ts
@@ -112,7 +112,7 @@ export class AccessibilityManager extends Disposable {
     this._register(this._terminal.onA11yChar(char => this._handleChar(char)));
     this._register(this._terminal.onLineFeed(() => this._handleChar('\n')));
     this._register(this._terminal.onA11yTab(spaceCount => this._handleTab(spaceCount)));
-    this._register(this._terminal.onKey(e => this._handleKey(e.key)));
+    this._register(this._terminal.onData(e => this._handleKey(e)));
     this._register(this._terminal.onBlur(() => this._clearLiveRegion()));
     this._register(this._renderService.onDimensionsChange(() => this._refreshRowsDimensions()));
     this._register(addDisposableListener(doc, 'selectionchange', () => this._handleSelectionChange()));


### PR DESCRIPTION
Issue:
In Android, screen reader feature sometimes generates the voice output including previous content

Reason:
`_liveRegion.textContent` from previous command is supposed be cleaned up in key stroke event, but onKey doesn't work as intended with IME(except 'enter' in Android) as mentioned in #3025. So the voice output includes previous content.

Fix:
As @Tyriars said in #3025, use `onData` instead of `onKey`