### PR TITLE
Added an option to disable character joiner when WebGL is not used

### DIFF
--- a/addons/addon-ligatures/src/LigaturesAddon.ts
+++ b/addons/addon-ligatures/src/LigaturesAddon.ts
@@ -18,6 +18,7 @@ export class LigaturesAddon implements ITerminalAddon , ILigaturesApi {
 
   private _terminal: Terminal | undefined;
   private _characterJoinerId: number | undefined;
+  private _useWebGl: boolean;
 
   constructor(options?: Partial<ILigatureOptions>) {
     this._fallbackLigatures = (options?.fallbackLigatures || [
@@ -28,6 +29,8 @@ export class LigaturesAddon implements ITerminalAddon , ILigaturesApi {
       ':=', ':-', ':+', '<*', '<*>', '*>', '<|', '<|>', '|>', '+:', '-:', '=:', ':>',
       '++', '+++', '<!--', '<!---', '<***>'
     ]).sort((a, b) => b.length - a.length);
+
+    this._useWebGl = options?.useWebGl === undefined ? true : options.useWebGl;
   }
 
   public activate(terminal: Terminal): void {
@@ -35,7 +38,9 @@ export class LigaturesAddon implements ITerminalAddon , ILigaturesApi {
       throw new Error('Cannot activate LigaturesAddon before open is called');
     }
     this._terminal = terminal;
-    this._characterJoinerId = enableLigatures(terminal, this._fallbackLigatures);
+    if (this._useWebGl){
+      this._characterJoinerId = enableLigatures(terminal, this._fallbackLigatures);
+    }
     terminal.element.style.fontFeatureSettings = '"liga" on, "calt" on';
   }
 

--- a/addons/addon-ligatures/src/Types.ts
+++ b/addons/addon-ligatures/src/Types.ts
@@ -5,4 +5,5 @@
 
 export interface ILigatureOptions {
   fallbackLigatures: string[];
+  useWebGl: boolean;
 }

--- a/addons/addon-ligatures/typings/addon-ligatures.d.ts
+++ b/addons/addon-ligatures/typings/addon-ligatures.d.ts
@@ -53,6 +53,10 @@ declare module '@xterm/addon-ligatures' {
      * ++ +++ <!-- <!--- <***>
      * ```
      */
-    fallbackLigatures: string[]
+    fallbackLigatures: string[],
+     /**
+     Defaults to true. If you do not plan to use WebGL set this to false to increase performance.
+     */
+     useWebGl:boolean
   }
 }


### PR DESCRIPTION
### Description
Improve performance when using DOM renderer by not running the CharacterJoiner for WebGl unnecessarily in the LigaturesAddon.

The added  parameter `useWebGl`   is optional and defaults to `true` to keep this change from breaking projects running on WebGl.

A better solution would be to check if the WebGl addon is loaded and register/dispose the CharacterJoiner accordingly.

### Performance Tests
1-I run tests using DOM render only.

2- I tested it using 3 files with 70k lines each. One with many ligatures [test-many-ligatures.txt](https://github.com/user-attachments/files/18242784/test-many-ligatures.txt), the other with few ligatures [test-few-ligatures.txt](https://github.com/user-attachments/files/18242786/test-few-ligatures.txt) and the third without any ligatures [test-no-ligatures.txt](https://github.com/user-attachments/files/18242787/test-no-ligatures.txt)

3-I created a separate Playwright project and accessed the demo of Xterm.js.

4-The Playwright code looks like this 
```typescript
import { test, expect } from '@playwright/test';

test('test', async ({ page }) => {
  await page.goto('http://localhost:3000/');
  await page.getByRole('button', { name: 'Addons' }).click();
  await page.getByText('ligatures').click();
  await page.locator('div').filter({ hasText: /^webgl$/ }).click();
  await page.getByLabel('webgl').uncheck();

 let totalTime =0
  for(let i=0;i<10;i++){
    await page.getByLabel('Terminal input').fill('clear');
    await page.keyboard.press("Enter");
    await page.getByLabel('Terminal input').fill('cat test-many-ligatures.txt');
    await page.keyboard.press("Enter");
    const StartTime = performance.now()
    await expect(page.locator('#terminal-container')).toContainText('DONE');
    const EndTime = performance.now()
    totalTime += (EndTime-StartTime);
  }


  console.log("Many ligatures time is "+(totalTime/10).toFixed(2))
});
```
 ## Result 1 : 
 before the fix or when ```new LigaturesAddon({ useWebGl:true });``` (Don't forget I am using DOM renderer)
Sorry about the slight tilt. Something is wrong with Ubuntu's screenshot tool.
![DOM Render useWebGl= true (before fix)](https://github.com/user-attachments/assets/be417f1c-67ca-471d-a200-b0c3fadb38ee)
 ## Result 2 : 
  after the fix **with** `new LigaturesAddon({ useWebGl:flase });`
  
![DOM Render useWebGl= false (aka fix)](https://github.com/user-attachments/assets/c23824c0-e614-405a-96e0-188503e9454f)
