### PR TITLE
Fix click event bug caused by DomRenderer replaceChildren behavior

### DIFF
--- a/src/browser/renderer/dom/DomRenderer.ts
+++ b/src/browser/renderer/dom/DomRenderer.ts
@@ -161,6 +161,10 @@ export class DomRenderer extends Disposable implements IRenderer {
     // Base CSS
     let styles =
       `${this._terminalSelector} .${ROW_CONTAINER_CLASS} {` +
+      // Disabling pointer events circumvents a browser behavior that prevents `click` events from
+      // being delivered if the target element is replaced during the click. This happened due to
+      // refresh() being called during the mousedown handler to start a selection.
+      ` pointer-events: none;` +
       ` color: ${colors.foreground.css};` +
       ` font-family: ${this._optionsService.rawOptions.fontFamily};` +
       ` font-size: ${this._optionsService.rawOptions.fontSize}px;` +


### PR DESCRIPTION
Fixes an issue where `click` events on the terminal would not be sent when using DomRenderer. (Fixes https://github.com/xtermjs/xterm.js/issues/5220)

As described in https://github.com/xtermjs/xterm.js/issues/5220#issuecomment-2524541815, as far as I can tell, the issue happens because the clicked element (`event.target`) is replaced (via `replaceChildren`) between mousedown & mouseup. This caused the browser to never deliver a `click` event at all. Adding `pointer-events: none;` makes it so the descendants of `.xterm-rows` are not considered, and the `event.target` is always the parent `.xterm-screen` element for both mousedown & mouseup events — and the click events are delivered as expected.