### PR TITLE
Don't crash if terminal open and closed quickly

### DIFF
--- a/src/browser/Viewport.ts
+++ b/src/browser/Viewport.ts
@@ -170,7 +170,7 @@ export class Viewport extends Disposable {
   }
 
   private _sync(ydisp: number = this._bufferService.buffer.ydisp): void {
-    if (!this._renderService || this._isSyncing) {
+    if (this._isDisposed || !this._renderService || this._isSyncing) {
       return;
     }
     // Defer DOM scroll updates during synchronized output to prevent visible


### PR DESCRIPTION
When creating and destroying a terminal quickly it would throw an uncaught exception and crash, small guard to make that not happen