### PR TITLE
bug: properly render the terminal when open() is called again

### DIFF
--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -400,7 +400,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     }
 
     // If the terminal is already opened
-    if (this.element?.ownerDocument.defaultView && this._coreBrowserService) {
+    if (this.element?.ownerDocument.defaultView && this._coreBrowserService && this.element?.isConnected) {
       // Adjust the window if needed
       if (this.element.ownerDocument.defaultView !== this._coreBrowserService.window) {
         this._coreBrowserService.window = this.element.ownerDocument.defaultView;


### PR DESCRIPTION
Fixes https://github.com/xtermjs/xterm.js/issues/4978 based on the suggestion by @Tyriar in https://github.com/xtermjs/xterm.js/issues/4978#issuecomment-2539396611