### PR TITLE
API for addons

### DIFF
--- a/addons/addon-progress/src/tsconfig.json
+++ b/addons/addon-progress/src/tsconfig.json
@@ -22,6 +22,9 @@
       "vs/*": [
         "../../../src/vs/*"
       ],
+      "shared/*": [
+        "../../../src/shared/*"
+      ],
       "@xterm/addon-progress": [
         "../typings/addon-progress.d.ts"
       ]
@@ -37,6 +40,9 @@
     },
     {
       "path": "../../../src/vs"
+    },
+    {
+      "path": "../../../src/shared"
     }
   ]
 }

--- a/addons/addon-progress/typings/addon-progress.d.ts
+++ b/addons/addon-progress/typings/addon-progress.d.ts
@@ -3,19 +3,20 @@
  * @license MIT
  */
 
-import { Terminal, ITerminalAddon, IDisposable, IEvent } from '@xterm/xterm';
+import { Terminal, ITerminalAddon, IDisposable, IEvent, EmitterCtorType } from '@xterm/xterm';
+import { EmitterAddon } from 'shared/shared';
 
 declare module '@xterm/addon-progress' {
   /**
    * An xterm.js addon that provides an interface for ConEmu's progress
    * sequence.
    */
-  export class ProgressAddon implements ITerminalAddon, IDisposable {
+  export class ProgressAddon extends EmitterAddon implements ITerminalAddon, IDisposable {
 
     /**
      * Creates a new progress addon
      */
-    constructor();
+    constructor(emitterCtor: EmitterCtorType);
 
     /**
      * Activates the addon

--- a/addons/addon-progress/webpack.config.js
+++ b/addons/addon-progress/webpack.config.js
@@ -27,7 +27,8 @@ module.exports = {
     alias: {
       common: path.resolve('../../out/common'),
       browser: path.resolve('../../out/browser'),
-      vs: path.resolve('../../out/vs')
+      vs: path.resolve('../../out/vs'),
+      shared: path.resolve('../../out/shared')
     }
   },
   output: {

--- a/demo/client.ts
+++ b/demo/client.ts
@@ -16,7 +16,7 @@ if ('WebAssembly' in window) {
   ImageAddon = imageAddon.ImageAddon;
 }
 
-import { Terminal, ITerminalOptions, type IDisposable, type ITheme } from '@xterm/xterm';
+import { Terminal, ITerminalOptions, type IDisposable, type ITheme, emitterCtor } from '@xterm/xterm';
 import { AttachAddon } from '@xterm/addon-attach';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { FitAddon } from '@xterm/addon-fit';
@@ -279,7 +279,7 @@ function createTerminal(): void {
   addons.serialize.instance = new SerializeAddon();
   addons.fit.instance = new FitAddon();
   addons.image.instance = new ImageAddon();
-  addons.progress.instance = new ProgressAddon();
+  addons.progress.instance = new ProgressAddon(emitterCtor);
   addons.unicodeGraphemes.instance = new UnicodeGraphemesAddon();
   addons.clipboard.instance = new ClipboardAddon();
   try {  // try to start with webgl renderer (might throw on older safari/webkit)
@@ -660,7 +660,7 @@ function initAddons(term: Terminal): void {
       }
       if (checkbox.checked) {
         // HACK: Manually remove addons that cannot be changes
-        addon.instance = new (addon as IDemoAddon<Exclude<AddonType, 'attach'>>).ctor();
+        //addon.instance = new (addon as IDemoAddon<Exclude<AddonType, 'attach'>>).ctor();
         try {
           term.loadAddon(addon.instance);
           if (name === 'webgl') {

--- a/src/browser/public/Terminal.ts
+++ b/src/browser/public/Terminal.ts
@@ -6,14 +6,14 @@
 import * as Strings from 'browser/LocalizableStrings';
 import { CoreBrowserTerminal as TerminalCore } from 'browser/CoreBrowserTerminal';
 import { IBufferRange, ITerminal } from 'browser/Types';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, toDisposable as toDisposableOrig } from 'vs/base/common/lifecycle';
 import { ITerminalOptions } from 'common/Types';
 import { AddonManager } from 'common/public/AddonManager';
 import { BufferNamespaceApi } from 'common/public/BufferNamespaceApi';
 import { ParserApi } from 'common/public/ParserApi';
 import { UnicodeApi } from 'common/public/UnicodeApi';
 import { IBufferNamespace as IBufferNamespaceApi, IDecoration, IDecorationOptions, IDisposable, ILinkProvider, ILocalizableStrings, IMarker, IModes, IParser, ITerminalAddon, Terminal as ITerminalApi, ITerminalInitOnlyOptions, IUnicodeHandling } from '@xterm/xterm';
-import type { Event } from 'vs/base/common/event';
+import { Emitter, type Event } from 'vs/base/common/event';
 
 /**
  * The set of options that only have an effect when set in the Terminal constructor.
@@ -272,3 +272,18 @@ export class Terminal extends Disposable implements ITerminalApi {
     }
   }
 }
+
+
+/**
+ * Expose often needed vs/* parts in addons.
+ * Exposed statically on the xterm package,
+ * so they can be used on addon ctors already.
+ */
+export {
+  DisposableStore as disposableStoreCtor,
+  toDisposable,
+  Emitter as emitterCtor,
+  DisposableAddon,
+  EmitterAddon,
+  DisposableEmitterAddon
+} from 'shared/shared';

--- a/src/browser/tsconfig.json
+++ b/src/browser/tsconfig.json
@@ -13,7 +13,8 @@
     "baseUrl": "..",
     "paths": {
       "common/*": [ "./common/*" ],
-      "vs/*": [ "./vs/*" ]
+      "vs/*": [ "./vs/*" ],
+      "shared/*": [ "./shared/*" ],
     }
   },
   "include": [
@@ -22,6 +23,7 @@
   ],
   "references": [
     { "path": "../common" },
-    { "path": "../vs" }
+    { "path": "../vs" },
+    { "path": "../shared" },
   ]
 }

--- a/src/shared/shared.ts
+++ b/src/shared/shared.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2024 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { IDisposable, IDisposableStore, DisposableStoreCtorType, EmitterCtorType } from '@xterm/xterm';
+
+export { DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
+export { Emitter } from 'vs/base/common/event';
+
+export class DisposableAddon implements IDisposable {
+  protected readonly _store: IDisposableStore;
+
+  constructor(storeCtor: DisposableStoreCtorType) {
+    this._store = new storeCtor();
+  }
+
+  dispose(): void {
+    this._store.dispose();
+  }
+}
+
+
+export class EmitterAddon {
+  constructor(
+    protected readonly emitterCtor: EmitterCtorType
+  ) {}
+}
+
+
+export class DisposableEmitterAddon implements IDisposable {
+  protected readonly _store: IDisposableStore;
+
+  constructor(
+    readonly storeCtor: DisposableStoreCtorType,
+    protected readonly emitterCtor: EmitterCtorType
+  ) {
+    this._store = new storeCtor();
+  }
+
+  dispose(): void {
+    this._store.dispose();
+  }
+}

--- a/src/shared/tsconfig.json
+++ b/src/shared/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../tsconfig-library-base",
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "es2016.Array.Include"
+    ],
+    "outDir": "../../out",
+    "types": [
+      "../../node_modules/@types/mocha"
+    ],
+    "baseUrl": "..",
+    "paths": {
+      "vs/*": [ "./vs/*" ]
+    }
+  },
+  "include": [
+    "./**/*",
+    "../../typings/xterm.d.ts"
+  ],
+  "references": [
+    { "path": "../vs" }
+  ]
+}

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -1956,4 +1956,71 @@ declare module '@xterm/xterm' {
      */
     readonly wraparoundMode: boolean;
   }
