### PR TITLE
addon-image: Fix Kitty placement lifecycle

### DIFF
--- a/addons/addon-image/src/ImageRenderer.ts
+++ b/addons/addon-image/src/ImageRenderer.ts
@@ -240,8 +240,8 @@ export class ImageRenderer extends Disposable implements IDisposable {
   /**
    * Draw a line with placeholder on the image layer canvas.
    */
-  public drawPlaceholder(col: number, row: number, count: number = 1): void {
-    const ctx = this._layers.get('top');
+  public drawPlaceholder(col: number, row: number, count: number = 1, layer: ImageLayer = 'top'): void {
+    const ctx = this._layers.get(layer);
     if (ctx) {
       const { width, height } = this.cellSize;
 

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -273,6 +273,7 @@ export class ImageStorage implements IDisposable {
 
   public deleteImages(ids: Iterable<number>): number {
     const uniqueIds = new Set(ids);
+    this._rebuildImageCellIndex(uniqueIds);
     const clearedCells = this._clearImageCells(uniqueIds);
     for (const id of uniqueIds) {
       const spec = this._images.get(id);
@@ -313,88 +314,7 @@ export class ImageStorage implements IDisposable {
   }
 
   public reconcileImageCellIndexes(imageIds: Iterable<number>): void {
-    const uniqueIds = new Set(imageIds);
-    const lineImageIds = new Map<IBufferLineExt, Set<number>>();
-    const liveTileCounts = new Map<number, number>();
-    for (const imageId of uniqueIds) {
-      const lines = this._imageCells.get(imageId);
-      if (!lines) {
-        continue;
-      }
-      liveTileCounts.set(imageId, 0);
-      for (const line of lines.keys()) {
-        let ids = lineImageIds.get(line);
-        if (!ids) {
-          ids = new Set();
-          lineImageIds.set(line, ids);
-        }
-        ids.add(imageId);
-      }
-    }
-
-    const attachedLines = new Set<IBufferLineExt>();
-    const buffers = [this._terminal._core.buffers.normal, this._terminal._core.buffers.alt];
-    for (const buffer of buffers) {
-      for (let row = 0; row < buffer.lines.length; row++) {
-        const line = buffer.lines.get(row) as IBufferLineExt | undefined;
-        if (line && lineImageIds.has(line)) {
-          attachedLines.add(line);
-        }
-      }
-    }
-
-    for (const [line, imageIdsOnLine] of lineImageIds) {
-      if (!attachedLines.has(line)) {
-        for (const imageId of imageIdsOnLine) {
-          this._imageCells.get(imageId)?.delete(line);
-        }
-        continue;
-      }
-      const liveColumns = new Map<number, Set<number>>();
-      for (const key of Object.keys(line._extendedAttrs)) {
-        const column = Number(key);
-        if (
-          column >= line.length ||
-          !(line._data[column * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)
-        ) {
-          continue;
-        }
-        const imageId = line._extendedAttrs[column]?.imageId;
-        if (imageId === undefined || !imageIdsOnLine.has(imageId)) {
-          continue;
-        }
-        let columns = liveColumns.get(imageId);
-        if (!columns) {
-          columns = new Set();
-          liveColumns.set(imageId, columns);
-        }
-        columns.add(column);
-      }
-      for (const imageId of imageIdsOnLine) {
-        const lines = this._imageCells.get(imageId);
-        const columns = liveColumns.get(imageId);
-        if (columns?.size) {
-          lines?.set(line, columns);
-          liveTileCounts.set(imageId, (liveTileCounts.get(imageId) ?? 0) + columns.size);
-        } else {
-          lines?.delete(line);
-        }
-      }
-    }
-
-    for (const [imageId, tileCount] of liveTileCounts) {
-      const spec = this._images.get(imageId);
-      if (spec) {
-        spec.tileCount = tileCount;
-      }
-    }
-    const emptyImageIds = [...uniqueIds].filter(imageId => {
-      const lines = this._imageCells.get(imageId);
-      return !!lines && !lines.size;
-    });
-    if (emptyImageIds.length) {
-      this.deleteImages(emptyImageIds);
-    }
+    this._rebuildImageCellIndex(new Set(imageIds));
   }
 
   /**
@@ -915,14 +835,24 @@ export class ImageStorage implements IDisposable {
     return cleared;
   }
 
-  private _rebuildImageCellIndex(): void {
-    this._imageCells.clear();
-    for (const [id, spec] of this._images) {
-      this._imageCells.set(id, new Map());
-      spec.tileCount = 0;
+  private _rebuildImageCellIndex(imageIds?: ReadonlySet<number>): void {
+    const targetIds = imageIds ?? new Set([
+      ...this._images.keys(),
+      ...this._evictedImages.keys(),
+      ...this._imageCells.keys()
+    ]);
+    if (!imageIds) {
+      this._imageCells.clear();
     }
-    for (const id of this._evictedImages.keys()) {
-      this._imageCells.set(id, new Map());
+    for (const imageId of targetIds) {
+      const spec = this._images.get(imageId);
+      if (!spec && !this._evictedImages.has(imageId) && !this._imageCells.has(imageId)) {
+        continue;
+      }
+      this._imageCells.set(imageId, new Map());
+      if (spec) {
+        spec.tileCount = 0;
+      }
     }
     const buffers = [this._terminal._core.buffers.normal, this._terminal._core.buffers.alt];
     for (const buffer of buffers) {
@@ -941,7 +871,7 @@ export class ImageStorage implements IDisposable {
             continue;
           }
           const imageId = line._extendedAttrs[x]?.imageId;
-          if (imageId === undefined || !this._imageCells.has(imageId)) {
+          if (imageId === undefined || !targetIds.has(imageId) || !this._imageCells.has(imageId)) {
             continue;
           }
           this._trackCell(imageId, line, x);
@@ -952,9 +882,10 @@ export class ImageStorage implements IDisposable {
         }
       }
     }
-    const emptyImageIds = [...this._imageCells]
-      .filter(([, lines]) => !lines.size)
-      .map(([imageId]) => imageId);
+    const emptyImageIds = [...targetIds].filter(imageId => {
+      const lines = this._imageCells.get(imageId);
+      return !!lines && !lines.size;
+    });
     for (const imageId of emptyImageIds) {
       const marker = this._images.get(imageId)?.marker ?? this._evictedImages.get(imageId)?.marker;
       marker?.dispose();

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -312,6 +312,91 @@ export class ImageStorage implements IDisposable {
     return result;
   }
 
+  public reconcileImageCellIndexes(imageIds: Iterable<number>): void {
+    const uniqueIds = new Set(imageIds);
+    const lineImageIds = new Map<IBufferLineExt, Set<number>>();
+    const liveTileCounts = new Map<number, number>();
+    for (const imageId of uniqueIds) {
+      const lines = this._imageCells.get(imageId);
+      if (!lines) {
+        continue;
+      }
+      liveTileCounts.set(imageId, 0);
+      for (const line of lines.keys()) {
+        let ids = lineImageIds.get(line);
+        if (!ids) {
+          ids = new Set();
+          lineImageIds.set(line, ids);
+        }
+        ids.add(imageId);
+      }
+    }
+
+    const attachedLines = new Set<IBufferLineExt>();
+    const buffers = [this._terminal._core.buffers.normal, this._terminal._core.buffers.alt];
+    for (const buffer of buffers) {
+      for (let row = 0; row < buffer.lines.length; row++) {
+        const line = buffer.lines.get(row) as IBufferLineExt | undefined;
+        if (line && lineImageIds.has(line)) {
+          attachedLines.add(line);
+        }
+      }
+    }
+
+    for (const [line, imageIdsOnLine] of lineImageIds) {
+      if (!attachedLines.has(line)) {
+        for (const imageId of imageIdsOnLine) {
+          this._imageCells.get(imageId)?.delete(line);
+        }
+        continue;
+      }
+      const liveColumns = new Map<number, Set<number>>();
+      for (const key of Object.keys(line._extendedAttrs)) {
+        const column = Number(key);
+        if (
+          column >= line.length ||
+          !(line._data[column * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)
+        ) {
+          continue;
+        }
+        const imageId = line._extendedAttrs[column]?.imageId;
+        if (imageId === undefined || !imageIdsOnLine.has(imageId)) {
+          continue;
+        }
+        let columns = liveColumns.get(imageId);
+        if (!columns) {
+          columns = new Set();
+          liveColumns.set(imageId, columns);
+        }
+        columns.add(column);
+      }
+      for (const imageId of imageIdsOnLine) {
+        const lines = this._imageCells.get(imageId);
+        const columns = liveColumns.get(imageId);
+        if (columns?.size) {
+          lines?.set(line, columns);
+          liveTileCounts.set(imageId, (liveTileCounts.get(imageId) ?? 0) + columns.size);
+        } else {
+          lines?.delete(line);
+        }
+      }
+    }
+
+    for (const [imageId, tileCount] of liveTileCounts) {
+      const spec = this._images.get(imageId);
+      if (spec) {
+        spec.tileCount = tileCount;
+      }
+    }
+    const emptyImageIds = [...uniqueIds].filter(imageId => {
+      const lines = this._imageCells.get(imageId);
+      return !!lines && !lines.size;
+    });
+    if (emptyImageIds.length) {
+      this.deleteImages(emptyImageIds);
+    }
+  }
+
   /**
    * Method to add an image to the storage.
    * @param img - The image to add (canvas or bitmap).

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -18,6 +18,12 @@ export const CELL_SIZE_DEFAULT: ICellSize = {
   height: 14
 };
 
+export interface IImageStoragePixelCache {
+  readonly pixelCount: number;
+  evict(pixels: number): number;
+  clear(): void;
+}
+
 /**
  * Extend extended attribute to also hold image tile information.
  *
@@ -116,6 +122,9 @@ const EMPTY_ATTRS = new ExtendedAttrsImage();
 export class ImageStorage implements IDisposable {
   // storage
   private _images: Map<number, IImageSpec> = new Map();
+  private _evictedImages: Map<number, Pick<IImageSpec, 'marker' | 'bufferType'>> = new Map();
+  private _imageCells: Map<number, Map<IBufferLineExt, Set<number>>> = new Map();
+  private _pixelCaches: Set<IImageStoragePixelCache> = new Set();
   // last used id
   private _lastId = 0;
   // last evicted id
@@ -155,13 +164,28 @@ export class ImageStorage implements IDisposable {
   }
 
   public reset(): void {
+    for (const cache of this._pixelCaches) {
+      cache.clear();
+    }
     for (const spec of this._images.values()) {
+      spec.marker?.dispose();
+    }
+    for (const spec of this._evictedImages.values()) {
       spec.marker?.dispose();
     }
     // NOTE: marker.dispose above already calls ImageBitmap.close
     // therefore we can just wipe the map here
     this._images.clear();
+    this._evictedImages.clear();
+    this._imageCells.clear();
     this._renderer.clearAll();
+  }
+
+  public registerPixelCache(cache: IImageStoragePixelCache): IDisposable {
+    this._pixelCaches.add(cache);
+    return {
+      dispose: () => this._pixelCaches.delete(cache)
+    };
   }
 
   public getLimit(): number {
@@ -173,6 +197,10 @@ export class ImageStorage implements IDisposable {
       throw RangeError('invalid storageLimit, should be at least 0.5 MB and not exceed 1G');
     }
     this._pixelLimit = (value / 4 * 1000000) >>> 0;
+    this._evictOldest(0);
+  }
+
+  public enforceLimit(): void {
     this._evictOldest(0);
   }
 
@@ -190,15 +218,20 @@ export class ImageStorage implements IDisposable {
         }
       }
     }
+    for (const cache of this._pixelCaches) {
+      storedPixels += cache.pixelCount;
+    }
     return storedPixels;
   }
 
   private _delImg(id: number): void {
     const spec = this._images.get(id);
-    if (!spec) return;
+    if (!spec && !this._evictedImages.has(id) && !this._imageCells.has(id)) return;
     this._images.delete(id);
+    this._evictedImages.delete(id);
+    this._imageCells.delete(id);
     // FIXME: really ugly workaround to get bitmaps deallocated :(
-    if (window.ImageBitmap && spec.orig instanceof ImageBitmap) {
+    if (window.ImageBitmap && spec?.orig instanceof ImageBitmap) {
       spec.orig.close();
     }
     this.onImageDeleted?.(id);
@@ -216,6 +249,12 @@ export class ImageStorage implements IDisposable {
         zero.push(id);
       }
     }
+    for (const [id, spec] of this._evictedImages.entries()) {
+      if (spec.bufferType === 'alternate') {
+        spec.marker?.dispose();
+        zero.push(id);
+      }
+    }
     for (const id of zero) {
       this._delImg(id);
     }
@@ -228,12 +267,49 @@ export class ImageStorage implements IDisposable {
    * Delete an image by its internal storage ID.
    * Used by protocols that support explicit deletion (e.g. Kitty a=d).
    */
-  public deleteImage(id: number): void {
-    const spec = this._images.get(id);
-    if (spec) {
-      spec.marker?.dispose();
-      this._delImg(id);
+  public deleteImage(id: number): number {
+    return this.deleteImages([id]);
+  }
+
+  public deleteImages(ids: Iterable<number>): number {
+    const uniqueIds = new Set(ids);
+    const clearedCells = this._clearImageCells(uniqueIds);
+    for (const id of uniqueIds) {
+      const spec = this._images.get(id);
+      const evicted = this._evictedImages.get(id);
+      if (spec || evicted || this._imageCells.has(id)) {
+        (spec?.marker ?? evicted?.marker)?.dispose();
+        this._delImg(id);
+      }
     }
+    if (uniqueIds.size) {
+      this._needsFullClear = true;
+      this._fullyCleared = false;
+      this._terminal._core._inputHandler._dirtyRowTracker.markAllDirty();
+    }
+    return clearedCells;
+  }
+
+  public getVisibleImageStorageIds(): Set<number> {
+    const result = new Set<number>();
+    const buffer = this._terminal._core.buffer;
+    const end = Math.min(buffer.ydisp + this._terminal.rows, buffer.lines.length);
+    for (let row = buffer.ydisp; row < end; row++) {
+      const line = buffer.lines.get(row) as IBufferLineExt | undefined;
+      if (!line) {
+        continue;
+      }
+      for (let col = 0; col < this._terminal.cols; col++) {
+        if (!(line._data[col * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
+          continue;
+        }
+        const imageId = line._extendedAttrs[col]?.imageId;
+        if (imageId !== undefined && imageId !== -1 && this._imageCells.has(imageId)) {
+          result.add(imageId);
+        }
+      }
+    }
+    return result;
   }
 
   /**
@@ -260,6 +336,7 @@ export class ImageStorage implements IDisposable {
     const rows = Math.ceil(img.height / cellSize.height);
 
     const imageId = ++this._lastId;
+    this._imageCells.set(imageId, new Map());
 
     const buffer = this._terminal._core.buffer;
     const termCols = this._terminal.cols;
@@ -320,10 +397,7 @@ export class ImageStorage implements IDisposable {
     // delete the image when the marker gets disposed
     const endMarker = this._terminal.registerMarker(0);
     endMarker?.onDispose(() => {
-      const spec = this._images.get(imageId);
-      if (spec) {
-        this._delImg(imageId);
-      }
+      this._delImg(imageId);
     });
 
     // since markers do not work on alternate for some reason,
@@ -359,7 +433,7 @@ export class ImageStorage implements IDisposable {
   // TODO: Should we move this to the ImageRenderer?
   public render(range: { start: number, end: number }): void {
     // Determine which layers have images
-    let hasTopImages = false;
+    let hasTopImages = !!this._evictedImages.size;
     let hasBottomImages = false;
     for (const spec of this._images.values()) {
       if (spec.layer === 'bottom') {
@@ -383,7 +457,7 @@ export class ImageStorage implements IDisposable {
     this._renderer.rescaleCanvas();
 
     // exit early if we dont have any images to test for
-    if (!this._images.size) {
+    if (!this._images.size && !this._evictedImages.size) {
       if (!this._fullyCleared) {
         this._renderer.clearAll();
         this._fullyCleared = true;
@@ -487,9 +561,13 @@ export class ImageStorage implements IDisposable {
 
   public viewportResize(metrics: { cols: number, rows: number }): void {
     // exit early if we have nothing in storage
-    if (!this._images.size) {
+    if (!this._images.size && !this._evictedImages.size) {
       this._viewportMetrics = metrics;
       return;
+    }
+
+    if (metrics.cols !== this._viewportMetrics.cols) {
+      this._rebuildImageCellIndex();
     }
 
     // handle only viewport width enlargements, exit all other cases
@@ -586,6 +664,14 @@ export class ImageStorage implements IDisposable {
   private _evictOldest(room: number): number {
     const used = this._getStoredPixels();
     let current = used;
+    let evictedImage = false;
+    for (const cache of this._pixelCaches) {
+      const needed = current + room - this._pixelLimit;
+      if (needed <= 0) {
+        break;
+      }
+      current -= cache.evict(needed);
+    }
     while (this._pixelLimit < current + room && this._images.size) {
       const spec = this._images.get(++this._lowestId);
       if (spec && spec.orig) {
@@ -593,38 +679,186 @@ export class ImageStorage implements IDisposable {
         if (spec.actual && spec.orig !== spec.actual) {
           current -= spec.actual.width * spec.actual.height;
         }
-        spec.marker?.dispose();
-        this._delImg(this._lowestId);
+        this._images.delete(this._lowestId);
+        this._evictedImages.set(this._lowestId, {
+          marker: spec.marker,
+          bufferType: spec.bufferType
+        });
+        evictedImage = true;
+        if (window.ImageBitmap && spec.orig instanceof ImageBitmap) {
+          spec.orig.close();
+        }
       }
+    }
+    if (evictedImage) {
+      this._needsFullClear = true;
+      this._fullyCleared = false;
+      this._terminal._core._inputHandler._dirtyRowTracker.markAllDirty();
+      this._terminal._core._renderService.refreshRows(0, this._terminal.rows - 1);
     }
     return used - current;
   }
 
   private _writeToCell(line: IBufferLineExt, x: number, imageId: number, tileId: number): void {
-    if (line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED) {
-      const old = line._extendedAttrs[x];
+    const hasExtendedAttrs = !!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED);
+    const old = hasExtendedAttrs ? line._extendedAttrs[x] : undefined;
+    if (old?.imageId !== undefined) {
+      const oldSpec = this._images.get(old.imageId);
+      if (oldSpec) {
+        // early eviction for in-viewport overwrites
+        oldSpec.tileCount--;
+      }
+      this._untrackCell(old.imageId, line, x);
+      if (hasExtendedAttrs) {
+        // ExtendedAttrsImage instances are always isolated to a single cell.
+        old.imageId = imageId;
+        old.tileId = tileId;
+        this._trackCell(imageId, line, x);
+        return;
+      }
+    }
+    if (hasExtendedAttrs) {
       if (old) {
-        if (old.imageId !== undefined) {
-          // found an old ExtendedAttrsImage, since we know that
-          // they are always isolated instances (single cell usage),
-          // we can re-use it and just update their id entries
-          const oldSpec = this._images.get(old.imageId);
-          if (oldSpec) {
-            // early eviction for in-viewport overwrites
-            oldSpec.tileCount--;
-          }
-          old.imageId = imageId;
-          old.tileId = tileId;
-          return;
-        }
         // found a plain ExtendedAttrs instance, clone it to new entry
         line._extendedAttrs[x] = new ExtendedAttrsImage(old.ext, old.urlId, imageId, tileId);
+        this._trackCell(imageId, line, x);
         return;
       }
     }
     // fall-through: always create new ExtendedAttrsImage entry
     line._data[x * Cell.SIZE + Cell.BG] |= BgFlags.HAS_EXTENDED;
     line._extendedAttrs[x] = new ExtendedAttrsImage(0, 0, imageId, tileId);
+    this._trackCell(imageId, line, x);
+  }
+
+  private _trackCell(imageId: number, line: IBufferLineExt, x: number): void {
+    let lines = this._imageCells.get(imageId);
+    if (!lines) {
+      lines = new Map();
+      this._imageCells.set(imageId, lines);
+    }
+    let columns = lines.get(line);
+    if (!columns) {
+      columns = new Set();
+      lines.set(line, columns);
+    }
+    columns.add(x);
+  }
+
+  private _untrackCell(imageId: number, line: IBufferLineExt, x: number): void {
+    const lines = this._imageCells.get(imageId);
+    if (!lines) {
+      return;
+    }
+    const columns = lines.get(line);
+    if (!columns) {
+      return;
+    }
+    const deleted = columns.delete(x);
+    let remainingColumns = columns;
+    if (!deleted || !columns.size) {
+      const shiftedColumns = new Set<number>();
+      for (const key of Object.keys(line._extendedAttrs)) {
+        const column = Number(key);
+        if (
+          column !== x &&
+          line._data[column * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED &&
+          line._extendedAttrs[column]?.imageId === imageId
+        ) {
+          shiftedColumns.add(column);
+        }
+      }
+      if (shiftedColumns.size) {
+        lines.set(line, shiftedColumns);
+        remainingColumns = shiftedColumns;
+      } else {
+        lines.delete(line);
+      }
+    }
+    if (!remainingColumns.size) {
+      lines.delete(line);
+    }
+    if (!lines.size && this._evictedImages.has(imageId)) {
+      this._evictedImages.get(imageId)?.marker?.dispose();
+      this._delImg(imageId);
+    }
+  }
+
+  private _clearImageCells(imageIds: ReadonlySet<number>): number {
+    let cleared = 0;
+    for (const imageId of imageIds) {
+      const lines = this._imageCells.get(imageId);
+      if (!lines) {
+        continue;
+      }
+      for (const line of lines.keys()) {
+        for (const key of Object.keys(line._extendedAttrs)) {
+          const x = Number(key);
+          if (!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
+            continue;
+          }
+          const attrs = line._extendedAttrs[x];
+          if (attrs?.imageId !== imageId) {
+            continue;
+          }
+          attrs.imageId = -1;
+          attrs.tileId = -1;
+          if (attrs.isEmpty()) {
+            delete line._extendedAttrs[x];
+            line._data[x * Cell.SIZE + Cell.BG] &= ~BgFlags.HAS_EXTENDED;
+          }
+          cleared++;
+        }
+      }
+    }
+    return cleared;
+  }
+
+  private _rebuildImageCellIndex(): void {
+    this._imageCells.clear();
+    for (const [id, spec] of this._images) {
+      this._imageCells.set(id, new Map());
+      spec.tileCount = 0;
+    }
+    for (const id of this._evictedImages.keys()) {
+      this._imageCells.set(id, new Map());
+    }
+    const buffers = [this._terminal._core.buffers.normal, this._terminal._core.buffers.alt];
+    for (const buffer of buffers) {
+      for (let y = 0; y < buffer.lines.length; y++) {
+        const line = buffer.lines.get(y) as IBufferLineExt;
+        if (!line) {
+          continue;
+        }
+        for (const key of Object.keys(line._extendedAttrs)) {
+          const x = Number(key);
+          if (x >= line.length) {
+            delete line._extendedAttrs[x];
+            continue;
+          }
+          if (!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
+            continue;
+          }
+          const imageId = line._extendedAttrs[x]?.imageId;
+          if (imageId === undefined || !this._imageCells.has(imageId)) {
+            continue;
+          }
+          this._trackCell(imageId, line, x);
+          const spec = this._images.get(imageId);
+          if (spec) {
+            spec.tileCount++;
+          }
+        }
+      }
+    }
+    const emptyImageIds = [...this._imageCells]
+      .filter(([, lines]) => !lines.size)
+      .map(([imageId]) => imageId);
+    for (const imageId of emptyImageIds) {
+      const marker = this._images.get(imageId)?.marker ?? this._evictedImages.get(imageId)?.marker;
+      marker?.dispose();
+      this._delImg(imageId);
+    }
   }
 
   private _evictOnAlternate(): void {

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -300,9 +300,7 @@ export class ImageStorage implements IDisposable {
         continue;
       }
       for (let col = 0; col < this._terminal.cols; col++) {
-        if (!(line._data[col * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
-          continue;
-        }
+        // Text writes can clear HAS_EXTENDED while leaving top-layer image metadata live.
         const imageId = line._extendedAttrs[col]?.imageId;
         if (imageId !== undefined && imageId !== -1 && this._imageCells.has(imageId)) {
           result.add(imageId);
@@ -701,7 +699,7 @@ export class ImageStorage implements IDisposable {
 
   private _writeToCell(line: IBufferLineExt, x: number, imageId: number, tileId: number): void {
     const hasExtendedAttrs = !!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED);
-    const old = hasExtendedAttrs ? line._extendedAttrs[x] : undefined;
+    const old = line._extendedAttrs[x];
     if (old?.imageId !== undefined) {
       const oldSpec = this._images.get(old.imageId);
       if (oldSpec) {
@@ -762,7 +760,6 @@ export class ImageStorage implements IDisposable {
         const column = Number(key);
         if (
           column !== x &&
-          line._data[column * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED &&
           line._extendedAttrs[column]?.imageId === imageId
         ) {
           shiftedColumns.add(column);
@@ -794,9 +791,6 @@ export class ImageStorage implements IDisposable {
       for (const line of lines.keys()) {
         for (const key of Object.keys(line._extendedAttrs)) {
           const x = Number(key);
-          if (!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
-            continue;
-          }
           const attrs = line._extendedAttrs[x];
           if (attrs?.imageId !== imageId) {
             continue;
@@ -834,9 +828,6 @@ export class ImageStorage implements IDisposable {
           const x = Number(key);
           if (x >= line.length) {
             delete line._extendedAttrs[x];
-            continue;
-          }
-          if (!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
             continue;
           }
           const imageId = line._extendedAttrs[x]?.imageId;

--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -8,7 +8,7 @@ import { ImageRenderer } from './ImageRenderer';
 import {
   ITerminalExt, IExtendedAttrsImage, IImageAddonOptions, IImageSpec,
   IBufferLineExt, BgFlags, Cell, Content, ICellSize, ExtFlags, Attributes,
-  UnderlineStyle, IAddImageOpts
+  UnderlineStyle, IAddImageOpts, ImageLayer
 } from './Types';
 
 
@@ -122,7 +122,7 @@ const EMPTY_ATTRS = new ExtendedAttrsImage();
 export class ImageStorage implements IDisposable {
   // storage
   private _images: Map<number, IImageSpec> = new Map();
-  private _evictedImages: Map<number, Pick<IImageSpec, 'marker' | 'bufferType'>> = new Map();
+  private _evictedImages: Map<number, Pick<IImageSpec, 'marker' | 'bufferType' | 'layer'>> = new Map();
   private _imageCells: Map<number, Map<IBufferLineExt, Set<number>>> = new Map();
   private _pixelCaches: Set<IImageStoragePixelCache> = new Set();
   // last used id
@@ -293,14 +293,16 @@ export class ImageStorage implements IDisposable {
   public getVisibleImageStorageIds(): Set<number> {
     const result = new Set<number>();
     const buffer = this._terminal._core.buffer;
-    const end = Math.min(buffer.ydisp + this._terminal.rows, buffer.lines.length);
-    for (let row = buffer.ydisp; row < end; row++) {
+    const end = Math.min(buffer.ybase + this._terminal.rows, buffer.lines.length);
+    for (let row = buffer.ybase; row < end; row++) {
       const line = buffer.lines.get(row) as IBufferLineExt | undefined;
       if (!line) {
         continue;
       }
       for (let col = 0; col < this._terminal.cols; col++) {
-        // Text writes can clear HAS_EXTENDED while leaving top-layer image metadata live.
+        if (!(line._data[col * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
+          continue;
+        }
         const imageId = line._extendedAttrs[col]?.imageId;
         if (imageId !== undefined && imageId !== -1 && this._imageCells.has(imageId)) {
           result.add(imageId);
@@ -431,7 +433,7 @@ export class ImageStorage implements IDisposable {
   // TODO: Should we move this to the ImageRenderer?
   public render(range: { start: number, end: number }): void {
     // Determine which layers have images
-    let hasTopImages = !!this._evictedImages.size;
+    let hasTopImages = false;
     let hasBottomImages = false;
     for (const spec of this._images.values()) {
       if (spec.layer === 'bottom') {
@@ -440,6 +442,16 @@ export class ImageStorage implements IDisposable {
         hasTopImages = true;
       }
       if (hasTopImages && hasBottomImages) break;
+    }
+    if (!hasTopImages || !hasBottomImages) {
+      for (const spec of this._evictedImages.values()) {
+        if (spec.layer === 'bottom') {
+          hasBottomImages = true;
+        } else {
+          hasTopImages = true;
+        }
+        if (hasTopImages && hasBottomImages) break;
+      }
     }
 
     // Lazily insert layers that are needed
@@ -496,7 +508,7 @@ export class ImageStorage implements IDisposable {
 
     // Collect draw calls so we can sort by z-index (lower z drawn first).
     const drawCalls: { imgSpec: IImageSpec, tileId: number, col: number, row: number, count: number }[] = [];
-    const placeholderCalls: { col: number, row: number, count: number }[] = [];
+    const placeholderCalls: { col: number, row: number, count: number, layer: ImageLayer }[] = [];
 
     // walk all cells in viewport and collect tiles found
     for (let row = start; row <= end; ++row) {
@@ -535,7 +547,12 @@ export class ImageStorage implements IDisposable {
                 drawCalls.push({ imgSpec, tileId: startTile, col: startCol, row, count });
               }
             } else if (this._opts.showPlaceholder) {
-              placeholderCalls.push({ col: startCol, row, count });
+              placeholderCalls.push({
+                col: startCol,
+                row,
+                count,
+                layer: this._evictedImages.get(imageId)?.layer ?? 'top'
+              });
             }
             this._fullyCleared = false;
           }
@@ -548,7 +565,7 @@ export class ImageStorage implements IDisposable {
 
     // Draw placeholders first (lowest priority)
     for (const call of placeholderCalls) {
-      this._renderer.drawPlaceholder(call.col, call.row, call.count);
+      this._renderer.drawPlaceholder(call.col, call.row, call.count, call.layer);
     }
 
     // Draw images in z-index order
@@ -680,7 +697,8 @@ export class ImageStorage implements IDisposable {
         this._images.delete(this._lowestId);
         this._evictedImages.set(this._lowestId, {
           marker: spec.marker,
-          bufferType: spec.bufferType
+          bufferType: spec.bufferType,
+          layer: spec.layer
         });
         evictedImage = true;
         if (window.ImageBitmap && spec.orig instanceof ImageBitmap) {
@@ -699,7 +717,7 @@ export class ImageStorage implements IDisposable {
 
   private _writeToCell(line: IBufferLineExt, x: number, imageId: number, tileId: number): void {
     const hasExtendedAttrs = !!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED);
-    const old = line._extendedAttrs[x];
+    const old = hasExtendedAttrs ? line._extendedAttrs[x] : undefined;
     if (old?.imageId !== undefined) {
       const oldSpec = this._images.get(old.imageId);
       if (oldSpec) {
@@ -760,6 +778,7 @@ export class ImageStorage implements IDisposable {
         const column = Number(key);
         if (
           column !== x &&
+          line._data[column * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED &&
           line._extendedAttrs[column]?.imageId === imageId
         ) {
           shiftedColumns.add(column);
@@ -791,6 +810,9 @@ export class ImageStorage implements IDisposable {
       for (const line of lines.keys()) {
         for (const key of Object.keys(line._extendedAttrs)) {
           const x = Number(key);
+          if (!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
+            continue;
+          }
           const attrs = line._extendedAttrs[x];
           if (attrs?.imageId !== imageId) {
             continue;
@@ -828,6 +850,9 @@ export class ImageStorage implements IDisposable {
           const x = Number(key);
           if (x >= line.length) {
             delete line._extendedAttrs[x];
+            continue;
+          }
+          if (!(line._data[x * Cell.SIZE + Cell.BG] & BgFlags.HAS_EXTENDED)) {
             continue;
           }
           const imageId = line._extendedAttrs[x]?.imageId;

--- a/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
+++ b/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
@@ -403,7 +403,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
     const transmission = cmd.transmission ?? 'd';
     if (transmission !== 'd') {
       if (cmd.id !== undefined) {
-        this._sendResponse(cmd.id, 'EINVAL:unsupported transmission medium', cmd.quiet ?? 0);
+        this._sendResponse(cmd.id, 'EINVAL:unsupported transmission medium', cmd.quiet ?? 0, cmd.placementId);
       }
       return true;
     }
@@ -423,7 +423,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
   private _handleTransmitDisplay(cmd: IKittyCommand, bytes: Uint8Array, decodeError: boolean): boolean | Promise<boolean> {
     if (decodeError) {
       if (cmd.id !== undefined) {
-        this._sendResponse(cmd.id, 'EINVAL:invalid base64 data', cmd.quiet ?? 0);
+        this._sendResponse(cmd.id, 'EINVAL:invalid base64 data', cmd.quiet ?? 0, cmd.placementId);
       }
       return true;
     }
@@ -436,7 +436,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
       const result = this._displayImage(image, cmd);
       if (cmd.id !== undefined) {
         return result.then(success => {
-          this._sendResponse(id, success ? 'OK' : 'EINVAL:image rendering failed', cmd.quiet ?? 0);
+          this._sendResponse(id, success ? 'OK' : 'EINVAL:image rendering failed', cmd.quiet ?? 0, cmd.placementId);
           return true;
         });
       }
@@ -497,35 +497,25 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
   }
 
   private _handleDelete(cmd: IKittyCommand): boolean {
+    this._cleanupAllPending();
+
     // Per spec: default delete selector is 'a' (delete all visible placements)
     const selector = cmd.deleteSelector ?? 'a';
 
     switch (selector) {
       case 'a':
-        this._cleanupAllPending();
         this._kittyStorage.deleteVisiblePlacements(false);
         break;
       case 'A':
-        this._cleanupAllPending();
         this._kittyStorage.deleteVisiblePlacements(true);
         break;
       case 'i':
         if (cmd.id !== undefined) {
-          const pending = this._pendingTransmissions.get(cmd.id);
-          if (pending) {
-            pending.decoder.release();
-          }
-          this._removePendingEntry(cmd.id);
           this._kittyStorage.deletePlacements(cmd.id, cmd.placementId);
         }
         break;
       case 'I':
         if (cmd.id !== undefined) {
-          const pending = this._pendingTransmissions.get(cmd.id);
-          if (pending) {
-            pending.decoder.release();
-          }
-          this._removePendingEntry(cmd.id);
           this._kittyStorage.deleteImage(cmd.id, cmd.placementId);
         }
         break;

--- a/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
+++ b/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
@@ -29,7 +29,8 @@ const enum Constants {
   // Maximum control data size
   MAX_CONTROL_DATA_SIZE = 512,
   // Semicolon codepoint
-  SEMICOLON = 0x3B
+  SEMICOLON = 0x3B,
+  MAX_IMAGE_ID = 0xFFFFFFFF
 }
 
 const DECODER_OK = Constants.DECODER_OK as unknown as DecodeStatus.OK;
@@ -148,9 +149,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
         // Found semicolon - parse control data early for validation
         this._parsedCommand = parseKittyCommand(this._parseControlDataString());
 
-        // Early validation: i+I conflict
-        if (this._parsedCommand.id !== undefined && this._parsedCommand.imageNumber !== undefined) {
-          this._sendResponse(this._parsedCommand.id, 'EINVAL:cannot specify both i and I keys', this._parsedCommand.quiet ?? 0);
+        if (!this._validateImageIdentifiers(this._parsedCommand)) {
           this._aborted = true;
           return;
         }
@@ -305,12 +304,29 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
     return str;
   }
 
+  private _validateImageIdentifiers(cmd: IKittyCommand): boolean {
+    if (cmd.id !== undefined && cmd.imageNumber !== undefined) {
+      this._sendResponse(cmd.id, 'EINVAL:cannot specify both i and I keys', cmd.quiet ?? 0);
+      return false;
+    }
+    if (cmd.id === 0) {
+      cmd.id = undefined;
+      return true;
+    }
+    if (
+      cmd.id !== undefined &&
+      (!Number.isInteger(cmd.id) || cmd.id < 0 || cmd.id > Constants.MAX_IMAGE_ID)
+    ) {
+      this._sendResponse(cmd.id, 'EINVAL:invalid image id', cmd.quiet ?? 0);
+      return false;
+    }
+    return true;
+  }
+
   private _handleNoPayloadCommand(): boolean | Promise<boolean> {
     const cmd = parseKittyCommand(this._parseControlDataString());
 
-    // Per spec: specifying both i and I is an error
-    if (cmd.id !== undefined && cmd.imageNumber !== undefined) {
-      this._sendResponse(cmd.id, 'EINVAL:cannot specify both i and I keys', cmd.quiet ?? 0);
+    if (!this._validateImageIdentifiers(cmd)) {
       return true;
     }
 
@@ -341,7 +357,10 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
 
     switch (action) {
       case KittyAction.TRANSMIT: {
-        const result = this._handleTransmit(cmd, bytes, decodeError);
+        const imageId = this._handleTransmit(cmd, bytes, decodeError);
+        if (cmd.id === undefined && imageId !== undefined) {
+          this._kittyStorage.releaseUnreferencedImage(imageId);
+        }
         // Only send response when _handleTransmit didn't already respond
         // (it handles unsupported transmission medium responses internally)
         if ((cmd.transmission ?? 'd') === 'd' && cmd.id !== undefined) {
@@ -351,7 +370,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
             this._sendResponse(cmd.id, 'OK', cmd.quiet ?? 0);
           }
         }
-        return result;
+        return true;
       }
       case KittyAction.TRANSMIT_DISPLAY:
         return this._handleTransmitDisplay(cmd, bytes, decodeError);
@@ -389,7 +408,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
     });
   }
 
-  private _handleTransmit(cmd: IKittyCommand, bytes: Uint8Array, decodeError: boolean): boolean {
+  private _handleTransmit(cmd: IKittyCommand, bytes: Uint8Array, decodeError: boolean): number | undefined {
     // TODO: Support file-based transmission modes (t=f, t=t, t=s)
     // Currently only supports direct transmission (t=d, the default).
     // - t=f (file): Payload is base64-encoded file path. Terminal reads image from that path.
@@ -405,19 +424,24 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
       if (cmd.id !== undefined) {
         this._sendResponse(cmd.id, 'EINVAL:unsupported transmission medium', cmd.quiet ?? 0, cmd.placementId);
       }
-      return true;
+      return undefined;
     }
 
-    if (decodeError || bytes.length === 0) return true;
+    if (decodeError) return undefined;
+    if (bytes.length === 0) {
+      if (cmd.id !== undefined) {
+        this._sendResponse(cmd.id, 'EINVAL:missing image data', cmd.quiet ?? 0, cmd.placementId);
+      }
+      return undefined;
+    }
 
-    this._kittyStorage.storeImage(cmd.id, {
+    return this._kittyStorage.storeImage(cmd.id, {
       data: new Blob([bytes as BlobPart]),
       width: cmd.width ?? 0,
       height: cmd.height ?? 0,
       format: (cmd.format ?? KittyFormat.RGBA) as 24 | 32 | 100,
       compression: cmd.compression ?? ''
     });
-    return true;
   }
 
   private _handleTransmitDisplay(cmd: IKittyCommand, bytes: Uint8Array, decodeError: boolean): boolean | Promise<boolean> {
@@ -428,19 +452,24 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
       return true;
     }
 
-    this._handleTransmit(cmd, bytes, decodeError);
-
-    const id = cmd.id ?? this._kittyStorage.lastImageId;
+    const id = this._handleTransmit(cmd, bytes, decodeError);
+    if (id === undefined) {
+      return true;
+    }
     const image = this._kittyStorage.getImage(id);
     if (image) {
-      const result = this._displayImage(image, cmd);
+      const placementCmd = cmd.id === undefined ? { ...cmd, placementId: 0 } : cmd;
+      const result = this._displayImage(image, placementCmd);
       if (cmd.id !== undefined) {
         return result.then(success => {
           this._sendResponse(id, success ? 'OK' : 'EINVAL:image rendering failed', cmd.quiet ?? 0, cmd.placementId);
           return true;
         });
       }
-      return result.then(() => true);
+      return result.then(() => {
+        this._kittyStorage.releaseUnreferencedImage(id);
+        return true;
+      });
     }
     return true;
   }

--- a/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
+++ b/addons/addon-image/src/kitty/KittyGraphicsHandler.ts
@@ -500,28 +500,33 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
     // Per spec: default delete selector is 'a' (delete all visible placements)
     const selector = cmd.deleteSelector ?? 'a';
 
-    // TODO: Distinguish lowercase (delete placements only) from uppercase
-    // (delete placements + free stored image data). Currently both variants
-    // free everything since we don't separate stored data from placements.
     switch (selector) {
       case 'a':
+        this._cleanupAllPending();
+        this._kittyStorage.deleteVisiblePlacements(false);
+        break;
       case 'A':
         this._cleanupAllPending();
-        this._kittyStorage.deleteAll();
+        this._kittyStorage.deleteVisiblePlacements(true);
         break;
       case 'i':
-      case 'I':
-        // TODO: When placement id tracking is implemented (see TODO in
-        // KittyImageStorage), d=i with p=<pid> should delete only that
-        // specific placement, while d=i without p should delete all
-        // placements for the image.
         if (cmd.id !== undefined) {
           const pending = this._pendingTransmissions.get(cmd.id);
           if (pending) {
             pending.decoder.release();
           }
           this._removePendingEntry(cmd.id);
-          this._kittyStorage.deleteById(cmd.id);
+          this._kittyStorage.deletePlacements(cmd.id, cmd.placementId);
+        }
+        break;
+      case 'I':
+        if (cmd.id !== undefined) {
+          const pending = this._pendingTransmissions.get(cmd.id);
+          if (pending) {
+            pending.decoder.release();
+          }
+          this._removePendingEntry(cmd.id);
+          this._kittyStorage.deleteImage(cmd.id, cmd.placementId);
         }
         break;
       default:
@@ -550,9 +555,14 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
   }
 
   private async _decodeAndDisplay(image: IKittyImageData, cmd: IKittyCommand): Promise<void> {
-    let bitmap: ImageBitmap | undefined = await this._createBitmap(image);
+    const operationGeneration = this._kittyStorage.operationGeneration;
+    const source = await this._kittyStorage.getDecodedImage(image.id, () => this._createBitmap(image));
+    let bitmap: ImageBitmap | undefined;
 
     try {
+      bitmap = await createImageBitmap(source);
+      this._kittyStorage.enforceCacheLimit();
+
       const cropX = Math.max(0, cmd.x ?? 0);
       const cropY = Math.max(0, cmd.y ?? 0);
       const cropW = cmd.sourceWidth || (bitmap.width - cropX);
@@ -661,7 +671,10 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
       }
 
       const zIndex = cmd.zIndex ?? 0;
-      this._kittyStorage.addImage(image.id, bitmap, true, layer, zIndex);
+      if (!this._kittyStorage.isPlacementOperationCurrent(operationGeneration, image)) {
+        throw new Error('image placement was invalidated');
+      }
+      this._kittyStorage.addImage(image.id, cmd.placementId ?? 0, bitmap, true, layer, zIndex);
       bitmap = undefined;  // ownership transferred to storage
 
       // Kitty cursor movement
@@ -680,6 +693,7 @@ export class KittyGraphicsHandler implements IApcHandler, IResetHandler, IDispos
       }
     } catch (e) {
       bitmap?.close();
+      this._kittyStorage.enforceCacheLimit();
       throw e;
     }
   }

--- a/addons/addon-image/src/kitty/KittyImageStorage.ts
+++ b/addons/addon-image/src/kitty/KittyImageStorage.ts
@@ -4,42 +4,64 @@
  */
 
 import { IDisposable } from '@xterm/xterm';
-import { ImageStorage } from '../ImageStorage';
+import { IImageStoragePixelCache, ImageStorage } from '../ImageStorage';
 import { ImageLayer, IAddImageOpts } from '../Types';
 import { IKittyImageData } from './KittyGraphicsTypes';
 
+interface IStoredKittyImage extends IKittyImageData {
+  decodedSource?: ImageBitmap;
+  decodePromise?: Promise<ImageBitmap>;
+  decodedPixels: number;
+  lastDecodeUse: number;
+  decodeGeneration: number;
+}
+
+interface IKittyPlacement {
+  imageId: number;
+  placementId: number;
+}
+
+const enum Constants {
+  MAX_STORED_IMAGES = 256
+}
+
 // Kitty-specific image storage controller.
 //
-// Wraps shared ImageStorage with kitty protocol semantics:
-// - tracks transmitted image payloads by kitty image id
-// - tracks kitty image id -> shared ImageStorage id mapping for displayed images
-// - mirrors shared-storage evictions into kitty maps
-// - applies protocol-level undisplayed-image eviction policy
-export class KittyImageStorage implements IDisposable {
-  private static readonly _maxStoredImages = 256;
-
+// Transmitted image data is image-scoped and survives placement deletion.
+// Displayed placements are tracked independently by (image id, placement id);
+// omitted/zero placement ids are anonymous and additive.
+export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
   private _nextImageId = 1;
-  private readonly _images: Map<number, IKittyImageData> = new Map();
-  // TODO: Support multiple placements per image. The kitty spec identifies
-  // placements by an (image id, placement id) pair — same i + different p
-  // values should coexist, and same i + same p should replace the prior
-  // placement. Currently we track only one storage entry per kitty image id,
-  // so multiple placements of the same image overwrite each other. Fixing
-  // this requires changing these maps to Map<number, Map<number, number>>
-  // (kittyId → placementId → storageId) and updating addImage/deleteById
-  // accordingly. The underlying shared ImageStorage would also need to
-  // support multiple entries per logical image.
-  private readonly _kittyIdToStorageId: Map<number, number> = new Map();
-  private readonly _storageIdToKittyId: Map<number, number> = new Map();
+  private _decodeUseSequence = 0;
+  private _decodedPixels = 0;
+  private _operationGeneration = 0;
+  private _isDisposed = false;
+  private readonly _images: Map<number, IStoredKittyImage> = new Map();
+  private readonly _namedPlacements: Map<number, Map<number, number>> = new Map();
+  private readonly _anonymousPlacements: Map<number, Set<number>> = new Map();
+  private readonly _storageIdToPlacement: Map<number, IKittyPlacement> = new Map();
 
   private readonly _previousOnImageDeleted: ((storageId: number) => void) | undefined;
   private readonly _wrappedOnImageDeleted: (storageId: number) => void;
+  private readonly _pixelCacheRegistration: IDisposable;
   private readonly _handleStorageImageDeleted = (storageId: number): void => {
-    const kittyId = this._storageIdToKittyId.get(storageId);
-    if (kittyId !== undefined) {
-      this._kittyIdToStorageId.delete(kittyId);
-      this._storageIdToKittyId.delete(storageId);
-      this._images.delete(kittyId);
+    const placement = this._storageIdToPlacement.get(storageId);
+    if (!placement) {
+      return;
+    }
+    this._storageIdToPlacement.delete(storageId);
+    if (placement.placementId > 0) {
+      const named = this._namedPlacements.get(placement.imageId);
+      named?.delete(placement.placementId);
+      if (!named?.size) {
+        this._namedPlacements.delete(placement.imageId);
+      }
+    } else {
+      const anonymous = this._anonymousPlacements.get(placement.imageId);
+      anonymous?.delete(storageId);
+      if (!anonymous?.size) {
+        this._anonymousPlacements.delete(placement.imageId);
+      }
     }
   };
   private _addImageOpts: IAddImageOpts = { scrolling: true, layer: 'top', zIndex: 0, cursorPos: 'iip' };
@@ -53,81 +75,228 @@ export class KittyImageStorage implements IDisposable {
       this._handleStorageImageDeleted(storageId);
     };
     this._storage.onImageDeleted = this._wrappedOnImageDeleted;
+    this._pixelCacheRegistration = this._storage.registerPixelCache(this);
   }
 
   public reset(): void {
+    this._invalidatePlacementOperations();
+    this._deleteAllPlacements();
+    this.clear();
     this._nextImageId = 1;
     this._images.clear();
-    this._kittyIdToStorageId.clear();
-    this._storageIdToKittyId.clear();
+    this._namedPlacements.clear();
+    this._anonymousPlacements.clear();
+    this._storageIdToPlacement.clear();
   }
 
   public dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
     this.reset();
+    this._isDisposed = true;
+    this._invalidatePlacementOperations();
+    this._pixelCacheRegistration.dispose();
     if (this._storage.onImageDeleted === this._wrappedOnImageDeleted) {
       this._storage.onImageDeleted = this._previousOnImageDeleted;
     }
   }
 
   public storeImage(id: number | undefined, imageData: Omit<IKittyImageData, 'id'>): number {
+    this._invalidatePlacementOperations();
     const imageId = id ?? this._nextImageId++;
 
-    const oldStorageId = this._kittyIdToStorageId.get(imageId);
-    if (oldStorageId !== undefined) {
-      this._storage.deleteImage(oldStorageId);
-      this._kittyIdToStorageId.delete(imageId);
-      this._storageIdToKittyId.delete(oldStorageId);
+    this._deletePlacements(imageId);
+    if (this._images.has(imageId)) {
+      this._deleteImageData(imageId);
     }
 
-    if (!this._images.has(imageId) && this._images.size >= KittyImageStorage._maxStoredImages) {
+    if (this._images.size >= Constants.MAX_STORED_IMAGES) {
       this._evictUndisplayedImages();
+      while (this._images.size >= Constants.MAX_STORED_IMAGES) {
+        const oldestImageId = this._images.keys().next().value;
+        if (oldestImageId === undefined) {
+          break;
+        }
+        this._deleteImageData(oldestImageId);
+      }
     }
 
     this._images.set(imageId, {
       ...imageData,
-      id: imageId
+      id: imageId,
+      decodedPixels: 0,
+      lastDecodeUse: 0,
+      decodeGeneration: 0
     });
     return imageId;
   }
 
-  public addImage(kittyId: number, image: HTMLCanvasElement | ImageBitmap, scrolling: boolean, layer: ImageLayer, zIndex: number): void {
-    // Clean up stale reverse-mapping from a previous placement of the same
-    // kitty image.  The old shared-storage entry is kept (it may still be
-    // visible on screen) but its reverse mapping is removed so that eviction
-    // of the old entry won't incorrectly delete the kitty image data.
-    const oldStorageId = this._kittyIdToStorageId.get(kittyId);
-    if (oldStorageId !== undefined) {
-      this._storageIdToKittyId.delete(oldStorageId);
+  public addImage(kittyId: number, placementId: number, image: HTMLCanvasElement | ImageBitmap, scrolling: boolean, layer: ImageLayer, zIndex: number): void {
+    if (placementId > 0) {
+      const oldStorageId = this._namedPlacements.get(kittyId)?.get(placementId);
+      if (oldStorageId !== undefined) {
+        this._storage.deleteImage(oldStorageId);
+      }
     }
+
     this._addImageOpts.scrolling = scrolling;
     this._addImageOpts.layer = layer;
     this._addImageOpts.zIndex = zIndex;
     const storageId = this._storage.addImage(image, this._addImageOpts);
-    this._kittyIdToStorageId.set(kittyId, storageId);
-    this._storageIdToKittyId.set(storageId, kittyId);
+    this._storageIdToPlacement.set(storageId, { imageId: kittyId, placementId });
+
+    if (placementId > 0) {
+      let named = this._namedPlacements.get(kittyId);
+      if (!named) {
+        named = new Map();
+        this._namedPlacements.set(kittyId, named);
+      }
+      named.set(placementId, storageId);
+    } else {
+      let anonymous = this._anonymousPlacements.get(kittyId);
+      if (!anonymous) {
+        anonymous = new Set();
+        this._anonymousPlacements.set(kittyId, anonymous);
+      }
+      anonymous.add(storageId);
+    }
   }
 
   public getImage(kittyId: number): IKittyImageData | undefined {
     return this._images.get(kittyId);
   }
 
-  public deleteById(kittyId: number): void {
-    this._images.delete(kittyId);
-    const storageId = this._kittyIdToStorageId.get(kittyId);
-    if (storageId !== undefined) {
-      this._storage.deleteImage(storageId);
-      this._kittyIdToStorageId.delete(kittyId);
-      this._storageIdToKittyId.delete(storageId);
+  public getDecodedImage(kittyId: number, decode: () => Promise<ImageBitmap>): Promise<ImageBitmap> {
+    const image = this._images.get(kittyId);
+    if (!image) {
+      return Promise.reject(new Error('image not found'));
+    }
+    image.lastDecodeUse = ++this._decodeUseSequence;
+    if (image.decodedSource) {
+      return Promise.resolve(image.decodedSource);
+    }
+    if (image.decodePromise) {
+      return image.decodePromise;
+    }
+
+    const generation = image.decodeGeneration;
+    const promise = decode().then(bitmap => {
+      if (this._images.get(kittyId) !== image || image.decodeGeneration !== generation) {
+        bitmap.close();
+        throw new Error('image data was deleted while decoding');
+      }
+      image.decodePromise = undefined;
+      image.decodedSource = bitmap;
+      image.decodedPixels = bitmap.width * bitmap.height;
+      image.lastDecodeUse = ++this._decodeUseSequence;
+      this._decodedPixels += image.decodedPixels;
+      return bitmap;
+    }, error => {
+      if (image.decodePromise === promise) {
+        image.decodePromise = undefined;
+      }
+      throw error;
+    });
+    image.decodePromise = promise;
+    return promise;
+  }
+
+  public get operationGeneration(): number {
+    return this._operationGeneration;
+  }
+
+  public isPlacementOperationCurrent(generation: number, image: IKittyImageData): boolean {
+    return !this._isDisposed &&
+      generation === this._operationGeneration &&
+      this._images.get(image.id) === image;
+  }
+
+  public enforceCacheLimit(): void {
+    this._storage.enforceLimit();
+  }
+
+  public deletePlacements(kittyId: number, placementId?: number): void {
+    this._invalidatePlacementOperations();
+    this._deletePlacements(kittyId, placementId);
+  }
+
+  public deleteVisiblePlacements(freeData: boolean): void {
+    this._invalidatePlacementOperations();
+    const storageIds = new Set<number>();
+    const kittyIds = new Set<number>();
+    for (const storageId of this._storage.getVisibleImageStorageIds()) {
+      const placement = this._storageIdToPlacement.get(storageId);
+      if (placement) {
+        storageIds.add(storageId);
+        kittyIds.add(placement.imageId);
+      }
+    }
+    if (storageIds.size) {
+      this._storage.deleteImages(storageIds);
+    }
+    if (freeData) {
+      for (const kittyId of kittyIds) {
+        if (!this._hasPlacements(kittyId)) {
+          this._deleteImageData(kittyId);
+        }
+      }
     }
   }
 
-  public deleteAll(): void {
-    this._images.clear();
-    for (const storageId of this._kittyIdToStorageId.values()) {
-      this._storage.deleteImage(storageId);
+  public deleteImage(kittyId: number, placementId?: number): void {
+    this._invalidatePlacementOperations();
+    this._deletePlacements(kittyId, placementId);
+    if (!this._hasPlacements(kittyId)) {
+      this._deleteImageData(kittyId);
     }
-    this._kittyIdToStorageId.clear();
-    this._storageIdToKittyId.clear();
+  }
+
+  private _deletePlacements(kittyId: number, placementId?: number): void {
+    if (placementId !== undefined && placementId > 0) {
+      const storageId = this._namedPlacements.get(kittyId)?.get(placementId);
+      if (storageId !== undefined) {
+        this._storage.deleteImage(storageId);
+      }
+      return;
+    }
+
+    const storageIds = this._getPlacementStorageIds(kittyId);
+    if (storageIds.length) {
+      this._storage.deleteImages(storageIds);
+    }
+  }
+
+  private _deleteAllPlacements(): void {
+    const storageIds = [...this._storageIdToPlacement.keys()];
+    if (storageIds.length) {
+      this._storage.deleteImages(storageIds);
+    }
+  }
+
+  public get pixelCount(): number {
+    return this._decodedPixels;
+  }
+
+  public evict(pixels: number): number {
+    let freed = 0;
+    const candidates = [...this._images.values()]
+      .filter(image => image.decodedSource)
+      .sort((a, b) => a.lastDecodeUse - b.lastDecodeUse);
+    for (const image of candidates) {
+      if (freed >= pixels) {
+        break;
+      }
+      freed += image.decodedPixels;
+      this._dropDecodedSource(image);
+    }
+    return freed;
+  }
+
+  public clear(): void {
+    for (const image of this._images.values()) {
+      this._dropDecodedSource(image);
+    }
   }
 
   public get images(): ReadonlyMap<number, IKittyImageData> {
@@ -135,20 +304,72 @@ export class KittyImageStorage implements IDisposable {
   }
 
   public get kittyIdToStorageId(): ReadonlyMap<number, number> {
-    return this._kittyIdToStorageId;
+    const result = new Map<number, number>();
+    for (const [kittyId, placements] of this._namedPlacements) {
+      const storageId = placements.values().next().value;
+      if (storageId !== undefined) {
+        result.set(kittyId, storageId);
+      }
+    }
+    for (const [kittyId, placements] of this._anonymousPlacements) {
+      if (result.has(kittyId)) {
+        continue;
+      }
+      const storageId = placements.values().next().value;
+      if (storageId !== undefined) {
+        result.set(kittyId, storageId);
+      }
+    }
+    return result;
   }
 
   public get lastImageId(): number {
     return this._nextImageId - 1;
   }
 
+  private _getPlacementStorageIds(kittyId: number): number[] {
+    return [
+      ...this._namedPlacements.get(kittyId)?.values() ?? [],
+      ...this._anonymousPlacements.get(kittyId)?.values() ?? []
+    ];
+  }
+
+  private _deleteImageData(kittyId: number): void {
+    const image = this._images.get(kittyId);
+    if (!image) {
+      return;
+    }
+    this._dropDecodedSource(image);
+    this._images.delete(kittyId);
+  }
+
+  private _hasPlacements(kittyId: number): boolean {
+    return !!this._namedPlacements.get(kittyId)?.size ||
+      !!this._anonymousPlacements.get(kittyId)?.size;
+  }
+
+  private _invalidatePlacementOperations(): void {
+    this._operationGeneration++;
+  }
+
+  private _dropDecodedSource(image: IStoredKittyImage): void {
+    image.decodeGeneration++;
+    image.decodePromise = undefined;
+    if (image.decodedSource) {
+      image.decodedSource.close();
+      image.decodedSource = undefined;
+      this._decodedPixels -= image.decodedPixels;
+    }
+    image.decodedPixels = 0;
+  }
+
   private _evictUndisplayedImages(): void {
     for (const [kittyId] of this._images) {
-      if (this._images.size <= KittyImageStorage._maxStoredImages / 2) {
+      if (this._images.size <= Constants.MAX_STORED_IMAGES / 2) {
         break;
       }
-      if (!this._kittyIdToStorageId.has(kittyId)) {
-        this._images.delete(kittyId);
+      if (!this._namedPlacements.has(kittyId) && !this._anonymousPlacements.has(kittyId)) {
+        this._deleteImageData(kittyId);
       }
     }
   }

--- a/addons/addon-image/src/kitty/KittyImageStorage.ts
+++ b/addons/addon-image/src/kitty/KittyImageStorage.ts
@@ -9,6 +9,7 @@ import { ImageLayer, IAddImageOpts } from '../Types';
 import { IKittyImageData } from './KittyGraphicsTypes';
 
 interface IStoredKittyImage extends IKittyImageData {
+  hasClientId: boolean;
   decodedSource?: ImageBitmap;
   decodePromise?: Promise<ImageBitmap>;
   decodedPixels: number;
@@ -31,7 +32,8 @@ const enum Constants {
 // Displayed placements are tracked independently by (image id, placement id);
 // omitted/zero placement ids are anonymous and additive.
 export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
-  private _nextImageId = 1;
+  // Keep id-less images outside the valid positive client ID namespace.
+  private _nextInternalImageId = -1;
   private _decodeUseSequence = 0;
   private _decodedPixels = 0;
   private _operationGeneration = 0;
@@ -63,6 +65,7 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
         this._anonymousPlacements.delete(placement.imageId);
       }
     }
+    this.releaseUnreferencedImage(placement.imageId);
   };
   private _addImageOpts: IAddImageOpts = { scrolling: true, layer: 'top', zIndex: 0, cursorPos: 'iip' };
 
@@ -82,7 +85,7 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
     this._invalidatePlacementOperations();
     this._deleteAllPlacements();
     this.clear();
-    this._nextImageId = 1;
+    this._nextInternalImageId = -1;
     this._images.clear();
     this._namedPlacements.clear();
     this._anonymousPlacements.clear();
@@ -104,7 +107,7 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
 
   public storeImage(id: number | undefined, imageData: Omit<IKittyImageData, 'id'>): number {
     this._invalidatePlacementOperations();
-    const imageId = id ?? this._nextImageId++;
+    const imageId = id ?? this._nextInternalImageId--;
 
     this._deletePlacements(imageId);
     if (this._images.has(imageId)) {
@@ -126,6 +129,7 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
     this._images.set(imageId, {
       ...imageData,
       id: imageId,
+      hasClientId: id !== undefined,
       decodedPixels: 0,
       lastDecodeUse: 0,
       decodeGeneration: 0
@@ -226,6 +230,12 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
     this._invalidatePlacementOperations();
     const storageIds = new Set<number>();
     const kittyIds = new Set<number>();
+    for (const [storageId, placement] of this._storageIdToPlacement) {
+      storageIds.add(storageId);
+      kittyIds.add(placement.imageId);
+    }
+    this._storage.reconcileImageCellIndexes(storageIds);
+    storageIds.clear();
     for (const storageId of this._storage.getVisibleImageStorageIds()) {
       const placement = this._storageIdToPlacement.get(storageId);
       if (placement) {
@@ -329,8 +339,11 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
     return result;
   }
 
-  public get lastImageId(): number {
-    return this._nextImageId - 1;
+  public releaseUnreferencedImage(kittyId: number): void {
+    const image = this._images.get(kittyId);
+    if (image && !image.hasClientId && !this._hasPlacements(kittyId)) {
+      this._deleteImageData(kittyId);
+    }
   }
 
   private _getPlacementStorageIds(kittyId: number): number[] {

--- a/addons/addon-image/src/kitty/KittyImageStorage.ts
+++ b/addons/addon-image/src/kitty/KittyImageStorage.ts
@@ -118,6 +118,7 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
         if (oldestImageId === undefined) {
           break;
         }
+        this._deletePlacements(oldestImageId);
         this._deleteImageData(oldestImageId);
       }
     }
@@ -246,25 +247,30 @@ export class KittyImageStorage implements IDisposable, IImageStoragePixelCache {
 
   public deleteImage(kittyId: number, placementId?: number): void {
     this._invalidatePlacementOperations();
-    this._deletePlacements(kittyId, placementId);
+    const placementDeleted = this._deletePlacements(kittyId, placementId);
+    if (placementId !== undefined && placementId > 0 && !placementDeleted) {
+      return;
+    }
     if (!this._hasPlacements(kittyId)) {
       this._deleteImageData(kittyId);
     }
   }
 
-  private _deletePlacements(kittyId: number, placementId?: number): void {
+  private _deletePlacements(kittyId: number, placementId?: number): boolean {
     if (placementId !== undefined && placementId > 0) {
       const storageId = this._namedPlacements.get(kittyId)?.get(placementId);
       if (storageId !== undefined) {
         this._storage.deleteImage(storageId);
+        return true;
       }
-      return;
+      return false;
     }
 
     const storageIds = this._getPlacementStorageIds(kittyId);
     if (storageIds.length) {
       this._storage.deleteImages(storageIds);
     }
+    return storageIds.length > 0;
   }
 
   private _deleteAllPlacements(): void {

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -94,10 +94,6 @@ const RAW_RGBA_5X1 = Buffer.from([
   255, 0, 255, 255
 ]).toString('base64');
 
-const enum TestBgFlags {
-  HAS_EXTENDED = 0x10000000
-}
-
 let ctx: ITestContext;
 test.beforeAll(async ({ browser }) => {
   ctx = await createTestContext(browser);
@@ -136,6 +132,18 @@ test.describe('Kitty Graphics Protocol', () => {
       await timeout(100);
       strictEqual(await getImageStorageLength(), 1);
       deepStrictEqual(await getOrigSize(1), [3, 1]);
+    });
+
+    test('a=T acknowledgement includes the placement id', async () => {
+      await ctx.page.evaluate(() => {
+        (window as any).kittyResponse = '';
+        (window as any).term.onData((data: string) => { (window as any).kittyResponse = data; });
+      });
+
+      await ctx.proxy.write(`\x1b_Ga=T,f=100,i=31,p=42;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyResponse'), '\x1b_Gi=31,p=42;OK\x1b\\');
     });
 
     test('transmit only (a=t) does not display but stores in handler', async () => {
@@ -382,19 +390,17 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').pendingTransmissions.size`), 0);
     });
 
-    test('delete by id only aborts targeted upload, not others', async () => {
+    test('unsupported delete selector aborts an in-flight chunked upload', async () => {
       const half = Math.floor(KITTY_BLACK_1X1_BASE64.length / 2);
       const part1 = KITTY_BLACK_1X1_BASE64.substring(0, half);
 
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=55,m=1;${part1}\x1b\\`);
-      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=56,m=1;${part1}\x1b\\`);
-      await timeout(50);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').pendingTransmissions.size`), 2);
-
-      await ctx.proxy.write(`\x1b_Ga=d,d=i,i=55\x1b\\`);
       await timeout(50);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').pendingTransmissions.size`), 1);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').pendingTransmissions.has(56)`), true);
+
+      await ctx.proxy.write(`\x1b_Ga=d,d=c\x1b\\`);
+      await timeout(50);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').pendingTransmissions.size`), 0);
     });
 
     test('delete all aborts in-flight chunked upload', async () => {
@@ -697,17 +703,17 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
     });
 
-    test('a=T sends EINVAL on decode error when id is specified', async () => {
+    test('a=T sends EINVAL with placement id on decode error', async () => {
       await ctx.page.evaluate(() => {
         (window as any).kittyResponse = '';
         (window as any).term.onData((data: string) => { (window as any).kittyResponse = data; });
       });
 
-      await ctx.proxy.write('\x1b_Gi=120,a=T,f=100;!!!invalid!!!\x1b\\');
+      await ctx.proxy.write('\x1b_Gi=120,p=42,a=T,f=100;!!!invalid!!!\x1b\\');
       await timeout(100);
 
       const response = await ctx.page.evaluate('window.kittyResponse');
-      strictEqual(response, '\x1b_Gi=120;EINVAL:invalid base64 data\x1b\\');
+      strictEqual(response, '\x1b_Gi=120,p=42;EINVAL:invalid base64 data\x1b\\');
     });
 
     test('a=T sends no response on decode error without id', async () => {
@@ -952,17 +958,17 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(response, '');
     });
 
-    test('transmit+display rejects t=f with id (EINVAL response)', async () => {
+    test('transmit+display rejects t=f with placement id (EINVAL response)', async () => {
       await ctx.page.evaluate(() => {
         (window as any).kittyResponse = '';
         (window as any).term.onData((data: string) => { (window as any).kittyResponse = data; });
       });
 
-      await ctx.proxy.write(`\x1b_Gi=310,a=T,t=f,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write(`\x1b_Gi=310,p=43,a=T,t=f,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await timeout(100);
 
       const response: string = await ctx.page.evaluate('window.kittyResponse');
-      strictEqual(response.startsWith('\x1b_Gi=310;EINVAL:'), true);
+      strictEqual(response.startsWith('\x1b_Gi=310,p=43;EINVAL:'), true);
     });
 
     test('transmit+display rejects t=s with id (EINVAL response)', async () => {
@@ -1514,43 +1520,8 @@ test.describe('Kitty Graphics Protocol', () => {
       deepStrictEqual(await getRenderedViewportPixel(0, 4), [0, 0, 0, 255]);
     });
 
-    test('deletes visible placement cells whose extended flag was cleared by text', async () => {
-      await ctx.page.evaluate(`
-        window.imageAddon.dispose();
-        window.imageAddon = new ImageAddon({ showPlaceholder: true });
-        window.term.loadAddon(window.imageAddon);
-      `);
-      await ctx.proxy.write(`\x1b_Ga=t,f=32,s=1,v=1,i=942,t=d,q=2,m=0;${RAW_RGBA_1X1_RED}\x1b\\`);
-      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=942,p=1,c=10,r=5,C=1,q=2\x1b\\');
-      await timeout(100);
-      const storageId = await getViewportCellImageId(0, 0);
-      ok(storageId > 0);
-
-      await ctx.proxy.write(Array.from({ length: 5 }, (_, row) => `\x1b[${row + 1};1Hxxxxxxxxxx`).join(''));
-      await timeout(100);
-
-      strictEqual(await countFlaglessBufferImageRefs(storageId), 50);
-      deepStrictEqual(await getRenderedViewportPixel(0, 0), [255, 0, 0, 255]);
-      await ctx.page.evaluate(() => (window as any).imageAddon._storage.viewportResize({ cols: 79, rows: 24 }));
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._storage._images.has(${storageId})`), true);
-
-      await ctx.proxy.write('\x1b_Ga=d,d=a,q=2\x1b\\');
-      await timeout(100);
-
-      strictEqual(await getImageStorageLength(), 0);
-      strictEqual(await countBufferImageRefs(storageId), 0);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(942)`), true);
-      strictEqual(await getRenderedViewportPixel(0, 0), null);
-
-      await ctx.proxy.write('\x1b_Ga=d,d=I,i=942,q=2\x1b\\');
-      await timeout(100);
-
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(942)`), false);
-      strictEqual(await countDanglingBufferImageRefs(), 0);
-    });
-
     for (const [selector, imageId] of [['a', 930], ['A', 931]] as const) {
-      test(`d=${selector} deletes only visible placements and preserves scrollback references`, async () => {
+      test(`d=${selector} deletes the live screen when the viewport is in scrollback`, async () => {
         await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${imageId};${KITTY_BLACK_1X1_BASE64}\x1b\\`);
         await ctx.proxy.write(`\x1b[1;1H\x1b_Ga=p,i=${imageId},p=1,c=1,r=1,C=1\x1b\\`);
         await ctx.page.evaluate(() => new Promise<void>(resolve => {
@@ -1559,8 +1530,13 @@ test.describe('Kitty Graphics Protocol', () => {
         }));
         await ctx.proxy.write(`\x1b_Ga=p,i=${imageId},p=2,c=1,r=1,C=1\x1b\\`);
         await timeout(100);
+        await ctx.page.evaluate(() => (window as any).term.scrollToTop());
 
         strictEqual(await getImageStorageLength(), 2);
+        strictEqual(await ctx.page.evaluate(() => {
+          const buffer = (window as any).term._core.buffer;
+          return buffer.ydisp < buffer.ybase;
+        }), true);
         ok(await getAbsoluteCellImageId(0, 0) > 0);
         ok(await getViewportCellImageId(0, 23) > 0);
 
@@ -1653,6 +1629,18 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(934)`), false);
     });
 
+    test('uppercase targeted delete with an unmatched placement preserves image data', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=935;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b_Ga=d,d=I,i=935,p=99\x1b\\');
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(935)`), true);
+
+      await ctx.proxy.write('\x1b_Ga=p,i=935,p=1,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 1);
+    });
+
     test('uppercase delete frees matching payloads and every placement', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=908;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=909;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
@@ -1714,7 +1702,7 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await getImageStorageLength(), 1);
     });
 
-    test('caps retained image data when every image has a placement', async () => {
+    test('hard image cap evicts placements with their payload data', async () => {
       let sequence = '';
       for (let id = 1000; id <= 1256; id++) {
         sequence += `\x1b_Ga=T,f=32,s=1,v=1,i=${id},p=1,C=1;${RAW_RGBA_1X1_RED}\x1b\\\n`;
@@ -1725,8 +1713,8 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 256);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1000)`), false);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1256)`), true);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(1000)`), true);
-      ok(await getAbsoluteCellImageId(0, 0) > 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(1000)`), false);
+      strictEqual(await getAbsoluteCellImageId(0, 0), -1);
 
       await ctx.proxy.write(`\x1b_Ga=t,f=32,s=1,v=1,i=1000;${RAW_RGBA_1X1_WHITE}\x1b\\`);
       await timeout(100);
@@ -2712,6 +2700,34 @@ test.describe('Kitty Graphics Protocol', () => {
       await ctx.page.evaluate('window.term.resize(80, 24)');
     });
 
+    test('memory limit eviction keeps a negative-z placeholder below text', async () => {
+      await ctx.page.evaluate(`
+        window.term.reset();
+        window.imageAddon?.dispose();
+        window.term.resize(80, 48);
+        window.imageAddon = new ImageAddon({ showPlaceholder: true, storageLimit: 0.5 });
+        window.term.loadAddon(window.imageAddon);
+      `);
+
+      await ctx.proxy.write(`\x1b[1;1H\x1b_Ga=T,f=100,i=67,z=-1,C=1;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+      await timeout(100);
+      const storageId = await ctx.page.evaluate<number | undefined>(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(67)`);
+      ok(storageId !== undefined);
+
+      const positions = [[30, 1], [1, 9], [30, 9], [1, 17], [30, 17], [1, 25]];
+      for (let n = 0; n < positions.length; n++) {
+        const [col, row] = positions[n];
+        await ctx.proxy.write(`\x1b[${row};${col}H\x1b_Ga=T,f=100,i=${68 + n},z=1,C=1;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+      }
+      await pollFor(ctx.page, `window.imageAddon._storage._images.has(${storageId})`, false);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._storage._evictedImages.get(${storageId}).layer`), 'bottom');
+      const bottomPixel = await getRenderedLayerPixel('bottom', 0, 0);
+      ok(bottomPixel && bottomPixel[3] > 0);
+      deepStrictEqual(await getRenderedLayerPixel('top', 0, 0), [0, 0, 0, 0]);
+    });
+
     test('deletes a reflowed placement when only its evicted placeholder remains', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=71;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
       await ctx.proxy.write('\x1b_Ga=p,i=71,p=1,c=30,r=1,C=1\x1b\\');
@@ -2925,45 +2941,6 @@ async function countBufferImageRefs(imageId: number): Promise<number> {
   }, imageId);
 }
 
-async function countFlaglessBufferImageRefs(imageId: number): Promise<number> {
-  return ctx.page.evaluate((imageId: number) => {
-    const buffers = (window as any).term._core.buffers;
-    let count = 0;
-    for (const buffer of [buffers.normal, buffers.alt]) {
-      for (let row = 0; row < buffer.lines.length; row++) {
-        const line = buffer.lines.get(row);
-        for (const key of Object.keys(line?._extendedAttrs ?? {})) {
-          const column = Number(key);
-          if (line._extendedAttrs[column]?.imageId === imageId && !(line.getBg(column) & TestBgFlags.HAS_EXTENDED)) {
-            count++;
-          }
-        }
-      }
-    }
-    return count;
-  }, imageId);
-}
-
-async function countDanglingBufferImageRefs(): Promise<number> {
-  return ctx.page.evaluate(() => {
-    const term = (window as any).term;
-    const storage = (window as any).imageAddon._storage;
-    let count = 0;
-    for (const buffer of [term._core.buffers.normal, term._core.buffers.alt]) {
-      for (let row = 0; row < buffer.lines.length; row++) {
-        const line = buffer.lines.get(row);
-        for (const key of Object.keys(line?._extendedAttrs ?? {})) {
-          const imageId = line._extendedAttrs[Number(key)]?.imageId;
-          if (imageId !== undefined && imageId !== -1 && !storage._images.has(imageId) && !storage._evictedImages.has(imageId)) {
-            count++;
-          }
-        }
-      }
-    }
-    return count;
-  });
-}
-
 async function countActiveBufferImageRefs(imageId: number): Promise<number> {
   return (await getActiveBufferImageRefs(imageId)).length;
 }
@@ -3004,6 +2981,23 @@ async function getRenderedViewportPixels(col: number, row: number, x: number, y:
       height
     ).data);
   }, [col, row, x, y, width, height]);
+}
+
+async function getRenderedLayerPixel(layer: 'top' | 'bottom', col: number, row: number): Promise<number[] | null> {
+  return ctx.page.evaluate(({ layer, col, row }: { layer: 'top' | 'bottom', col: number, row: number }) => {
+    const canvas = document.querySelector(`.xterm-image-layer-${layer}`) as HTMLCanvasElement | null;
+    const dimensions = (window as any).term._core._renderService.dimensions.css.cell;
+    const context = canvas?.getContext('2d');
+    if (!context) {
+      return null;
+    }
+    return Array.from(context.getImageData(
+      Math.floor(col * dimensions.width),
+      Math.floor(row * dimensions.height),
+      1,
+      1
+    ).data);
+  }, { layer, col, row });
 }
 
 async function startBlobDecodeCounter(): Promise<void> {

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -146,8 +146,8 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate('window.kittyResponse'), '\x1b_Gi=31,p=42;OK\x1b\\');
     });
 
-    test('transmit only (a=t) does not display but stores in handler', async () => {
-      const seq = `\x1b_Ga=t,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`;
+    test('transmit only (a=t) does not display but stores an addressable image', async () => {
+      const seq = `\x1b_Ga=t,f=100,i=41;${KITTY_BLACK_1X1_BASE64}\x1b\\`;
       await ctx.proxy.write(seq);
       await timeout(100);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
@@ -161,20 +161,18 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1)`), false);
     });
 
-    test('assigns auto-incrementing IDs when not specified', async () => {
+    test('discards id-less transmit-only payloads', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write(`\x1b_Ga=t,f=100;${KITTY_RGB_3X1_BASE64}\x1b\\`);
       await timeout(100);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 2);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1)`), true);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(2)`), true);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
     });
 
     test('defaults to transmit action when action is omitted', async () => {
-      const seq = `\x1b_Gf=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`;
+      const seq = `\x1b_Gf=100,i=42;${KITTY_BLACK_1X1_BASE64}\x1b\\`;
       await ctx.proxy.write(seq);
       await timeout(100);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(42)`), true);
     });
 
     test('ignores command when action is empty string', async () => {
@@ -662,6 +660,19 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(response, '\x1b_Gi=100;EINVAL:cannot specify both i and I keys\x1b\\');
     });
 
+    test('rejects image ids outside the unsigned 32-bit range', async () => {
+      await ctx.page.evaluate(() => {
+        (window as any).kittyResponse = '';
+        (window as any).term.onData((data: string) => { (window as any).kittyResponse = data; });
+      });
+
+      await ctx.proxy.write(`\x1b_Gi=-1,a=t,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyResponse'), '\x1b_Gi=-1;EINVAL:invalid image id\x1b\\');
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+    });
+
     test('responds with EINVAL for i+I conflict even without payload', async () => {
       await ctx.page.evaluate(() => {
         (window as any).kittyResponse = '';
@@ -726,6 +737,23 @@ test.describe('Kitty Graphics Protocol', () => {
       await timeout(100);
 
       strictEqual(await ctx.page.evaluate('window.kittyGotResponse'), false);
+    });
+
+    test('a=T sends EINVAL with placement id when image data is missing', async () => {
+      await ctx.proxy.write('\x1b[4;5H');
+      const cursorBefore = await getCursor();
+      await ctx.page.evaluate(() => {
+        (window as any).kittyResponse = '';
+        (window as any).term.onData((data: string) => { (window as any).kittyResponse = data; });
+      });
+
+      await ctx.proxy.write('\x1b_Gi=121,p=43,a=T,f=100;\x1b\\');
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate('window.kittyResponse'), '\x1b_Gi=121,p=43;EINVAL:missing image data\x1b\\');
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(121)`), false);
+      deepStrictEqual(await getCursor(), cursorBefore);
     });
 
     test('a=T sends EINVAL when raw pixel render fails (missing dimensions)', async () => {
@@ -958,7 +986,12 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(response, '');
     });
 
-    test('transmit+display rejects t=f with placement id (EINVAL response)', async () => {
+    test('failed transmit+display does not reuse an older image with the same id', async () => {
+      await ctx.proxy.write(`\x1b_Gi=310,a=t,q=2,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[4;5H');
+      await timeout(100);
+      const cursorBefore = await getCursor();
+
       await ctx.page.evaluate(() => {
         (window as any).kittyResponse = '';
         (window as any).term.onData((data: string) => { (window as any).kittyResponse = data; });
@@ -968,7 +1001,11 @@ test.describe('Kitty Graphics Protocol', () => {
       await timeout(100);
 
       const response: string = await ctx.page.evaluate('window.kittyResponse');
-      strictEqual(response.startsWith('\x1b_Gi=310,p=43;EINVAL:'), true);
+      strictEqual(response, '\x1b_Gi=310,p=43;EINVAL:unsupported transmission medium\x1b\\');
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(310)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(310)`), true);
+      deepStrictEqual(await getCursor(), cursorBefore);
     });
 
     test('transmit+display rejects t=s with id (EINVAL response)', async () => {
@@ -1473,6 +1510,78 @@ test.describe('Kitty Graphics Protocol', () => {
         await getViewportCellImageId(0, 4)
       ];
       strictEqual(new Set(storageIds).size, 3);
+    });
+
+    test('ignores placement id for ID-zero transmissions and releases payloads after deletion', async () => {
+      for (const imageIdControl of ['', ',i=0']) {
+        await ctx.proxy.write(`\x1b[1;1H\x1b_Ga=T${imageIdControl},p=7,c=1,r=1,C=1,f=100;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+        await timeout(100);
+
+        const placementState = await ctx.page.evaluate(() => {
+          const storage = (window as any).imageAddon._handlers.get('kitty')._kittyStorage;
+          const placement = [...storage._storageIdToPlacement.values()][0];
+          return {
+            namedPlacements: storage._namedPlacements.size,
+            anonymousPlacements: storage._anonymousPlacements.size,
+            placementId: placement?.placementId
+          };
+        });
+        deepStrictEqual(placementState, {
+          namedPlacements: 0,
+          anonymousPlacements: 1,
+          placementId: 0
+        });
+        strictEqual(await getImageStorageLength(), 1);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
+
+        await ctx.proxy.write('\x1b_Ga=d,d=a\x1b\\');
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 0);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyStorage._storageIdToPlacement.size`), 0);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+      }
+    });
+
+    test('d=A removes a placement and payload after all placement cells are overwritten', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,q=2,f=100,i=908;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,q=2,i=908,p=1,c=2,r=1,C=1\x1b\\');
+      await timeout(100);
+      const storageId = await ctx.page.evaluate<number | undefined>(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(908)`);
+      ok(storageId !== undefined);
+
+      await ctx.proxy.write('\x1b[1;1H##');
+      await timeout(100);
+      strictEqual(await hasTileAtBufferCell(0, 0), false);
+      strictEqual(await hasTileAtBufferCell(1, 0), false);
+      strictEqual(await getImageStorageLength(), 1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(908)`), true);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=A\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(908)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(908)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyStorage._storageIdToPlacement.size`), 0);
+    });
+
+    test('d=A ignores detached buffer lines when reconciling overwritten placements', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,q=2,f=100,i=909;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,q=2,i=909,p=1,c=1,r=2,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write('\x1b[1;1H\x1b[1M#');
+      await timeout(100);
+      strictEqual(await hasTileAtBufferCell(0, 0), false);
+      strictEqual(await getImageStorageLength(), 1);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=A\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(909)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(909)`), false);
     });
 
     test('lowercase delete by image removes all placements but preserves payload', async () => {
@@ -2048,9 +2157,9 @@ test.describe('Kitty Graphics Protocol', () => {
       });
 
       test('transmit only (a=t) stores 200x100 image without display', async () => {
-        await ctx.proxy.write(`\x1b_Ga=t,f=100;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=401;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
         await timeout(200);
-        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(401)`), true);
       });
 
       test('stores with specified image ID', async () => {

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -44,6 +44,7 @@ const KITTY_BLACK_1X1_BYTES = Array.from(readFileSync('./addons/addon-image/fixt
 const KITTY_RGB_3X1_BASE64 = readFileSync('./addons/addon-image/fixture/kitty/rgb-3x1.png').toString('base64');
 const KITTY_MULTICOLOR_200X100_BASE64 = readFileSync('./addons/addon-image/fixture/kitty/multicolor-200x100.png').toString('base64');
 const KITTY_MULTICOLOR_200X100_BYTES = Array.from(readFileSync('./addons/addon-image/fixture/kitty/multicolor-200x100.png'));
+const IIP_W3C_PNG = readFileSync('./addons/addon-image/fixture/iip/w3c_png.iip', { encoding: 'utf-8' });
 
 // Raw RGB pixel data (f=24): 3 bytes per pixel, no header — requires s= and v=
 const RAW_RGB_1X1_BLACK = Buffer.from([0, 0, 0]).toString('base64');
@@ -106,7 +107,6 @@ test.describe('Kitty Graphics Protocol', () => {
   // TODO: Add tests for animation frames
   // TODO: Add performance tests for streaming large images
   // TODO: Implement cursor movement per Kitty spec - cursor should move by cols/rows after placement (unless C=1)
-  // TODO: Distinguish lowercase delete selectors (placement only) from uppercase (placement + free data)
 
   test.beforeEach(async ({}, testInfo) => {
     await ctx.page.evaluate(`
@@ -344,17 +344,17 @@ test.describe('Kitty Graphics Protocol', () => {
   });
 
   test.describe('Delete commands', () => {
-    test('delete command (a=d,d=i) removes specific image by id', async () => {
+    test('delete command (a=d,d=i) preserves transmitted image data', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=10;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await timeout(50);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
 
       await ctx.proxy.write(`\x1b_Ga=d,d=i,i=10\x1b\\`);
       await timeout(50);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
     });
 
-    test('delete command (a=d) removes all images when no id specified', async () => {
+    test('delete command (a=d) preserves all transmitted image data', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=1;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=2;${KITTY_RGB_3X1_BASE64}\x1b\\`);
       await timeout(50);
@@ -362,7 +362,7 @@ test.describe('Kitty Graphics Protocol', () => {
 
       await ctx.proxy.write(`\x1b_Ga=d\x1b\\`);
       await timeout(50);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 2);
     });
 
     test('delete by id aborts in-flight chunked upload', async () => {
@@ -407,7 +407,7 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').pendingTransmissions.size`), 0);
     });
 
-    test('d=i selector deletes specific image by id', async () => {
+    test('d=i selector preserves specific image data', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=80;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=81;${KITTY_RGB_3X1_BASE64}\x1b\\`);
       await timeout(50);
@@ -415,7 +415,8 @@ test.describe('Kitty Graphics Protocol', () => {
 
       await ctx.proxy.write(`\x1b_Ga=d,d=i,i=80\x1b\\`);
       await timeout(50);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 2);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(80)`), true);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(81)`), true);
     });
 
@@ -431,7 +432,7 @@ test.describe('Kitty Graphics Protocol', () => {
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(83)`), true);
     });
 
-    test('d=a selector deletes all images', async () => {
+    test('d=a selector preserves all image data', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=84;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=85;${KITTY_RGB_3X1_BASE64}\x1b\\`);
       await timeout(50);
@@ -439,10 +440,10 @@ test.describe('Kitty Graphics Protocol', () => {
 
       await ctx.proxy.write(`\x1b_Ga=d,d=a\x1b\\`);
       await timeout(50);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 2);
     });
 
-    test('d=A selector deletes all images (uppercase)', async () => {
+    test('d=A selector preserves transmitted data without visible placements', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=86;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=87;${KITTY_RGB_3X1_BASE64}\x1b\\`);
       await timeout(50);
@@ -450,7 +451,7 @@ test.describe('Kitty Graphics Protocol', () => {
 
       await ctx.proxy.write(`\x1b_Ga=d,d=A\x1b\\`);
       await timeout(50);
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 2);
     });
 
     test('d=a selector also removes displayed images from storage', async () => {
@@ -1309,6 +1310,487 @@ test.describe('Kitty Graphics Protocol', () => {
     });
   });
 
+  test.describe('Placement identity and lifetime', () => {
+    test('tracks named sibling placements and decodes their shared source once', async () => {
+      await startBlobDecodeCounter();
+      try {
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=900;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+        await timeout(100);
+
+        await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=900,p=10,c=1,r=1,C=1\x1b\\');
+        await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=900,p=20,c=1,r=1,C=1\x1b\\');
+        await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=900,p=30,c=1,r=1,C=1\x1b\\');
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 3);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
+        const storageIds = [
+          await getViewportCellImageId(0, 0),
+          await getViewportCellImageId(0, 2),
+          await getViewportCellImageId(0, 4)
+        ];
+        strictEqual(new Set(storageIds).size, 3);
+        deepStrictEqual(await getRenderedViewportPixel(0, 0), [0, 0, 0, 255]);
+        deepStrictEqual(await getRenderedViewportPixel(0, 2), [0, 0, 0, 255]);
+        deepStrictEqual(await getRenderedViewportPixel(0, 4), [0, 0, 0, 255]);
+        strictEqual(await getBlobDecodeCount(), 1);
+      } finally {
+        await stopBlobDecodeCounter();
+      }
+    });
+
+    test('renders independently cropped placements from one decoded source', async () => {
+      await startBlobDecodeCounter();
+      try {
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=912;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+        await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=912,p=1,x=0,y=0,w=20,h=50,c=1,r=1,C=1\x1b\\');
+        await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=912,p=2,x=20,y=0,w=20,h=50,c=1,r=1,C=1\x1b\\');
+        await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=912,p=3,x=0,y=50,w=20,h=50,c=1,r=1,C=1\x1b\\');
+        await ctx.proxy.write('\x1b[7;1H\x1b_Ga=p,i=912,p=4,x=180,y=50,w=20,h=50,c=1,r=1,C=1\x1b\\');
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 4);
+        const storageIds = [
+          await getViewportCellImageId(0, 0),
+          await getViewportCellImageId(0, 2),
+          await getViewportCellImageId(0, 4),
+          await getViewportCellImageId(0, 6)
+        ];
+        strictEqual(new Set(storageIds).size, 4);
+        deepStrictEqual(await getRenderedViewportPixel(0, 0), [255, 0, 0, 255]);
+        deepStrictEqual(await getRenderedViewportPixel(0, 2), [255, 128, 0, 255]);
+        deepStrictEqual(await getRenderedViewportPixel(0, 4), [255, 192, 203, 255]);
+        deepStrictEqual(await getRenderedViewportPixel(0, 6), [255, 255, 255, 255]);
+        strictEqual(await getBlobDecodeCount(), 1);
+      } finally {
+        await stopBlobDecodeCounter();
+      }
+    });
+
+    test('replaces a named placement with cleanup proportional to its cells', async () => {
+      await ctx.page.evaluate(() => new Promise<void>(resolve => {
+        (window as any).term.write('\n'.repeat(2000), resolve);
+      }));
+
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=901;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=901,p=5,c=2,r=1,C=1\x1b\\');
+      await timeout(100);
+      ok(await getViewportCellImageId(0, 0) > 0);
+      ok(await getViewportCellImageId(1, 0) > 0);
+
+      await ctx.page.evaluate(() => {
+        const storage = (window as any).imageAddon._storage;
+        const original = storage.deleteImage.bind(storage);
+        (window as any)._kittyCleanupCounts = [];
+        storage.deleteImage = (id: number) => {
+          const count = original(id);
+          (window as any)._kittyCleanupCounts.push(count);
+          return count;
+        };
+      });
+
+      await ctx.proxy.write('\x1b[4;5H\x1b_Ga=p,i=901,p=5,c=3,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 1);
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      strictEqual(await getViewportCellImageId(1, 0), -1);
+      ok(await getViewportCellImageId(4, 3) > 0);
+      ok(await getViewportCellImageId(5, 3) > 0);
+      ok(await getViewportCellImageId(6, 3) > 0);
+      deepStrictEqual(await getRenderedViewportPixel(0, 0), [0, 0, 0, 0]);
+      deepStrictEqual(await getRenderedViewportPixel(4, 3), [0, 0, 0, 255]);
+      deepStrictEqual(await ctx.page.evaluate('window._kittyCleanupCounts'), [2]);
+    });
+
+    test('deletes only the targeted named placement and keeps image data reusable', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=902;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=902,p=10,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=902,p=20,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=902,p=30,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=i,i=902,p=20\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 2);
+      ok(await getViewportCellImageId(0, 0) > 0);
+      strictEqual(await getViewportCellImageId(0, 2), -1);
+      ok(await getViewportCellImageId(0, 4) > 0);
+      deepStrictEqual(await getRenderedViewportPixel(0, 2), [0, 0, 0, 0]);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(902)`), true);
+
+      await ctx.proxy.write('\x1b[7;1H\x1b_Ga=p,i=902,p=20,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 3);
+      deepStrictEqual(await getRenderedViewportPixel(0, 6), [0, 0, 0, 255]);
+    });
+
+    for (const [name, imageId, placementColumn, shift, shiftedColumns] of [
+      ['ICH', 940, 1, '\x1b[1;1H\x1b[1@', [1, 2]],
+      ['DCH', 941, 2, '\x1b[1;1H\x1b[1P', [0, 1]]
+    ] as const) {
+      test(`clears placement cells shifted by ${name}`, async () => {
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${imageId};${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+        await ctx.proxy.write(`\x1b[1;${placementColumn}H\x1b_Ga=p,i=${imageId},p=1,c=2,r=1,C=1\x1b\\`);
+        await ctx.proxy.write(shift);
+        await timeout(100);
+
+        ok(await getViewportCellImageId(shiftedColumns[0], 0) > 0);
+        ok(await getViewportCellImageId(shiftedColumns[1], 0) > 0);
+
+        await ctx.proxy.write(`\x1b_Ga=d,d=i,i=${imageId},p=1\x1b\\`);
+        await timeout(100);
+
+        strictEqual(await getViewportCellImageId(shiftedColumns[0], 0), -1);
+        strictEqual(await getViewportCellImageId(shiftedColumns[1], 0), -1);
+        strictEqual(await getRenderedViewportPixel(shiftedColumns[0], 0), null);
+        strictEqual(await getRenderedViewportPixel(shiftedColumns[1], 0), null);
+      });
+    }
+
+    test('treats omitted and zero placement IDs as anonymous and additive', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=903;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=903,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=903,p=0,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=903,p=0,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 3);
+      const storageIds = [
+        await getViewportCellImageId(0, 0),
+        await getViewportCellImageId(0, 2),
+        await getViewportCellImageId(0, 4)
+      ];
+      strictEqual(new Set(storageIds).size, 3);
+    });
+
+    test('lowercase delete by image removes all placements but preserves payload', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=904;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=905;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=904,p=1,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=904,p=2,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=905,p=1,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=i,i=904\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 1);
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      strictEqual(await getViewportCellImageId(0, 2), -1);
+      ok(await getViewportCellImageId(0, 4) > 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(904)`), true);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(905)`), true);
+
+      await ctx.proxy.write('\x1b[7;1H\x1b_Ga=p,i=904,p=3,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 2);
+      deepStrictEqual(await getRenderedViewportPixel(0, 6), [0, 0, 0, 255]);
+    });
+
+    test('lowercase delete all preserves payloads for later placements', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=906;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=907;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=906,p=1,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=907,p=1,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=a\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      strictEqual(await getViewportCellImageId(0, 2), -1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 2);
+
+      await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=906,p=2,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 1);
+      deepStrictEqual(await getRenderedViewportPixel(0, 4), [0, 0, 0, 255]);
+    });
+
+    for (const [selector, imageId] of [['a', 930], ['A', 931]] as const) {
+      test(`d=${selector} deletes only visible placements and preserves scrollback references`, async () => {
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${imageId};${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+        await ctx.proxy.write(`\x1b[1;1H\x1b_Ga=p,i=${imageId},p=1,c=1,r=1,C=1\x1b\\`);
+        await ctx.page.evaluate(() => new Promise<void>(resolve => {
+          const term = (window as any).term;
+          term.write('\n'.repeat(term.rows + 5), resolve);
+        }));
+        await ctx.proxy.write(`\x1b_Ga=p,i=${imageId},p=2,c=1,r=1,C=1\x1b\\`);
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 2);
+        ok(await getAbsoluteCellImageId(0, 0) > 0);
+        ok(await getViewportCellImageId(0, 23) > 0);
+
+        await ctx.proxy.write(`\x1b_Ga=d,d=${selector}\x1b\\`);
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 1);
+        ok(await getAbsoluteCellImageId(0, 0) > 0);
+        strictEqual(await getViewportCellImageId(0, 23), -1);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(${imageId})`), true);
+      });
+    }
+
+    for (const [selector, imageId] of [['a', 932], ['A', 933]] as const) {
+      test(`d=${selector} affects only the active buffer's visible placements`, async () => {
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${imageId};${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+        await ctx.proxy.write(`\x1b[1;1H\x1b_Ga=p,i=${imageId},p=1,c=1,r=1,C=1\x1b\\`);
+        await ctx.proxy.write('\x1b[?1049h');
+        await ctx.proxy.write(`\x1b_Ga=p,i=${imageId},p=2,c=1,r=1,C=1\x1b\\`);
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 2);
+        ok(await getViewportCellImageId(0, 0) > 0);
+
+        await ctx.proxy.write(`\x1b_Ga=d,d=${selector}\x1b\\`);
+        await timeout(100);
+
+        strictEqual(await getImageStorageLength(), 1);
+        strictEqual(await getViewportCellImageId(0, 0), -1);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(${imageId})`), true);
+
+        await ctx.proxy.write('\x1b[?1049l');
+        await timeout(100);
+        ok(await getViewportCellImageId(0, 0) > 0);
+        deepStrictEqual(await getRenderedViewportPixel(0, 0), [0, 0, 0, 255]);
+      });
+    }
+
+    test('retains an alternate-buffer placement when rebuilding cell indexes', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=938;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[?1049h');
+      await ctx.proxy.write('\x1b_Ga=p,i=938,p=1,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      const storageId = await ctx.page.evaluate<number | undefined>(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(938)`);
+      ok(storageId !== undefined);
+      await ctx.page.evaluate(() => (window as any).imageAddon._storage.viewportResize({ cols: 79, rows: 24 }));
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._storage._images.has(${storageId})`), true);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(938)`), storageId);
+      strictEqual(await getViewportCellImageId(0, 0), storageId);
+      deepStrictEqual(await getRenderedViewportPixel(0, 0), [0, 0, 0, 255]);
+
+      await ctx.proxy.write('\x1b[?1049l');
+    });
+
+    test('d=a leaves visible placements from other image protocols intact', async () => {
+      await ctx.proxy.write(IIP_W3C_PNG);
+      await ctx.proxy.write(`\x1b[10;1H\x1b_Ga=T,f=100,i=939,C=1;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 2);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=a\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._storage._images.has(1)`), true);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(939)`), true);
+    });
+
+    test('uppercase targeted delete frees data only after the last placement', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=934;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=934,p=1,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=934,p=2,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=I,i=934,p=1\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 1);
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      ok(await getViewportCellImageId(0, 2) > 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(934)`), true);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=I,i=934,p=2\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await getViewportCellImageId(0, 2), -1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(934)`), false);
+    });
+
+    test('uppercase delete frees matching payloads and every placement', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=908;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=909;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=908,p=1,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=908,p=2,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=909,p=1,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=I,i=908\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 1);
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      strictEqual(await getViewportCellImageId(0, 2), -1);
+      ok(await getViewportCellImageId(0, 4) > 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(908)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(909)`), true);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=A\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 0);
+    });
+
+    test('retransmitting an image removes all old placements before reuse', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=910;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=910,p=1,c=1,r=1,C=1\x1b\\');
+      await ctx.proxy.write('\x1b[3;1H\x1b_Ga=p,i=910,p=2,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=910;${KITTY_RGB_3X1_BASE64}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      strictEqual(await getViewportCellImageId(0, 2), -1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(910)`), true);
+
+      await ctx.proxy.write('\x1b[5;1H\x1b_Ga=p,i=910,p=3,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      deepStrictEqual(await getRenderedViewportPixel(0, 4), [255, 0, 0, 255]);
+    });
+
+    test('keeps transmitted data reusable after its only placement leaves scrollback', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=911;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b_Ga=p,i=911,p=1,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 1);
+
+      await ctx.page.evaluate(() => new Promise<void>(resolve => {
+        const term = (window as any).term;
+        term.write('\n'.repeat(term.options.scrollback + term.rows + 10), resolve);
+      }));
+      await pollFor(ctx.page, 'window.imageAddon._storage._images.size', 0);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(911)`), true);
+      await ctx.proxy.write('\x1b_Ga=p,i=911,p=2,c=1,r=1,C=1\x1b\\');
+      await timeout(100);
+      strictEqual(await getImageStorageLength(), 1);
+    });
+
+    test('caps retained image data when every image has a placement', async () => {
+      let sequence = '';
+      for (let id = 1000; id <= 1256; id++) {
+        sequence += `\x1b_Ga=T,f=32,s=1,v=1,i=${id},p=1,C=1;${RAW_RGBA_1X1_RED}\x1b\\\n`;
+      }
+      await ctx.proxy.write(sequence);
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 256);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1000)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1256)`), true);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(1000)`), true);
+      ok(await getAbsoluteCellImageId(0, 0) > 0);
+
+      await ctx.proxy.write(`\x1b_Ga=t,f=32,s=1,v=1,i=1000;${RAW_RGBA_1X1_WHITE}\x1b\\`);
+      await timeout(100);
+
+      strictEqual(await getAbsoluteCellImageId(0, 0), -1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(1000)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(1000)`), true);
+    });
+
+    test('accounts for decoded sources and evicts them before visible placements', async () => {
+      await startBlobDecodeCounter();
+      try {
+        await ctx.page.evaluate(`
+          window.term.reset();
+          window.imageAddon?.dispose();
+          window.term.resize(80, 48);
+          window.imageAddon = new ImageAddon({ storageLimit: 0.5 });
+          window.term.loadAddon(window.imageAddon);
+        `);
+
+        const positions = [[1, 1], [30, 1], [1, 9], [30, 9]];
+        for (let n = 0; n < positions.length; n++) {
+          const id = 920 + n;
+          const [column, row] = positions[n];
+          await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${id};${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+          await ctx.proxy.write(`\x1b[${row};${column}H\x1b_Ga=p,i=${id},p=1,C=1\x1b\\`);
+        }
+        await pollFor(ctx.page, 'window.imageAddon._storage._images.size', 4);
+
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 4);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.get(920).decodedSource === undefined`), true);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.get(923).decodedSource !== undefined`), true);
+        ok(await ctx.page.evaluate<number>('window.imageAddon.storageUsage') <= 0.5);
+        strictEqual(await getBlobDecodeCount(), 4);
+
+        await ctx.proxy.write('\x1b[25;1H\x1b_Ga=p,i=920,p=2,C=1\x1b\\');
+        await pollFor(ctx.page, 'window.imageAddon._storage._images.size', 5);
+
+        strictEqual(await getBlobDecodeCount(), 5);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.get(920).decodedSource !== undefined`), true);
+        strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 4);
+        ok(await ctx.page.evaluate<number>('window.imageAddon.storageUsage') <= 0.5);
+      } finally {
+        await stopBlobDecodeCounter();
+        await ctx.page.evaluate('window.term.resize(80, 24)');
+      }
+    });
+
+    for (const [action, imageId] of [
+      ['reset', 935],
+      ['retransmit', 936],
+      ['delete', 937],
+      ['dispose', 938]
+    ] as const) {
+      test(`closes a stale placement bitmap after ${action}`, async () => {
+        await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${imageId};${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+        await startPlacementBitmapPause();
+        const writePromise = ctx.proxy.write(`\x1b_Ga=p,i=${imageId},p=1,C=1\x1b\\`);
+        try {
+          await pollFor(ctx.page, `typeof window._kittyReleasePlacementBitmap`, 'function');
+          await ctx.page.evaluate(([action, imageId, replacementBytes]) => {
+            const addon = (window as any).imageAddon;
+            const storage = addon._handlers.get('kitty')?._kittyStorage;
+            switch (action) {
+              case 'reset':
+                addon.reset();
+                break;
+              case 'retransmit':
+                storage.storeImage(imageId, {
+                  data: new Blob([new Uint8Array(replacementBytes)], { type: 'image/png' }),
+                  width: 0,
+                  height: 0,
+                  format: 100
+                });
+                break;
+              case 'delete':
+                storage.deleteImage(imageId);
+                break;
+              case 'dispose':
+                addon.dispose();
+                break;
+            }
+          }, [action, imageId, KITTY_BLACK_1X1_BYTES] as const);
+
+          await releasePlacementBitmap();
+          await writePromise;
+          await timeout(50);
+
+          strictEqual(await getImageStorageLength(), 0);
+          strictEqual(await ctx.page.evaluate(`window._kittyPausedPlacementBitmap.width`), 0);
+          if (action === 'retransmit') {
+            strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(${imageId})`), true);
+          } else if (action !== 'dispose') {
+            strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(${imageId})`), false);
+          }
+        } finally {
+          await releasePlacementBitmap();
+          await stopPlacementBitmapPause();
+        }
+      });
+    }
+  });
+
   test.describe('Cursor positioning', () => {
     // NOTE: Current tests document ACTUAL behavior (MVP - cursor doesn't move)
     // Per Kitty spec: cursor placed at first column after last image column,
@@ -1819,12 +2301,12 @@ test.describe('Kitty Graphics Protocol', () => {
     });
 
     test.describe('Delete commands', () => {
-      test('delete removes 200x100 image by id', async () => {
+      test('uppercase delete removes 200x100 image by id', async () => {
         await ctx.proxy.write(`\x1b_Ga=t,f=100,i=700;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
         await timeout(200);
         strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(700)`), true);
 
-        await ctx.proxy.write(`\x1b_Ga=d,d=i,i=700\x1b\\`);
+        await ctx.proxy.write(`\x1b_Ga=d,d=I,i=700\x1b\\`);
         await timeout(50);
         strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(700)`), false);
       });
@@ -2130,7 +2612,7 @@ test.describe('Kitty Graphics Protocol', () => {
       ok(newStorageId !== oldStorageId);
     });
 
-    test('memory limit eviction cleans Kitty handler maps', async () => {
+    test('memory limit eviction keeps placeholder placement deletable', async () => {
       // Resize terminal to fit 7 non-overlapping 200x100 images without scrolling.
       // Each image ≈ 29 cols × 8 rows at default cell size.
       await ctx.page.evaluate(`
@@ -2145,26 +2627,115 @@ test.describe('Kitty Graphics Protocol', () => {
       // 6 images = 120K pixels (under limit). 7th triggers eviction (140K > 125K).
       // Place non-overlapping so tile-count eviction doesn't interfere.
       const positions = [[1, 1], [30, 1], [1, 9], [30, 9], [1, 17], [30, 17]];
+      let firstStorageId: number | undefined;
+      let secondStorageId: number | undefined;
       for (let n = 0; n < 6; n++) {
         const [c, r] = positions[n];
         const id = 60 + n;
         await ctx.proxy.write(`\x1b[${r};${c}H\x1b_Ga=T,f=100,i=${id},C=1;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+        if (n === 0) {
+          firstStorageId = await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(60)`);
+        } else if (n === 1) {
+          secondStorageId = await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(61)`);
+        }
       }
       await pollFor(ctx.page, 'window.imageAddon._storage._images.size', 6);
+      ok(firstStorageId !== undefined);
+      ok(secondStorageId !== undefined);
 
-      // 7th image pushes total past 125K pixels — oldest evicted
+      // 7th image pushes placement pixels past 125K — oldest raster is evicted.
       await ctx.proxy.write(`\x1b[25;1H\x1b_Ga=T,f=100,i=66,C=1;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
-      await pollFor(ctx.page, `window.imageAddon._handlers.get('kitty').images.has(60)`, false);
+      await pollFor(ctx.page, `window.imageAddon._storage._images.has(${firstStorageId})`, false);
+      await timeout(100);
 
-      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(60)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(60)`), true);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(60)`), true);
+      strictEqual(await getViewportCellImageId(0, 0), firstStorageId);
+      deepStrictEqual(await getRenderedViewportPixel(0, 0), [0, 0, 0, 255]);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(66)`), true);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(66)`), true);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=i,i=60\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getViewportCellImageId(0, 0), -1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(60)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(60)`), true);
+
+      await ctx.proxy.write('\x1b[1;30H\x1b_Ga=p,i=66,p=2,C=1\x1b\\');
+      await pollFor(ctx.page, `window.imageAddon._storage._images.has(${secondStorageId})`, false);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(61)`), false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(61)`), true);
+      ok(await getViewportCellImageId(29, 0) > 0);
 
       // Restore terminal size
       await ctx.page.evaluate('window.term.resize(80, 24)');
     });
 
