### PR TITLE
Reflow on resize using similar logic to conpty

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "jsdom": "^18.0.1",
     "mocha": "^10.1.0",
     "mustache": "^4.2.0",
-    "node-pty": "1.1.0-beta19",
+    "node-pty": "^1.1.0-beta31",
     "nyc": "^15.1.0",
     "source-map-loader": "^3.0.0",
     "source-map-support": "^0.5.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,10 +3296,10 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-node-pty@1.1.0-beta19:
-  version "1.1.0-beta19"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta19.tgz#a74dc04429903c5ac49ee81a15a24590da67d4f3"
-  integrity sha512-/p4Zu56EYDdXjjaLWzrIlFyrBnND11LQGP0/L6GEVGURfCNkAlHc3Twg/2I4NPxghimHXgvDlwp7Z2GtvDIh8A==
+node-pty@^1.1.0-beta31:
+  version "1.1.0-beta9"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta9.tgz#ed643cb3b398d031b4e31c216e8f3b0042435f1d"
+  integrity sha512-/Ue38pvXJdgRZ3+me1FgfglLd301GhJN0NStiotdt61tm43N5htUyR/IXOUzOKuNaFmCwIhy6nwb77Ky41LMbw==
   dependencies:
     node-addon-api "^7.1.0"
 


### PR DESCRIPTION
This aligns reflowing much closer to how conpty does it. This was always an issue but only became a big issue recently because conpty 1.22+ opts to passthrough sequences rather than reprinting aggressively. This means that the conpty buffer being in sync with the xterm.js buffer is more important, otherwise the cursor will show up in a seemingly random position.

The existing reflow appears to differ somewhat in conpty, like it seems to reflow at the word level, not the character level like xterm.js, but refining that closer if not worth the effort since conpty may end up relying on the terminal's buffer in the [future][1].

Fixes #5319
Fixes #3513
Related #4231
Related microsoft/vscode#241978

[1]: https://github.com/microsoft/terminal/blob/main/doc/specs/%2313000%20-%20In-process%20ConPTY.md

---

ConsoleMonitor is showing the underlying conpty buffer. See how they're mostly the same now:

![Recording 2025-03-14 at 10 33 12](https://github.com/user-attachments/assets/cd0f51fd-c1c9-472d-b53b-b8e6ce96c849)