+
+
+  /**
+   * Get Emitter constructor.
+   */
+  export const emitterCtor: EmitterCtorType;
+
+  /**
+   * Get DisposableStore contructor.
+   */
+  export const disposableStoreCtor: DisposableStoreCtorType;
+
+  /**
+   * Turn a function into a Disposable.
+   */
+  export const toDisposable: (fn: () => void) => IDisposable;
+
+
+  export interface IEmitter<T> {
+    dispose(): void;
+    event: IEvent<T>;
+    fire(event: T): void;
+    hasListeners(): boolean;
+  }
+
+  interface IDisposableStore extends IDisposable {
+    /**
+     * `true` if this object has been disposed of.
+     */
+    isDisposed: boolean;
+    /**
+     * Dispose of all registered disposables but do not mark this object as disposed.
+     */
+    clear(): void;
+    /**
+     * Add a new {@link IDisposable disposable} to the collection.
+     */
+    add<T extends IDisposable>(o: T): T;
+    /**
+     * Deletes a disposable from store and disposes of it. This will not throw or warn and proceed to dispose the
+     * disposable even when the disposable is not part in the store.
+     */
+    delete<T extends IDisposable>(o: T): void;
+    /**
+     * Deletes the value from the store, but does not dispose it.
+     */
+    deleteAndLeak<T extends IDisposable>(o: T): void;
+  }
+
+  export type EmitterCtorType = { new<T>(): IEmitter<T> };
+  export type DisposableStoreCtorType = { new(): IDisposableStore; }
+
+  export class DisposableAddon implements IDisposable {
+    protected readonly _store: IDisposableStore;
+    constructor(storeCtor: DisposableStoreCtorType);
+    dispose(): void;
+  }
+  export class EmitterAddon {
+    protected readonly emitterCtor: EmitterCtorType;
+    constructor(emitterCtor: EmitterCtorType);
+  }
+  export class DisposableEmitterAddon implements IDisposable {
+    protected readonly _store: IDisposableStore;
+    protected readonly emitterCtor: EmitterCtorType;
+    constructor(storeCtor: DisposableStoreCtorType, emitterCtor: EmitterCtorType);
+    dispose(): void;
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ const config = {
       common: path.resolve('./out/common'),
       browser: path.resolve('./out/browser'),
       vs: path.resolve('./out/vs'),
+      shared: path.resolve('./out/shared')
     }
   },
   output: {


### PR DESCRIPTION
Attempt to fix #5283.

@Tyriar This is my first attempt to solve #5283.

It works quite well, the addon stubs under `/shared` only add ~500 bytes on the xtermjs package, and also on addons that derive their addon class from it. Only inconvenience so far is the fact, how we synthesize the final xtermjs package, which leads to an import switch:
- addons in xtermjs repo have to use `import { ... } from 'shared/shared';`
- 3rd party addons can import the shared symbols from xterm package

Currently I have only one testbed implemented with it in `ProgressAddon.ts` using the `EmitterAddon` class. Should be the same with `DisposableAddon`, but I didnt want to change too much in code before getting some feedback from you. So plz have a look at the idea and whether it goes into the right direction. Also we kinda need to cut type ropes for the vs objects, so plz also see the added types in d.ts - we prolly should keep them as small as possible while still being useful.

And last but not least the question, whether we should put these additions under a separate name in the API (maybe `shared.*`?)