### PR TITLE
Add Shellshare to real-world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Xterm.js is used in many world-class applications to provide great terminal expe
 - [**Codeman**](https://github.com/Ark0N/Codeman): Self-hosted mission control for AI coding agents, streaming live tmux sessions to browser and phone.
 - [**JSVIsion**](https://github.com/blendsdk/jsvision): A Turbo Vision-Style TUI SDK for TypeScript. We use xterm.js in our docs to show live JSVision examples running in a web terminal.
 - [**BitFun**](https://github.com/GCWing/BitFun): Open-source desktop AI agent whose integrated terminals and read-only terminal output views use xterm.js with the Fit, Web Links, and WebGL addons.
+- [**Shellshare**](https://github.com/vitorbaptista/shellshare): Live terminal broadcasting from a single command, end-to-end encrypted and read-only. Great for teaching, working together, and safely letting AI agents read your shell output.
 - [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)
 
 Do you use xterm.js in your application as well? Please [open a Pull Request](https://github.com/sourcelair/xterm.js/pulls) to include it here. We would love to have it on our list. Please add any new contributions to the end of the list.


### PR DESCRIPTION
I maintain Shellshare. We use xterm.js in the viewer page that renders the broadcast terminal live in the browser.

This adds it to the end of the Real-world uses list as requested in the README.