### PR TITLE
headless onRowChange event

### DIFF
--- a/src/headless/Terminal.ts
+++ b/src/headless/Terminal.ts
@@ -38,6 +38,8 @@ export class Terminal extends CoreTerminal {
   public readonly onA11yChar = this._onA11yCharEmitter.event;
   private readonly _onA11yTabEmitter = this._register(new Emitter<number>());
   public readonly onA11yTab = this._onA11yTabEmitter.event;
+  private readonly _onRowChange = this._register(new Emitter<{ start: number, end: number }>());
+  public readonly onRowChange = this._onRowChange.event;
 
   constructor(
     options: ITerminalOptions = {}
@@ -53,6 +55,11 @@ export class Terminal extends CoreTerminal {
     this._register(Event.forward(this._inputHandler.onTitleChange, this._onTitleChange));
     this._register(Event.forward(this._inputHandler.onA11yChar, this._onA11yCharEmitter));
     this._register(Event.forward(this._inputHandler.onA11yTab, this._onA11yTabEmitter));
+    this._register(this._inputHandler.onRequestRefreshRows(e => {
+      if (e) {
+        this._onRowChange.fire({ start: e.start, end: e.end });
+      }
+    }));
   }
 
   /**

--- a/src/headless/public/Terminal.ts
+++ b/src/headless/public/Terminal.ts
@@ -11,7 +11,7 @@ import { Terminal as TerminalCore } from 'headless/Terminal';
 import { AddonManager } from 'common/public/AddonManager';
 import { ITerminalOptions } from 'common/Types';
 import { Disposable } from 'vs/base/common/lifecycle';
-import type { Event } from 'vs/base/common/event';
+import { Event } from 'vs/base/common/event';
 /**
  * The set of options that only have an effect when set in the Terminal constructor.
  */
@@ -81,6 +81,10 @@ export class Terminal extends Disposable implements ITerminalApi {
   public get onScroll(): Event<number> { return this._core.onScroll; }
   public get onTitleChange(): Event<string> { return this._core.onTitleChange; }
   public get onWriteParsed(): Event<void> { return this._core.onWriteParsed; }
+  public get onRowChange(): Event<{ start: number, end: number }> {
+    this._checkProposedApi();
+    return Event.map(this._core.onRowChange, e => ({ start: e.start, end: e.end }));
+  }
 
   public get parser(): IParser {
     this._checkProposedApi();
@@ -186,7 +190,7 @@ export class Terminal extends Disposable implements ITerminalApi {
   }
   public loadAddon(addon: ITerminalAddon): void {
     // TODO: This could cause issues if the addon calls renderer apis
-    this._addonManager.loadAddon(this as any, addon);
+    this._addonManager.loadAddon(this as any, addon as any);
   }
 
   private _verifyIntegers(...values: number[]): void {

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -749,6 +749,13 @@ declare module '@xterm/headless' {
     onResize: IEvent<{ cols: number, rows: number }>;
 
     /**
+     * Adds an event listener for when buffer rows change during parsing. The event
+     * value contains the range of rows that changed.
+     * @returns an `IDisposable` to stop listening.
+     */
+    onRowChange: IEvent<{ start: number, end: number }>;
+
+    /**
      * Adds an event listener for when a scroll occurs. The event value is the
      * new position of the viewport.
      * @returns an `IDisposable` to stop listening.


### PR DESCRIPTION
Add a onRowChange event so that watchers can do efficient inspection of buffer changes.