### PR TITLE
fix: ensure that currentRow can not go out of the range

### DIFF
--- a/src/browser/input/MoveToCell.ts
+++ b/src/browser/input/MoveToCell.ts
@@ -199,7 +199,9 @@ function bufferLine(
   let currentRow = startRow;
   let bufferStr = '';
 
-  while (currentCol !== endCol || currentRow !== endRow) {
+  while ((currentCol !== endCol || currentRow !== endRow) &&
+         currentRow >= 0 &&
+         currentRow < bufferService.buffer.lines.length) {
     currentCol += forward ? 1 : -1;
 
     if (forward && currentCol > bufferService.cols - 1) {


### PR DESCRIPTION
With the code today, it is possible to get into a situation where the currentRow goes out of the range and will continue going in one direction until an out-of-memory crash.

There is no easy repro - the only one that works for me is to open an xterm inside Cursor, open the nano editor in a terminal, enter 10 one-character lines (like a, b, c, d, ...), and then make the option + click as quickly as possible.

<img width="761" height="498" alt="image" src="https://github.com/user-attachments/assets/6f192018-4342-4cdd-bde0-788cf5a04485" />
<img width="646" height="171" alt="image" src="https://github.com/user-attachments/assets/9b4fb48f-6094-4a07-90d7-f7d8c2668c92" />
