### PR TITLE
fix: externalize libraries instead of bundling them

### DIFF
--- a/bin/esbuild.mjs
+++ b/bin/esbuild.mjs
@@ -27,6 +27,7 @@ const commonOptions = {
   sourcemap: true,
   treeShaking: true,
   logLevel: 'warning',
+  packages: 'external'
 };
 
 /** @type {esbuild.BuildOptions} */


### PR DESCRIPTION
fix #6096

Keeping the library as external for the esm version allows the final bundle to chose which version it needs (main, module, browser...)