-    test('scrollback eviction cleans Kitty handler maps', async () => {
+    test('deletes a reflowed placement when only its evicted placeholder remains', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=71;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+      await ctx.proxy.write('\x1b_Ga=p,i=71,p=1,c=30,r=1,C=1\x1b\\');
+      await timeout(100);
+      const storageId = await ctx.page.evaluate<number | undefined>(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(71)`);
+      ok(storageId !== undefined);
+
+      await ctx.page.evaluate(() => {
+        const storage = (window as any).imageAddon._storage;
+        storage._pixelLimit = 0;
+        storage.enforceLimit();
+      });
+      await pollFor(ctx.page, 'window.imageAddon._storage._images.size', 0);
+      await timeout(100);
+      deepStrictEqual(await getRenderedViewportPixel(0, 0), [0, 0, 0, 255]);
+
+      await ctx.page.evaluate(() => (window as any).term.resize(20, 24));
+      ok(await countBufferImageRefs(storageId) > 0);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=i,i=71\x1b\\');
+      await timeout(100);
+
+      strictEqual(await countBufferImageRefs(storageId), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(71)`), false);
+      await ctx.page.evaluate('window.term.resize(80, 24)');
+    });
+
+    test('index rebuild drops an evicted placement with no remaining cells', async () => {
+      await ctx.proxy.write(`\x1b[1;80H\x1b_Ga=T,f=100,i=72,C=1;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+      await timeout(100);
+      const storageId = await ctx.page.evaluate<number | undefined>(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(72)`);
+      ok(storageId !== undefined);
+
+      await ctx.page.evaluate(() => {
+        const storage = (window as any).imageAddon._storage;
+        storage._pixelLimit = 0;
+        storage.enforceLimit();
+      });
+      await pollFor(ctx.page, 'window.imageAddon._storage._images.size', 0);
+      strictEqual(await countActiveBufferImageRefs(storageId), 1);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(72)`), true);
+
+      await ctx.page.evaluate((storageId: number) => {
+        const term = (window as any).term;
+        const buffer = term._core.buffer;
+        for (let row = 0; row < buffer.lines.length; row++) {
+          const line = buffer.lines.get(row);
+          for (const key of Object.keys(line?._extendedAttrs ?? {})) {
+            const column = Number(key);
+            if (line._extendedAttrs[column]?.imageId === storageId) {
+              delete line._extendedAttrs[column];
+            }
+          }
+        }
+        (window as any).imageAddon._storage.viewportResize({ cols: 79, rows: 24 });
+      }, storageId);
+      await pollFor(ctx.page, `window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(72)`, false);
+
+      deepStrictEqual(await getActiveBufferImageRefs(storageId), []);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._storage._evictedImages.has(${storageId})`), false);
+    });
+
+    test('scrollback eviction drops placement map but preserves Kitty image data', async () => {
       await ctx.page.evaluate(`
         window.term.reset();
         window.imageAddon?.dispose();
@@ -2184,7 +2755,8 @@ test.describe('Kitty Graphics Protocol', () => {
         term.write('\n'.repeat(amount), res);
       }));
 
-      await pollFor(ctx.page, `window.imageAddon._handlers.get('kitty').images.has(70)`, false);
+      await pollFor(ctx.page, `window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(70)`, false);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(70)`), true);
       strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.has(70)`), false);
     });
 
@@ -2280,4 +2852,145 @@ async function getPixels(col: number, row: number, x: number, y: number, w: numb
 
 async function hasTileAtBufferCell(x: number, y: number): Promise<boolean> {
   return ctx.page.evaluate(`!!window.imageAddon.extractTileAtBufferCell(${x}, ${y})`);
+}
+
+async function getViewportCellImageId(col: number, row: number): Promise<number> {
+  return ctx.page.evaluate(([col, row]: number[]) => {
+    const buffer = (window as any).term._core.buffer;
+    return buffer.lines.get(buffer.ybase + row)?._extendedAttrs[col]?.imageId ?? -1;
+  }, [col, row]);
+}
+
+async function getAbsoluteCellImageId(col: number, row: number): Promise<number> {
+  return ctx.page.evaluate(([col, row]: number[]) => {
+    const buffer = (window as any).term._core.buffer;
+    return buffer.lines.get(row)?._extendedAttrs[col]?.imageId ?? -1;
+  }, [col, row]);
+}
+
+async function countBufferImageRefs(imageId: number): Promise<number> {
+  return ctx.page.evaluate((imageId: number) => {
+    const buffers = (window as any).term._core.buffers;
+    let count = 0;
+    for (const buffer of [buffers.normal, buffers.alt]) {
+      for (let row = 0; row < buffer.lines.length; row++) {
+        const line = buffer.lines.get(row);
+        for (const key of Object.keys(line?._extendedAttrs ?? {})) {
+          if (line._extendedAttrs[Number(key)]?.imageId === imageId) {
+            count++;
+          }
+        }
+      }
+    }
+    return count;
+  }, imageId);
+}
+
+async function countActiveBufferImageRefs(imageId: number): Promise<number> {
+  return (await getActiveBufferImageRefs(imageId)).length;
+}
+
+async function getActiveBufferImageRefs(imageId: number): Promise<{ row: number, column: number, lineLength: number }[]> {
+  return ctx.page.evaluate((imageId: number) => {
+    const buffer = (window as any).term._core.buffer;
+    const refs: { row: number, column: number, lineLength: number }[] = [];
+    for (let row = 0; row < buffer.lines.length; row++) {
+      const line = buffer.lines.get(row);
+      for (const key of Object.keys(line?._extendedAttrs ?? {})) {
+        const column = Number(key);
+        if (line._extendedAttrs[column]?.imageId === imageId) {
+          refs.push({ row, column, lineLength: line.length });
+        }
+      }
+    }
+    return refs;
+  }, imageId);
+}
+
+async function getRenderedViewportPixel(col: number, row: number, x: number = 0, y: number = 0): Promise<number[] | null> {
+  return getRenderedViewportPixels(col, row, x, y, 1, 1);
+}
+
+async function getRenderedViewportPixels(col: number, row: number, x: number, y: number, width: number, height: number): Promise<number[] | null> {
+  return ctx.page.evaluate(([col, row, x, y, width, height]: number[]) => {
+    const canvas = document.querySelector('.xterm-image-layer-top') as HTMLCanvasElement | null;
+    const dimensions = (window as any).term._core._renderService.dimensions.css.cell;
+    const context = canvas?.getContext('2d');
+    if (!context) {
+      return null;
+    }
+    return Array.from(context.getImageData(
+      Math.floor(col * dimensions.width + x),
+      Math.floor(row * dimensions.height + y),
+      width,
+      height
+    ).data);
+  }, [col, row, x, y, width, height]);
+}
+
+async function startBlobDecodeCounter(): Promise<void> {
+  await ctx.page.evaluate(() => {
+    const globalWindow = window as any;
+    globalWindow._kittyOriginalCreateImageBitmap = globalWindow.createImageBitmap;
+    globalWindow._kittyBlobDecodeCount = 0;
+    globalWindow.createImageBitmap = (...args: any[]) => {
+      if (args[0] instanceof Blob) {
+        globalWindow._kittyBlobDecodeCount++;
+      }
+      return globalWindow._kittyOriginalCreateImageBitmap(...args);
+    };
+  });
+}
+
+async function stopBlobDecodeCounter(): Promise<void> {
+  await ctx.page.evaluate(() => {
+    const globalWindow = window as any;
+    if (globalWindow._kittyOriginalCreateImageBitmap) {
+      globalWindow.createImageBitmap = globalWindow._kittyOriginalCreateImageBitmap;
+      delete globalWindow._kittyOriginalCreateImageBitmap;
+    }
+  });
+}
+
+async function getBlobDecodeCount(): Promise<number> {
+  return ctx.page.evaluate('window._kittyBlobDecodeCount');
+}
+
+async function startPlacementBitmapPause(): Promise<void> {
+  await ctx.page.evaluate(() => {
+    const globalWindow = window as any;
+    globalWindow._kittyOriginalCreateImageBitmap = globalWindow.createImageBitmap;
+    globalWindow._kittyPlacementBitmapPaused = false;
+    globalWindow.createImageBitmap = (...args: any[]) => {
+      const result = globalWindow._kittyOriginalCreateImageBitmap(...args);
+      if (!globalWindow._kittyPlacementBitmapPaused && args[0] instanceof ImageBitmap) {
+        globalWindow._kittyPlacementBitmapPaused = true;
+        return result.then((bitmap: ImageBitmap) => new Promise<ImageBitmap>(resolve => {
+          globalWindow._kittyPausedPlacementBitmap = bitmap;
+          globalWindow._kittyReleasePlacementBitmap = () => {
+            delete globalWindow._kittyReleasePlacementBitmap;
+            resolve(bitmap);
+          };
+        }));
+      }
+      return result;
+    };
+  });
+}
+
+async function releasePlacementBitmap(): Promise<void> {
+  await ctx.page.evaluate(() => {
+    (window as any)._kittyReleasePlacementBitmap?.();
+  });
+}
+
+async function stopPlacementBitmapPause(): Promise<void> {
+  await ctx.page.evaluate(() => {
+    const globalWindow = window as any;
+    if (globalWindow._kittyOriginalCreateImageBitmap) {
+      globalWindow.createImageBitmap = globalWindow._kittyOriginalCreateImageBitmap;
+      delete globalWindow._kittyOriginalCreateImageBitmap;
+    }
+    delete globalWindow._kittyReleasePlacementBitmap;
+  });
 }

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -1450,6 +1450,56 @@ test.describe('Kitty Graphics Protocol', () => {
       deepStrictEqual(await ctx.page.evaluate('window._kittyCleanupCounts'), [2]);
     });
 
+    test('replaces a named placement after live buffer lines are cloned', async () => {
+      await ctx.proxy.write(`\x1b_Ga=t,f=100,i=913;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
+
+      const oldStorageIds: number[] = [];
+      for (const [index, [row, column, cols]] of [
+        [1, 1, 2],
+        [3, 5, 3],
+        [5, 9, 4],
+        [3, 5, 3],
+        [1, 1, 2]
+      ].entries()) {
+        if (index) {
+          await ctx.page.evaluate(() => {
+            const buffers = (window as any).term._core.buffers;
+            for (const buffer of [buffers.normal, buffers.alt]) {
+              for (let row = 0; row < buffer.lines.length; row++) {
+                const line = buffer.lines.get(row);
+                if (line) {
+                  const clone = line.clone();
+                  for (const key of Object.keys(clone._extendedAttrs)) {
+                    clone._extendedAttrs[Number(key)] = clone._extendedAttrs[Number(key)].clone();
+                  }
+                  buffer.lines.set(row, clone);
+                }
+              }
+            }
+          });
+        }
+
+        await ctx.proxy.write(`\x1b[${row};${column}H\x1b_Ga=p,i=913,p=5,c=${cols},r=1,C=1\x1b\\`);
+        await timeout(100);
+        const currentStorageId = await ctx.page.evaluate<number | undefined>(
+          `window.imageAddon._handlers.get('kitty')._kittyIdToStorageId.get(913)`
+        );
+        ok(currentStorageId !== undefined);
+        const state = await getImageStorageState(currentStorageId);
+        deepStrictEqual(state.liveImageCounts, [[currentStorageId, cols]]);
+        deepStrictEqual(state.storedImageIds, [currentStorageId]);
+        deepStrictEqual(state.indexedImageIds, [currentStorageId]);
+        deepStrictEqual(state.placementStorageIds, [currentStorageId]);
+        strictEqual(state.tileCount, cols);
+        strictEqual(state.allIndexedLinesAttached, true);
+        for (const storageId of oldStorageIds) {
+          strictEqual(await countBufferImageRefs(storageId), 0);
+        }
+        oldStorageIds.push(currentStorageId);
+      }
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.size`), 1);
+    });
+
     test('deletes only the targeted named placement and keeps image data reusable', async () => {
       await ctx.proxy.write(`\x1b_Ga=t,f=100,i=902;${KITTY_BLACK_1X1_BASE64}\x1b\\`);
       await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=902,p=10,c=1,r=1,C=1\x1b\\');
@@ -3047,6 +3097,50 @@ async function countBufferImageRefs(imageId: number): Promise<number> {
       }
     }
     return count;
+  }, imageId);
+}
+
+async function getImageStorageState(imageId: number): Promise<{
+  liveImageCounts: [number, number][];
+  storedImageIds: number[];
+  indexedImageIds: number[];
+  placementStorageIds: number[];
+  tileCount: number;
+  allIndexedLinesAttached: boolean;
+}> {
+  return ctx.page.evaluate((imageId: number) => {
+    const buffers = (window as any).term._core.buffers;
+    const storage = (window as any).imageAddon._storage;
+    const kittyStorage = (window as any).imageAddon._handlers.get('kitty')._kittyStorage;
+    const attachedLines = new Set<any>();
+    const liveImageCounts = new Map<number, number>();
+    for (const buffer of [buffers.normal, buffers.alt]) {
+      for (let row = 0; row < buffer.lines.length; row++) {
+        const line = buffer.lines.get(row);
+        if (!line) {
+          continue;
+        }
+        attachedLines.add(line);
+        for (let col = 0; col < line.length; col++) {
+          if (!(line._data[col * 3 + 2] & 268435456)) {
+            continue;
+          }
+          const cellImageId = line._extendedAttrs[col]?.imageId;
+          if (cellImageId !== undefined && cellImageId !== -1) {
+            liveImageCounts.set(cellImageId, (liveImageCounts.get(cellImageId) ?? 0) + 1);
+          }
+        }
+      }
+    }
+    const indexedLines = storage._imageCells.get(imageId);
+    return {
+      liveImageCounts: [...liveImageCounts].sort(([a], [b]) => a - b),
+      storedImageIds: [...storage._images.keys()].sort((a, b) => a - b),
+      indexedImageIds: [...storage._imageCells.keys()].sort((a, b) => a - b),
+      placementStorageIds: [...kittyStorage._storageIdToPlacement.keys()].sort((a, b) => a - b),
+      tileCount: storage._images.get(imageId)?.tileCount ?? -1,
+      allIndexedLinesAttached: !!indexedLines && [...indexedLines.keys()].every(line => attachedLines.has(line))
+    };
   }, imageId);
 }
 

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -94,6 +94,10 @@ const RAW_RGBA_5X1 = Buffer.from([
   255, 0, 255, 255
 ]).toString('base64');
 
+const enum TestBgFlags {
+  HAS_EXTENDED = 0x10000000
+}
+
 let ctx: ITestContext;
 test.beforeAll(async ({ browser }) => {
   ctx = await createTestContext(browser);
@@ -1510,6 +1514,41 @@ test.describe('Kitty Graphics Protocol', () => {
       deepStrictEqual(await getRenderedViewportPixel(0, 4), [0, 0, 0, 255]);
     });
 
+    test('deletes visible placement cells whose extended flag was cleared by text', async () => {
+      await ctx.page.evaluate(`
+        window.imageAddon.dispose();
+        window.imageAddon = new ImageAddon({ showPlaceholder: true });
+        window.term.loadAddon(window.imageAddon);
+      `);
+      await ctx.proxy.write(`\x1b_Ga=t,f=32,s=1,v=1,i=942,t=d,q=2,m=0;${RAW_RGBA_1X1_RED}\x1b\\`);
+      await ctx.proxy.write('\x1b[1;1H\x1b_Ga=p,i=942,p=1,c=10,r=5,C=1,q=2\x1b\\');
+      await timeout(100);
+      const storageId = await getViewportCellImageId(0, 0);
+      ok(storageId > 0);
+
+      await ctx.proxy.write(Array.from({ length: 5 }, (_, row) => `\x1b[${row + 1};1Hxxxxxxxxxx`).join(''));
+      await timeout(100);
+
+      strictEqual(await countFlaglessBufferImageRefs(storageId), 50);
+      deepStrictEqual(await getRenderedViewportPixel(0, 0), [255, 0, 0, 255]);
+      await ctx.page.evaluate(() => (window as any).imageAddon._storage.viewportResize({ cols: 79, rows: 24 }));
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._storage._images.has(${storageId})`), true);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=a,q=2\x1b\\');
+      await timeout(100);
+
+      strictEqual(await getImageStorageLength(), 0);
+      strictEqual(await countBufferImageRefs(storageId), 0);
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(942)`), true);
+      strictEqual(await getRenderedViewportPixel(0, 0), null);
+
+      await ctx.proxy.write('\x1b_Ga=d,d=I,i=942,q=2\x1b\\');
+      await timeout(100);
+
+      strictEqual(await ctx.page.evaluate(`window.imageAddon._handlers.get('kitty').images.has(942)`), false);
+      strictEqual(await countDanglingBufferImageRefs(), 0);
+    });
+
     for (const [selector, imageId] of [['a', 930], ['A', 931]] as const) {
       test(`d=${selector} deletes only visible placements and preserves scrollback references`, async () => {
         await ctx.proxy.write(`\x1b_Ga=t,f=100,i=${imageId};${KITTY_BLACK_1X1_BASE64}\x1b\\`);
@@ -2884,6 +2923,45 @@ async function countBufferImageRefs(imageId: number): Promise<number> {
     }
     return count;
   }, imageId);
+}
+
+async function countFlaglessBufferImageRefs(imageId: number): Promise<number> {
+  return ctx.page.evaluate((imageId: number) => {
+    const buffers = (window as any).term._core.buffers;
+    let count = 0;
+    for (const buffer of [buffers.normal, buffers.alt]) {
+      for (let row = 0; row < buffer.lines.length; row++) {
+        const line = buffer.lines.get(row);
+        for (const key of Object.keys(line?._extendedAttrs ?? {})) {
+          const column = Number(key);
+          if (line._extendedAttrs[column]?.imageId === imageId && !(line.getBg(column) & TestBgFlags.HAS_EXTENDED)) {
+            count++;
+          }
+        }
+      }
+    }
+    return count;
+  }, imageId);
+}
+
+async function countDanglingBufferImageRefs(): Promise<number> {
+  return ctx.page.evaluate(() => {
+    const term = (window as any).term;
+    const storage = (window as any).imageAddon._storage;
+    let count = 0;
+    for (const buffer of [term._core.buffers.normal, term._core.buffers.alt]) {
+      for (let row = 0; row < buffer.lines.length; row++) {
+        const line = buffer.lines.get(row);
+        for (const key of Object.keys(line?._extendedAttrs ?? {})) {
+          const imageId = line._extendedAttrs[Number(key)]?.imageId;
+          if (imageId !== undefined && imageId !== -1 && !storage._images.has(imageId) && !storage._evictedImages.has(imageId)) {
+            count++;
+          }
+        }
+      }
+    }
+    return count;
+  });
 }
 
 async function countActiveBufferImageRefs(imageId: number): Promise<number> {

--- a/demo/client/components/window/addonImageWindow.ts
+++ b/demo/client/components/window/addonImageWindow.ts
@@ -7,6 +7,13 @@ import { BaseWindow } from './baseWindow';
 import type { IControlWindow } from '../controlBar';
 import type { IImageAddonOptions } from '@xterm/addon-image';
 
+const enum Constants {
+  KITTY_PLACEMENT_IMAGE_ID = 900,
+  KITTY_CUBE_IMAGE_ID = 1000,
+  KITTY_CUBE_FRAME_COUNT = 60,
+  KITTY_CUBE_SIZE = 200
+}
+
 export class AddonImageWindow extends BaseWindow implements IControlWindow {
   public readonly id = 'addon-image';
   public readonly label = 'image';
@@ -77,6 +84,8 @@ export class AddonImageWindow extends BaseWindow implements IControlWindow {
     dtKitty.textContent = 'Kitty';
     dlKitty.appendChild(dtKitty);
     this._addDdWithButton(dlKitty, 'image-demo-kitty1', 'palette');
+    this._addDdWithButton(dlKitty, 'image-demo-kitty-placement-rain', 'placement rain (10 seconds)');
+    this._addDdWithButton(dlKitty, 'image-demo-kitty-placement-cube', 'wireframe cube (15 seconds)');
     container.appendChild(dlKitty);
 
     this._initImageAddonExposed();
@@ -94,13 +103,14 @@ export class AddonImageWindow extends BaseWindow implements IControlWindow {
     return this._imageOptionsTextarea;
   }
 
-  private _addDdWithButton(dl: HTMLElement, id: string, label: string): void {
+  private _addDdWithButton(dl: HTMLElement, id: string, label: string): HTMLButtonElement {
     const dd = document.createElement('dd');
     const button = document.createElement('button');
     button.id = id;
     button.textContent = label;
     dd.appendChild(button);
     dl.appendChild(dd);
+    return button;
   }
 
   private _initImageAddonExposed(): void {
@@ -170,6 +180,275 @@ export class AddonImageWindow extends BaseWindow implements IControlWindow {
         this._terminal.write(`\x1b_Ga=T,f=100;${payload}\x1b\\`);
       });
 
+    const setKittyAnimationButtonsDisabled = (disabled: boolean): void => {
+      for (const id of ['image-demo-kitty-placement-rain', 'image-demo-kitty-placement-cube']) {
+        (document.getElementById(id) as HTMLButtonElement).disabled = disabled;
+      }
+    };
+
+    const kittyPlacementRainDemo = async (): Promise<void> => {
+      const imageId = Constants.KITTY_PLACEMENT_IMAGE_ID;
+      const write = (data: string): Promise<void> => new Promise(resolve => this._terminal.write(data, resolve));
+      const delay = (duration: number): Promise<void> => new Promise(resolve => window.setTimeout(resolve, duration));
+      const activeBuffer = this._terminal.buffer.active;
+      const restoreCursor = `\x1b[${activeBuffer.cursorY + 1};${Math.min(this._terminal.cols, activeBuffer.cursorX + 1)}H`;
+      const sprite = [
+        '   1   ',
+        '   1   ',
+        '   2   ',
+        '  222  ',
+        '  222  ',
+        ' 22222 ',
+        ' 22222 ',
+        '2222222',
+        '2222222',
+        ' 22222 ',
+        '  222  ',
+        '   2   '
+      ];
+      const spriteWidth = sprite[0].length;
+      const spriteHeight = sprite.length;
+      const pixels = new Uint8Array(spriteWidth * spriteHeight * 4);
+      for (let y = 0; y < spriteHeight; y++) {
+        for (let x = 0; x < spriteWidth; x++) {
+          const shade = sprite[y][x];
+          if (shade === ' ') {
+            continue;
+          }
+          const offset = (y * spriteWidth + x) * 4;
+          pixels[offset] = shade === '1' ? 125 : 56;
+          pixels[offset + 1] = shade === '1' ? 211 : 189;
+          pixels[offset + 2] = 248;
+          pixels[offset + 3] = shade === '1' ? 160 : 230;
+        }
+      }
+      let binary = '';
+      for (const value of pixels) {
+        binary += String.fromCharCode(value);
+      }
+      const payload = btoa(binary);
+
+      const screen = this._terminal.element!.querySelector<HTMLElement>('.xterm-screen')!;
+      const bounds = screen.getBoundingClientRect();
+      const cellWidth = Math.max(1, Math.floor(bounds.width / this._terminal.cols));
+      const cellHeight = Math.max(1, Math.floor(bounds.height / this._terminal.rows));
+      const maxY = Math.max(cellHeight, (this._terminal.rows - 1) * cellHeight);
+      const dropCount = Math.max(12, Math.min(40, Math.floor(this._terminal.cols / 2)));
+      const drops = Array.from({ length: dropCount }, (_, index) => ({
+        placementId: index + 1,
+        column: 1 + Math.floor(Math.random() * this._terminal.cols),
+        xOffset: Math.floor(Math.random() * Math.max(1, cellWidth - spriteWidth + 1)),
+        y: Math.random() * maxY,
+        speed: 60 + Math.random() * 120,
+        visible: false
+      }));
+
+      setKittyAnimationButtonsDisabled(true);
+      try {
+        await write(`\x1b_Ga=t,f=32,s=${spriteWidth},v=${spriteHeight},i=${imageId},q=2;${payload}\x1b\\`);
+        let previousFrame = performance.now();
+        const endTime = previousFrame + 9000;
+        while (performance.now() < endTime) {
+          const frameStart = performance.now();
+          const elapsed = Math.min((frameStart - previousFrame) / 1000, 0.1);
+          previousFrame = frameStart;
+          let sequence = '';
+          for (const drop of drops) {
+            drop.y += drop.speed * elapsed;
+            if (drop.y >= maxY) {
+              if (drop.visible) {
+                sequence += `\x1b_Ga=d,d=i,i=${imageId},p=${drop.placementId},q=2\x1b\\`;
+              }
+              drop.column = 1 + Math.floor(Math.random() * this._terminal.cols);
+              drop.xOffset = Math.floor(Math.random() * Math.max(1, cellWidth - spriteWidth + 1));
+              drop.y = -spriteHeight - Math.random() * maxY * 0.15;
+              drop.speed = 60 + Math.random() * 120;
+              drop.visible = false;
+              continue;
+            }
+            if (drop.y < 0) {
+              continue;
+            }
+            const row = Math.floor(drop.y / cellHeight) + 1;
+            const yOffset = Math.floor(drop.y % cellHeight);
+            sequence += `\x1b[${row};${drop.column}H\x1b_Ga=p,i=${imageId},p=${drop.placementId},X=${drop.xOffset},Y=${yOffset},C=1,q=2\x1b\\`;
+            drop.visible = true;
+          }
+          if (sequence) {
+            await write(`${sequence}${restoreCursor}`);
+          }
+          const remainingFrameTime = 50 - (performance.now() - frameStart);
+          if (remainingFrameTime > 0) {
+            await delay(remainingFrameTime);
+          }
+        }
+
+        const bottomRow = Math.max(1, this._terminal.rows - 1);
+        await write(
+          `\x1b[${bottomRow};2H\x1b_Ga=p,i=${imageId},p=0,C=1,q=2\x1b\\` +
+          `\x1b[${bottomRow};4H\x1b_Ga=p,i=${imageId},p=0,C=1,q=2\x1b\\${restoreCursor}`
+        );
+        await delay(200);
+        await write(`\x1b_Ga=d,d=a,q=2\x1b\\`);
+        await delay(200);
+        await write(`\x1b[${Math.ceil(this._terminal.rows / 2)};${Math.ceil(this._terminal.cols / 2)}H\x1b_Ga=p,i=${imageId},p=1,C=1,q=2\x1b\\${restoreCursor}`);
+        await delay(300);
+        await write(`\x1b_Ga=d,d=I,i=${imageId},q=2\x1b\\${restoreCursor}`);
+      } finally {
+        setKittyAnimationButtonsDisabled(false);
+      }
+    };
+
+    const kittyPlacementCubeDemo = async (button: HTMLButtonElement): Promise<void> => {
+      const write = (data: string): Promise<void> => new Promise(resolve => this._terminal.write(data, resolve));
+      const delay = (duration: number): Promise<void> => new Promise(resolve => window.setTimeout(resolve, duration));
+      const originalLabel = button.textContent;
+      const activeBuffer = this._terminal.buffer.active;
+      const restoreCursor = `\x1b[${activeBuffer.cursorY + 1};${Math.min(this._terminal.cols, activeBuffer.cursorX + 1)}H`;
+      const vertices = [
+        [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+        [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]
+      ];
+      const edges = [
+        [0, 1], [1, 2], [2, 3], [3, 0],
+        [4, 5], [5, 6], [6, 7], [7, 4],
+        [0, 4], [1, 5], [2, 6], [3, 7]
+      ];
+      const framePayloads: string[] = [];
+      let canvas: HTMLCanvasElement | undefined;
+      let transmittedFrameCount = 0;
+      let currentImageId: number | undefined;
+      let placementStarted = false;
+
+      setKittyAnimationButtonsDisabled(true);
+      button.textContent = 'preparing cube frames...';
+      try {
+        const screen = this._terminal.element!.querySelector<HTMLElement>('.xterm-screen')!;
+        const bounds = screen.getBoundingClientRect();
+        const cellWidth = Math.max(1, bounds.width / this._terminal.cols);
+        const cellHeight = Math.max(1, bounds.height / this._terminal.rows);
+        const availableSize = Math.floor(Math.min(bounds.width - cellWidth, bounds.height - cellHeight));
+        if (availableSize < 32) {
+          button.textContent = 'terminal too small for cube';
+          await delay(1200);
+          return;
+        }
+        const cubeSize = Math.min(Constants.KITTY_CUBE_SIZE, availableSize);
+        canvas = document.createElement('canvas');
+        canvas.width = canvas.height = cubeSize;
+        const context = canvas.getContext('2d')!;
+
+        for (let frame = 0; frame < Constants.KITTY_CUBE_FRAME_COUNT; frame++) {
+          const angle = frame / Constants.KITTY_CUBE_FRAME_COUNT * Math.PI * 2;
+          const sinX = Math.sin(angle * 0.7);
+          const cosX = Math.cos(angle * 0.7);
+          const sinY = Math.sin(angle);
+          const cosY = Math.cos(angle);
+          const projected = vertices.map(([x, y, z]) => {
+            const rotatedX = x * cosY - z * sinY;
+            const rotatedZ = x * sinY + z * cosY;
+            const rotatedY = y * cosX - rotatedZ * sinX;
+            const depth = y * sinX + rotatedZ * cosX;
+            const perspective = 2.8 / (depth + 4);
+            return [
+              cubeSize / 2 + rotatedX * cubeSize * 0.31 * perspective,
+              cubeSize / 2 - rotatedY * cubeSize * 0.31 * perspective
+            ];
+          });
+
+          context.clearRect(0, 0, canvas.width, canvas.height);
+          context.strokeStyle = '#38bdf8';
+          context.lineWidth = Math.max(1.5, cubeSize / 67);
+          context.lineJoin = 'round';
+          context.shadowColor = '#0ea5e9';
+          context.shadowBlur = cubeSize / 25;
+          for (const [start, end] of edges) {
+            context.beginPath();
+            context.moveTo(projected[start][0], projected[start][1]);
+            context.lineTo(projected[end][0], projected[end][1]);
+            context.stroke();
+          }
+          framePayloads.push(canvas.toDataURL('image/png').split(',')[1]);
+        }
+
+        for (let frame = 0; frame < framePayloads.length; frame++) {
+          const imageId = Constants.KITTY_CUBE_IMAGE_ID + frame;
+          await write(`\x1b_Ga=t,f=100,i=${imageId},q=2;${framePayloads[frame]}\x1b\\`);
+          transmittedFrameCount++;
+        }
+
+        button.textContent = 'wireframe cube running...';
+        const maxX = Math.max(0, bounds.width - cubeSize - 1);
+        const maxY = Math.max(0, bounds.height - cubeSize - 1);
+        let x = maxX / 3;
+        let y = maxY / 3;
+        let velocityX = 110;
+        let velocityY = 80;
+        const animationStart = performance.now();
+        let previousFrame = animationStart;
+        const endTime = animationStart + 15000;
+
+        while (performance.now() < endTime) {
+          const frameStart = performance.now();
+          const elapsed = Math.min((frameStart - previousFrame) / 1000, 0.1);
+          previousFrame = frameStart;
+          x += velocityX * elapsed;
+          y += velocityY * elapsed;
+          if (x <= 0 || x >= maxX) {
+            x = Math.max(0, Math.min(maxX, x));
+            velocityX *= -1;
+          }
+          if (y <= 0 || y >= maxY) {
+            y = Math.max(0, Math.min(maxY, y));
+            velocityY *= -1;
+          }
+
+          const frameIndex = Math.floor((frameStart - animationStart) / 50) % Constants.KITTY_CUBE_FRAME_COUNT;
+          const imageId = Constants.KITTY_CUBE_IMAGE_ID + frameIndex;
+          let sequence = '';
+          if (currentImageId !== undefined && currentImageId !== imageId) {
+            sequence += `\x1b_Ga=d,d=i,i=${currentImageId},p=1,q=2\x1b\\`;
+          }
+          const row = Math.floor(y / cellHeight) + 1;
+          const col = Math.floor(x / cellWidth) + 1;
+          const xOffset = Math.floor(x % cellWidth);
+          const yOffset = Math.floor(y % cellHeight);
+          sequence += `\x1b[${row};${col}H\x1b_Ga=p,i=${imageId},p=1,X=${xOffset},Y=${yOffset},C=1,q=2\x1b\\${restoreCursor}`;
+          await write(sequence);
+          placementStarted = true;
+          currentImageId = imageId;
+
+          const remainingFrameTime = 50 - (performance.now() - frameStart);
+          if (remainingFrameTime > 0) {
+            await delay(remainingFrameTime);
+          }
+        }
+
+      } finally {
+        try {
+          let cleanup = '';
+          if (currentImageId !== undefined) {
+            cleanup += `\x1b_Ga=d,d=i,i=${currentImageId},p=1,q=2\x1b\\`;
+          }
+          for (let frame = 0; frame < transmittedFrameCount; frame++) {
+            cleanup += `\x1b_Ga=d,d=I,i=${Constants.KITTY_CUBE_IMAGE_ID + frame},q=2\x1b\\`;
+          }
+          if (placementStarted) {
+            cleanup += restoreCursor;
+          }
+          if (cleanup) {
+            await write(cleanup);
+          }
+        } finally {
+          if (canvas) {
+            canvas.width = canvas.height = 0;
+          }
+          button.textContent = originalLabel;
+          setKittyAnimationButtonsDisabled(false);
+        }
+      }
+    };
+
     document.getElementById('image-demo1')!.addEventListener('click',
       sixelDemo('https://raw.githubusercontent.com/saitoha/libsixel/master/images/snake.six'));
     document.getElementById('image-demo2')!.addEventListener('click',
@@ -184,6 +463,14 @@ export class AddonImageWindow extends BaseWindow implements IControlWindow {
       iipDemoMulti('https://raw.githubusercontent.com/xtermjs/xterm.js/master/addons/addon-image/fixture/testimages/kimono.crop.avif'));
     document.getElementById('image-demo-kitty1')!.addEventListener('click',
       kittyDemo('https://raw.githubusercontent.com/xtermjs/xterm.js/master/addons/addon-image/fixture/palette.png'));
+    const kittyPlacementRainButton = document.getElementById('image-demo-kitty-placement-rain') as HTMLButtonElement;
+    kittyPlacementRainButton.addEventListener('click', () => {
+      void kittyPlacementRainDemo();
+    });
+    const kittyPlacementCubeButton = document.getElementById('image-demo-kitty-placement-cube') as HTMLButtonElement;
+    kittyPlacementCubeButton.addEventListener('click', () => {
+      void kittyPlacementCubeDemo(kittyPlacementCubeButton);
+    });
 
     // demo for image retrieval API
     this._terminal.element!.addEventListener('click', (ev: MouseEvent) => {


### PR DESCRIPTION
Follow-up to #5707 and #5722. Partially addresses the `a/A` live-screen scope and
lower/uppercase lifetime requirements in #5710; the remaining delete selectors
from that issue are out of scope.

## Why

Kitty image data and placements have different lifetimes. One transmitted image
can have multiple displayed placements, and a non-zero placement ID identifies
one placement by `(imageId, placementId)`.

The current addon maps a Kitty image ID to one `ImageStorage` entry. Multiple
placements therefore overwrite shared bookkeeping, same-ID replacement can
leave old cells visible, and targeted deletion can remove shared image data.
It also decodes the transmitted source again for each placement.

## Behavior

| Command | Result |
|---|---|
| Repeated `a=p,i=N,p=P` | Replaces only named placement `(N,P)` |
| `a=p,i=N` or `p=0` | Adds an independent anonymous placement |
| `a=T` without `i=`, or with `i=0` | Ignores `p=`, creates an anonymous ID-zero placement, and releases its payload with its final placement |
| ID-less `a=t` | Discards the unaddressable payload after transmission |
| Failed `a=T` | Emits one error and does not reuse an older same-ID image or move the cursor |
| `d=i,i=N,p=P` | Deletes only `(N,P)` and preserves image data |
| `d=I,i=N,p=P` | Deletes only `(N,P)` and frees data only after a matching last placement |
| `d=i/I,i=N` | Deletes all placements for image N; uppercase frees unreferenced data |
| `d=a/A` | Deletes only active-buffer placements on the live application screen; uppercase frees only data left unreferenced |
| Retransmit `i=N` | Removes all old placements and replaces the transmitted data |

Explicit replacement and deletion clear their cell metadata so stale
placeholders cannot remain.

## Implementation

- Separates image-scoped payload/decoded-source state from named and anonymous
  placement records.
- Reuses one lazily decoded source bitmap for placement crop/scale operations.
- Indexes placement cells for targeted cleanup.
- Rebuilds cell indexes after resize/reflow and handles shifted cells.
- Rebuilds only candidate image-cell indexes from authoritative `HAS_EXTENDED`
  attributes on attached normal and alternate buffer lines before explicit
  deletion or named replacement. This drops detached line identities, discovers
  replacement live lines, repairs tile counts, and prevents stale tombstones.
- Reconciles Kitty placement indexes before `d=a/A` and deletes cell-less
  placements through the normal lifecycle path.
- Preserves placement tombstones and their render layer when raster quota
  eviction needs placeholder and later deletion semantics.
- Accounts decoded source pixels in storage limits. The hard cap remains 256
  transmitted images, with placements evicted together with capped payloads.
- Invalidates async placement work on reset, retransmit, delete, and dispose;
  stale bitmaps are closed before they can reach storage.
- Keeps ID-zero images under internal negative keys, validates client IDs as
  unsigned 32-bit values, and never exposes internal keys as reusable client IDs.
- Makes transmit-and-display transactional so transmission failure cannot fall
  through to an existing same-ID payload.
- Treats `HAS_EXTENDED` as authoritative in visibility/index scans, matching
  #6131. True Kitty placements that survive text overwrite require the separate
  placement store tracked in #6132.
- Extends the image demo with a single 10-second placement-rain smoke demo. It
  transmits one transparent teardrop sprite, animates a dense randomized field
  of named placements at independent pixel velocities using sub-cell offsets,
  targeted-deletes and reuses them, adds anonymous `p=0` placements, clears
  live-screen placements with `d=a`, proves payload reuse once more, and ends
  with uppercase cleanup.
- Adds a 15-second bouncing wireframe-cube demo that pre-renders and transmits 60
  transparent 200x200 PNG frames once, then moves/replaces the active placement
  and switches frames through lowercase hide/show operations before freeing all
  stored frame data.

## Performance

- Image bytes are transmitted once and source pixels are decoded once while the
  decoded source remains cached.
- Named replacement and targeted deletion rebuild only the requested storage
  IDs in a single pass over attached normal and alternate buffer lines. Index
  maps and column sets are allocated only for matching live cells.
- `d=a/A` scans the active buffer's live application screen for targets, then
  uses the same candidate-scoped reconciliation.
- Decoded source pixels are quota-accounted and evicted before visible placement
  rasters.

## Scope and compatibility

- No public API or typings change.
- Lowercase deletion intentionally changes to preserve transmitted image data,
  as required by the Kitty protocol.
- This does not implement the remaining `c/C`, `n/N`, `p/P`, `q/Q`, `r/R`,
  `x/X`, `y/Y`, `z/Z`, or `f/F` selectors tracked by #5710.
- The existing one-image-tile-per-cell model remains. Fully overlapping
  placements cannot yet stack and reveal an older image when a newer one is
  removed; image-on-image composition requires a broader renderer/buffer design.
- Relative placements (#5712), Unicode placeholders (#5711), and animation
  (#5713) remain out of scope.

## Validation

- `npm run build`
- `npm run esbuild`
- `npm run esbuild-demo-client`
- `npm run esbuild-demo-server`
- `npm run lint-changes`
- `npm run test-unit -- addons/addon-image/out-esbuild/kitty/KittyGraphicsTypes.test.js`
  - 23 passing
- `npm run test-integration -- --suite=addon-image`
  - 743 passing, 4 skipped across Chromium, Firefox, and WebKit
- `git diff --check`

The demo client/server bundles were built, and the Playwright suite exercised
the addon through its demo server. The placement-rain button was also exercised
headlessly through its full animation with no page errors. The wireframe-cube
button completed its preload, 15-second animation, and cleanup without page
errors or viewport scrolling.

Regression coverage includes named siblings, same-placement replacement,
independently cloned/replaced live buffer lines, bidirectional move sequences,
anonymous and ID-zero placements, targeted and live-screen deletion, scrolled-up
and alternate-buffer behavior, shared decode lifetime, crop fragments,
retransmission, quota pressure, negative-z placeholders, text overwrite,
detached lines, ICH/DCH shifts, resize/reflow, alternate-only index rebuilds,
acknowledgements, failed and empty transmit-and-display commands, invalid client
IDs, pending-upload deletion, and deterministic async
reset/retransmit/delete/dispose races.

Downstream validation in Hex1b covered the shared-payload placement lifecycle
and exposed the detached-line index invariant during repeated named-placement
movement. The regression and fix in `825f5605` are project-level xterm.js buffer
and storage correctness changes; a matched immutable browser build has been
prepared for downstream revalidation.