### PR TITLE
Fixed CapsLock triggering input twice in MacOS.

### DIFF
--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -93,7 +93,8 @@ export class CompositionHelper {
    */
   public keydown(ev: KeyboardEvent): boolean {
     if (this._isComposing || this._isSendingComposition) {
-      if (ev.keyCode === 229) {
+      if (ev.keyCode === 20 || ev.keyCode === 229) {
+        // 20 is CapsLock, 229 is Enter
         // Continue composing if the keyCode is the "composition character"
         return false;
       }


### PR DESCRIPTION
Hi @Tyriar, when I use the terminal to input Chinese on MacOS, if I press CapsLock, it will trigger English input twice, but it should only trigger once. This PR fixes this problem.


Produce:
1. Enable PinYin IME
2. Type "asd"(Chinese auto completions appear)
3. Caps lock on
4. Result:
  - Expected input: asd
  - Actual input: a s dasd
<img width="745" alt="image" src="https://github.com/user-attachments/assets/9092ecc8-c2c5-4230-831c-ea97faeec73a" />
<img width="872" alt="image" src="https://github.com/user-attachments/assets/e86a4b25-4b6b-479d-aec4-70f6bf47ebd3" />


My processor is Mac **M1 Pro**, and this problem occurs in https://xtermjs.org and **VS Code terminal**, but I am surprised that no one has reported this problem. This has troubled me for a long time, I'm pretty sure this is a bug, because on the **native terminal on MacOS**, it behaves as expected. Looking forward to your reply.