### PR TITLE
Enable native touch copy and paste on iOS

### DIFF
--- a/css/xterm.css
+++ b/css/xterm.css
@@ -76,6 +76,14 @@
     resize: none;
 }
 
+.xterm .xterm-char-measure-element,
+.xterm .xterm-width-cache-measure-container {
+    position: absolute;
+    visibility: hidden;
+    left: -9999em;
+    top: 0;
+}
+
 .xterm .composition-view {
     /* TODO: Composition position got messed up somewhere */
     background: #000;
@@ -113,6 +121,39 @@
     position: absolute;
     left: 0;
     top: 0;
+}
+
+.xterm.xterm-native-touch-selection,
+.xterm.xterm-native-touch-selection .xterm-screen,
+.xterm.xterm-native-touch-selection .xterm-rows,
+.xterm.xterm-native-touch-selection .xterm-rows * {
+    -webkit-user-select: text !important;
+    user-select: text !important;
+    -webkit-touch-callout: default;
+}
+
+.xterm.xterm-native-touch-selection .xterm-rows {
+    pointer-events: auto !important;
+}
+
+.xterm.xterm-native-touch-selection .xterm-rows span {
+    display: inline !important;
+}
+
+.xterm.xterm-native-touch-selection .xterm-helper-textarea {
+    opacity: 1;
+    background: transparent;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    caret-color: transparent;
+    outline: none;
+    text-shadow: none;
+    -webkit-appearance: none;
+    appearance: none;
+    -webkit-user-select: text;
+    user-select: text;
+    -webkit-touch-callout: default;
+    pointer-events: auto;
 }
 
 .xterm.enable-mouse-events {

--- a/demo/client/client.ts
+++ b/demo/client/client.ts
@@ -118,6 +118,11 @@ const xtermjsTheme = {
   white: '#F8F8F8',
   brightWhite: '#FFFFFF'
 } satisfies ITheme;
+
+function hasCoarsePrimaryPointer(): boolean {
+  return window.matchMedia?.('(hover: none) and (pointer: coarse)').matches ?? false;
+}
+
 function setPadding(): void {
   term!.element!.style.padding = parseInt(paddingElement.value, 10).toString() + 'px';
   addons.fit.instance!.fit();
@@ -242,11 +247,13 @@ if (document.location.pathname === '/test') {
   controlBar.setTabVisible('addon-serialize', true);
   controlBar.setTabVisible('addon-web-fonts', true);
   controlBar.setTabVisible('addon-web-links', !!addons.webLinks.instance);
-  controlBar.setTabVisible('addon-webgl', true);
-  addonWebglWindow.setTextureAtlas(addons.webgl.instance!.textureAtlas!);
-  addons.webgl.instance!.onChangeTextureAtlas(e => addonWebglWindow.setTextureAtlas(e));
-  addons.webgl.instance!.onAddTextureAtlasCanvas(e => addonWebglWindow.appendTextureAtlas(e));
-  addons.webgl.instance!.onRemoveTextureAtlasCanvas(e => addonWebglWindow.removeTextureAtlas(e));
+  controlBar.setTabVisible('addon-webgl', !!addons.webgl.instance);
+  if (addons.webgl.instance) {
+    addonWebglWindow.setTextureAtlas(addons.webgl.instance.textureAtlas!);
+    addons.webgl.instance.onChangeTextureAtlas(e => addonWebglWindow.setTextureAtlas(e));
+    addons.webgl.instance.onAddTextureAtlasCanvas(e => addonWebglWindow.appendTextureAtlas(e));
+    addons.webgl.instance.onRemoveTextureAtlasCanvas(e => addonWebglWindow.removeTextureAtlas(e));
+  }
 
   paddingElement.value = '0';
   addDomListener(paddingElement, 'change', setPadding);
@@ -304,10 +311,12 @@ function createTerminal(): Terminal {
   addons.progress.instance = new ProgressAddon();
   addons.unicodeGraphemes.instance = new UnicodeGraphemesAddon();
   addons.clipboard.instance = new ClipboardAddon();
-  try {  // try to start with webgl renderer (might throw on older safari/webkit)
-    addons.webgl.instance = new WebglAddon();
-  } catch (e) {
-    console.warn(e);
+  if (!hasCoarsePrimaryPointer()) {
+    try {  // try to start with webgl renderer (might throw on older safari/webkit)
+      addons.webgl.instance = new WebglAddon();
+    } catch (e) {
+      console.warn(e);
+    }
   }
   addons.webLinks.instance = new WebLinksAddon();
   addons.webFonts.instance = new WebFontsAddon();

--- a/src/browser/Clipboard.test.ts
+++ b/src/browser/Clipboard.test.ts
@@ -5,6 +5,7 @@
 
 import { assert } from 'chai';
 import * as Clipboard from 'browser/Clipboard';
+import { ICoreService, IOptionsService } from 'common/services/Services';
 
 describe('evaluatePastedTextProcessing', () => {
   it('should replace carriage return and/or line feed with carriage return', () => {
@@ -38,5 +39,31 @@ describe('evaluatePastedTextProcessing', () => {
 
     assert.equal(unbracketedText, pastedText, 'non bracketed paste should remain unchanged');
     assert.equal(bracketedText, `\x1b[200~${ESC_SYMBOL}[201~foo${ESC_SYMBOL}[200~bar\x1b[201~`);
+  });
+
+  it('should prevent native insertion when handling clipboard paste data', () => {
+    let triggeredData = '';
+    let didStopPropagation = false;
+    let didPreventDefault = false;
+    const textarea = { value: 'before' } as HTMLTextAreaElement;
+    const coreService = {
+      decPrivateModes: { bracketedPasteMode: false },
+      triggerDataEvent: (data: string) => triggeredData = data
+    } as unknown as ICoreService;
+    const optionsService = {
+      rawOptions: {}
+    } as unknown as IOptionsService;
+    const event = {
+      clipboardData: { getData: () => 'foo' },
+      preventDefault: () => didPreventDefault = true,
+      stopPropagation: () => didStopPropagation = true
+    } as unknown as ClipboardEvent;
+
+    Clipboard.handlePasteEvent(event, textarea, coreService, optionsService);
+
+    assert.equal(triggeredData, 'foo');
+    assert.equal(textarea.value, '');
+    assert.ok(didPreventDefault);
+    assert.ok(didStopPropagation);
   });
 });

--- a/src/browser/Clipboard.ts
+++ b/src/browser/Clipboard.ts
@@ -46,6 +46,7 @@ export function copyHandler(ev: ClipboardEvent, selectionService: ISelectionServ
 export function handlePasteEvent(ev: ClipboardEvent, textarea: HTMLTextAreaElement, coreService: ICoreService, optionsService: IOptionsService): void {
   ev.stopPropagation();
   if (ev.clipboardData) {
+    ev.preventDefault();
     const text = ev.clipboardData.getData('text/plain');
     paste(text, textarea, coreService, optionsService);
   }

--- a/src/browser/CoreBrowserTerminal.ts
+++ b/src/browser/CoreBrowserTerminal.ts
@@ -60,6 +60,12 @@ import { Emitter, EventUtils, type IEvent } from 'common/Event';
 import { addDisposableListener } from 'browser/Dom';
 import { MutableDisposable, toDisposable } from 'common/Lifecycle';
 
+function shouldUseNativeTouchSelection(targetWindow: Window): boolean {
+  const navigator = targetWindow.navigator as Navigator & { maxTouchPoints?: number };
+  return (/iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && (navigator.maxTouchPoints ?? 0) > 1))
+    && (targetWindow.matchMedia?.('(hover: none) and (pointer: coarse)').matches ?? true);
+}
+
 export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
   public textarea: HTMLTextAreaElement | undefined;
   public element: HTMLElement | undefined;
@@ -349,15 +355,16 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     const cellWidth = this._renderService.dimensions.css.cell.width * width;
     const cursorTop = this.buffer.y * this._renderService.dimensions.css.cell.height;
     const cursorLeft = cursorX * this._renderService.dimensions.css.cell.width;
+    const useNativeTouchSelection = this.element?.classList.contains('xterm-native-touch-selection');
 
     // Sync the textarea to the exact position of the composition view so the IME knows where the
     // text is.
     this.textarea.style.left = cursorLeft + 'px';
     this.textarea.style.top = cursorTop + 'px';
-    this.textarea.style.width = cellWidth + 'px';
-    this.textarea.style.height = cellHeight + 'px';
+    this.textarea.style.width = (useNativeTouchSelection ? Math.max(cellWidth, 80) : cellWidth) + 'px';
+    this.textarea.style.height = (useNativeTouchSelection ? Math.max(cellHeight, 32) : cellHeight) + 'px';
     this.textarea.style.lineHeight = cellHeight + 'px';
-    this.textarea.style.zIndex = '-5';
+    this.textarea.style.zIndex = useNativeTouchSelection ? '10' : '-5';
   }
 
   /**
@@ -508,6 +515,7 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
       this._document ?? (typeof window !== 'undefined') ? window.document : null as any
     ));
     this._instantiationService.setService(ICoreBrowserService, this._coreBrowserService);
+    this.element.classList.toggle('xterm-native-touch-selection', shouldUseNativeTouchSelection(this._coreBrowserService.window));
 
     this._register(addDisposableListener(this.textarea, 'focus', (ev: FocusEvent) => this._handleTextAreaFocus(ev)));
     this._register(addDisposableListener(this.textarea, 'blur', () => this._handleTextAreaBlur()));
@@ -615,7 +623,12 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
     }));
 
     this._register(this._instantiationService.createInstance(BufferDecorationRenderer, this.screenElement));
-    this._register(addDisposableListener(this.element, 'mousedown', (e: MouseEvent) => this._selectionService!.handleMouseDown(e)));
+    this._register(addDisposableListener(this.element, 'mousedown', (e: MouseEvent) => {
+      if (this.element!.classList.contains('xterm-native-touch-selection')) {
+        return;
+      }
+      this._selectionService!.handleMouseDown(e);
+    }));
 
     // apply mouse event classes set by escape codes before terminal was attached
     if (this.mouseStateService.areMouseEventsActive && !this.options.mouseEventsRequireAlt) {
@@ -1026,6 +1039,11 @@ export class CoreBrowserTerminal extends CoreTerminal implements ITerminal {
    * @param ev The input event to be handled.
    */
   protected _inputEvent(ev: InputEvent): boolean {
+    if (ev.inputType === 'insertFromPaste' && this.textarea?.value) {
+      paste(this.textarea.value, this.textarea, this.coreService, this.optionsService);
+      return true;
+    }
+
     // Only support emoji IMEs when screen reader mode is disabled as the event must bubble up to
     // support reading out character input which can doubling up input characters
     // Based on these event traces: https://github.com/xtermjs/xterm.js/issues/3679

--- a/src/browser/services/CharSizeService.ts
+++ b/src/browser/services/CharSizeService.ts
@@ -85,6 +85,8 @@ class DomMeasureStrategy extends BaseMeasureStategy {
     this._measureElement.classList.add('xterm-char-measure-element');
     this._measureElement.textContent = 'W'.repeat(DomMeasureStrategyConstants.REPEAT);
     this._measureElement.setAttribute('aria-hidden', 'true');
+    this._measureElement.style.position = 'absolute';
+    this._measureElement.style.visibility = 'hidden';
     this._measureElement.style.whiteSpace = 'pre';
     this._measureElement.style.fontKerning = 'none';
     this._parentElement.appendChild(this._measureElement);

--- a/src/browser/services/MouseService.ts
+++ b/src/browser/services/MouseService.ts
@@ -100,9 +100,11 @@ export class MouseService implements IMouseService {
      */
     register(addDisposableListener(element, 'mousedown', (ev: MouseEvent) => this._handleMouseDown(ctx, ev)));
     register(addDisposableListener(element, 'wheel', (ev: WheelEvent) => this._handlePassiveWheel(ctx, ev), { passive: false }));
-    register(Gesture.addTarget(target.screenElement));
-    register(addDisposableListener(target.screenElement, GestureEventType.START, () => this._handleTouchStart()));
-    register(addDisposableListener(target.screenElement, GestureEventType.CHANGE, (e: IGestureEvent) => this._handleTouchChange(ctx, e)));
+    if (!this._shouldUseNativeTouchSelection(ctx)) {
+      register(Gesture.addTarget(target.screenElement));
+      register(addDisposableListener(target.screenElement, GestureEventType.START, () => this._handleTouchStart()));
+      register(addDisposableListener(target.screenElement, GestureEventType.CHANGE, (e: IGestureEvent) => this._handleTouchChange(ctx, e)));
+    }
   }
 
   private _sendEvent(ctx: IMouseBindContext, ev: MouseEvent | WheelEvent): boolean {
@@ -230,6 +232,11 @@ export class MouseService implements IMouseService {
   }
 
   private _handleMouseDown(ctx: IMouseBindContext, ev: MouseEvent): void {
+    if (this._shouldUseNativeTouchSelection(ctx) && !this._mouseStateService.areMouseEventsActive) {
+      ctx.focus();
+      return;
+    }
+
     ev.preventDefault();
     ctx.focus();
 
@@ -252,6 +259,10 @@ export class MouseService implements IMouseService {
     if (ctx.requestedEvents.mousedrag) {
       ctx.target.document.addEventListener('mousemove', ctx.requestedEvents.mousedrag);
     }
+  }
+
+  private _shouldUseNativeTouchSelection(ctx: IMouseBindContext): boolean {
+    return ctx.target.element.classList.contains('xterm-native-touch-selection');
   }
 
   private _handlePassiveWheel(ctx: IMouseBindContext, ev: WheelEvent): false | void {


### PR DESCRIPTION
## Summary

Fixes #3727 by letting iOS use native DOM selection and the native paste menu for terminals rendered with DOM rows.

The change is intentionally narrow:

- Detect Apple touch devices with a coarse primary pointer and add `xterm-native-touch-selection` to the terminal element.
- In that mode, make `.xterm-rows` selectable and avoid xterm's internal gesture/selection mousedown handling when mouse reporting is inactive.
- Keep mouse reporting behavior intact for applications that enable mouse events.
- Move the helper textarea to the cursor with a usable touch target so long-press paste works natively.
- Prevent default textarea insertion when the paste event already provides clipboard data, avoiding duplicate pasted text.
- Make the demo prefer the DOM renderer on coarse-pointer devices, since native iOS selection cannot select text rendered only to a WebGL canvas.

## Verification

- `npm run build`
- `npm run lint-changes`
- `npm run test-unit`
- `npm run esbuild`
- `npm run esbuild-demo-client`
- `npm run esbuild-demo-server`
- Chromium integration suites for core and all addons, run against system Chromium on this host

I also manually verified on iPhone Safari that terminal output can be selected/copied with the native iOS UI and that long-pressing the prompt cursor offers Paste and inserts text once.

Note: the local host is Ubuntu 26.04, and `npx playwright install` currently refuses to install Playwright browser binaries for this OS. Because of that I could run Chromium integration coverage via system Chromium, but not local Firefox/WebKit integration coverage.