### PR TITLE
fix: don't swallow wheel events in the alt buffer when consumeWheelEvent() returns 0

### DIFF
--- a/src/browser/services/MouseService.test.ts
+++ b/src/browser/services/MouseService.test.ts
@@ -444,3 +444,73 @@ describe('MouseService multi-window', () => {
     assert.deepEqual(openDocument.removed, []);
   });
 });
+
+describe('MouseService _handlePassiveWheel (alt buffer)', () => {
+  before(() => {
+    (globalThis as any).WheelEvent = { DOM_DELTA_PIXEL: 0, DOM_DELTA_PAGE: 2 };
+  });
+
+  after(() => {
+    delete (globalThis as any).WheelEvent;
+  });
+
+  function createMouseService(): { mouseService: MouseService, reports: string[] } {
+    const reports: string[] = [];
+    const renderService = new MockRenderService();
+    renderService.dimensions.device.cell.height = 22;
+    const mouseService = new MouseService(
+      renderService,
+      {
+        getMouseReportCoords: (_ev: MouseEvent, _el: HTMLElement) => ({ col: 0, row: 0, x: 0, y: 0 })
+      } as any,
+      new MouseStateService(),
+      {
+        triggerDataEvent: (data: string) => reports.push(data),
+        triggerBinaryEvent: () => {},
+        decPrivateModes: { applicationCursorKeys: false }
+      } as any,
+      { buffer: { hasScrollback: false } } as any,
+      new OptionsService({}),
+      new TestSelectionService(),
+      logService,
+      new MockCoreBrowserService()
+    );
+    return { mouseService, reports };
+  }
+
+  function wheelEvent(deltaY: number, deltaMode: number = 0, shiftKey: boolean = false): WheelEvent {
+    return {
+      deltaY,
+      deltaMode,
+      shiftKey,
+      preventDefault: () => {},
+      stopPropagation: () => {}
+    } as any;
+  }
+
+  it('sends a single down sequence for a small pixel delta that rounds to zero lines', () => {
+    const { mouseService, reports } = createMouseService();
+    const result = (mouseService as any)._handlePassiveWheel({ requestedEvents: {} } as any, wheelEvent(20));
+    assert.equal(result, false);
+    assert.deepEqual(toBytes(reports.join('')), [0x1b, 0x5b, 0x42]);
+  });
+
+  it('sends a single up sequence for a negative delta', () => {
+    const { mouseService, reports } = createMouseService();
+    (mouseService as any)._handlePassiveWheel({ requestedEvents: {} } as any, wheelEvent(-100));
+    assert.deepEqual(toBytes(reports.join('')), [0x1b, 0x5b, 0x41]);
+  });
+
+  it('does not send sequences for a zero delta', () => {
+    const { mouseService, reports } = createMouseService();
+    (mouseService as any)._handlePassiveWheel({ requestedEvents: {} } as any, wheelEvent(0));
+    assert.deepEqual(reports, []);
+  });
+
+  it('does not send sequences when the app handles the wheel itself', () => {
+    const { mouseService, reports } = createMouseService();
+    const ctx = { requestedEvents: { wheel: () => {} } } as any;
+    (mouseService as any)._handlePassiveWheel(ctx, wheelEvent(100));
+    assert.deepEqual(reports, []);
+  });
+});

--- a/src/browser/services/MouseService.ts
+++ b/src/browser/services/MouseService.ts
@@ -273,16 +273,17 @@ export class MouseService implements IMouseService {
         return false;
       }
 
-      const lines = this._consumeWheelEvent(
+      // Keep the partial-scroll accumulator in sync for the wheel-scroll option,
+      // but never gate the up/down fallback on it: the magnitude is unused here
+      // (the comment above states the behavior is a single up/down sequence), so
+      // a zero result -- small pixel deltas dampened and floored to 0 lines,
+      // shift+wheel, or renderer dims not ready -- must not drop the event, or
+      // full-screen TUI apps receive no wheel input at all.
+      this._consumeWheelEvent(
         ev,
         this._renderService?.dimensions?.device?.cell?.height,
         this._coreBrowserService?.dpr
       );
-      if (lines === 0) {
-        ev.preventDefault();
-        ev.stopPropagation();
-        return false;
-      }
 
       // Construct and send sequences
       const sequence = C0.ESC + (this._coreService.decPrivateModes.applicationCursorKeys ? 'O' : '[') + (ev.deltaY < 0 ? 'A' : 'B');


### PR DESCRIPTION
## Summary

Since 5.6.0-beta.119 the alt-buffer wheel handler gates on `consumeWheelEvent()` returning a non-zero amount, and drops the event when it rounds to zero. That kills the wheel for full-screen TUI apps on trackpads, smooth wheels and low-sensitivity scroll settings: any single pixel delta below roughly one cell height gets dampened, floored to 0, and never reaches the app. It also swallows shift+wheel entirely.

The sequence this path sends is always exactly one ESC[A/ESC[B, the return value is only used as a boolean, and the comment above the code already states the behavior is "simply send a single up or down sequence". So the gate is leftover from the old line-scrolling implementation and has nothing to gain here.

This keeps the `consumeWheelEvent()` call so the partial-scroll accumulator stays in sync, but only `deltaY === 0` skips sending.

## Verification

Byte-level A/B between VS Code 1.104 (xterm 5.6.0-beta.118) and 1.105 (5.6.0-beta.119): raw-mode pty listener in the alt screen, instrumented bundle logging `consumeWheelEvent()` input and result per event.

| probe | 1.104 (beta.118) | 1.105 (beta.119) |
|---|---|---|
| pixel deltaY=20 | ESC[B sent | returns 0, nothing sent |
| pixel deltaY=100 | ESC[B sent | returns 6, ESC[B sent |
| line deltaY=3 | ESC[B sent | returns 3, ESC[B sent |
| line deltaY=100 | ESC[B sent | returns 100, ESC[B sent |
| CDP pixel deltaY=20 | ESC[B sent | returns 0, nothing sent |
| CDP pixel deltaY=100 | ESC[B sent | returns 6, ESC[B sent |

1.104 sent one ESC[B for every probe, 1.105 dropped all pixel probes under 50px (0 bytes on the pty) while line-mode and large deltas passed. Renderer dims were healthy in both runs, so the failures are the dampening path, not a sizing race.

Tests: 4 new unit cases (small pixel delta, negative delta, zero delta, app-handles-wheel-itself). Full unit suite passes (2342 tests), lint clean.
