### PR TITLE
Fix ReferenceError in publish.js

### DIFF
--- a/bin/publish.js
+++ b/bin/publish.js
@@ -114,8 +114,7 @@ function checkAndPublishPackage(packageDir, repoCommit, peerDependencies) {
     stdio: 'inherit'
   });
   if (result.status) {
-    error(`Spawn exited with code ${result.status}`);
-    process.exit(result.status);
+    throw new Error(`Spawn exited with code ${result.status}`);
   }
 
   return { isStableRelease, nextVersion };


### PR DESCRIPTION
In [this workflow run](https://github.com/xtermjs/xterm.js/actions/runs/12298607666/job/34322412357), a 404 error was encountered, but this was followed by a ReferenceError because `error` is not defined in this file.

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@xterm%2fxterm - Not found
npm error 404
npm error 404  '@xterm/xterm@5.6.0-beta.71' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2024-12-12T14_38_06_501Z-debug-0.log
/home/runner/work/xterm.js/xterm.js/bin/publish.js:117
    error(`Spawn exited with code ${result.status}`);
    ^

ReferenceError: error is not defined
    at checkAndPublishPackage (/home/runner/work/xterm.js/xterm.js/bin/publish.js:117:5)
    at Object.<anonymous> (/home/runner/work/xterm.js/xterm.js/bin/publish.js:33:16)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49
```