### PR TITLE
fix(RenderService): don't throw from dimensions after dispose

### DIFF
--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -22,6 +22,11 @@ const enum Constants {
   SYNCHRONIZED_OUTPUT_TIMEOUT_MS = 1000
 }
 
+const EMPTY_RENDER_DIMENSIONS: IRenderDimensions = {
+  css: { canvas: { width: 0, height: 0 }, cell: { width: 0, height: 0 } },
+  device: { canvas: { width: 0, height: 0 }, cell: { width: 0, height: 0 }, char: { width: 0, height: 0, top: 0, left: 0 } }
+};
+
 export class RenderService extends Disposable implements IRenderService {
   public serviceBrand: undefined;
 
@@ -53,7 +58,15 @@ export class RenderService extends Disposable implements IRenderService {
   private readonly _onRefreshRequest = this._register(new Emitter<{ start: number, end: number }>());
   public readonly onRefreshRequest = this._onRefreshRequest.event;
 
-  public get dimensions(): IRenderDimensions { return this._renderer.value!.dimensions; }
+  private _dimensions: IRenderDimensions = EMPTY_RENDER_DIMENSIONS;
+
+  /**
+   * Falls back to the last known dimensions when there is no live renderer (not yet set, or
+   * disposed), rather than throwing. A disposed terminal can still be reached here through a
+   * lingering event handler elsewhere (e.g. a document-level listener that hasn't torn down
+   * yet), and a stale-but-valid value is preferable to an uncaught exception from a getter.
+   */
+  public get dimensions(): IRenderDimensions { return this._renderer.value?.dimensions ?? this._dimensions; }
 
   constructor(
     private _rowCount: number,
@@ -233,11 +246,13 @@ export class RenderService extends Disposable implements IRenderService {
     if (!this._renderer.value) {
       return;
     }
+    this._dimensions = this._renderer.value.dimensions;
+
     // Don't fire the event if the dimensions haven't changed
-    if (this._renderer.value.dimensions.css.canvas.width === this._canvasWidth && this._renderer.value.dimensions.css.canvas.height === this._canvasHeight) {
+    if (this._dimensions.css.canvas.width === this._canvasWidth && this._dimensions.css.canvas.height === this._canvasHeight) {
       return;
     }
-    this._onDimensionsChange.fire(this._renderer.value.dimensions);
+    this._onDimensionsChange.fire(this._dimensions);
   }
 
   public hasRenderer(): boolean {
@@ -248,6 +263,7 @@ export class RenderService extends Disposable implements IRenderService {
     this._renderer.value = renderer;
     // If the value was not set, the terminal is being disposed so ignore it
     if (this._renderer.value) {
+      this._dimensions = this._renderer.value.dimensions;
       this._renderer.value.onRequestRedraw(e => this.refreshRows(e.start, e.end, e.sync, true));
 
       // Force a refresh

--- a/test/playwright/RenderService.test.ts
+++ b/test/playwright/RenderService.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+import { test } from '@playwright/test';
+import { deepStrictEqual } from 'assert';
+import { createTestContext, ITestContext, openTerminal } from './TestUtils';
+import { IRenderDimensions } from '../../src/browser/renderer/shared/Types';
+
+let ctx: ITestContext;
+test.beforeAll(async ({ browser }) => {
+  ctx = await createTestContext(browser);
+  await openTerminal(ctx);
+});
+test.afterAll(async () => await ctx.page.close());
+
+test.describe('RenderService dimensions after dispose', () => {
+  test('dimensions does not throw after dispose', async () => {
+    // RenderService.dimensions used a non-null assertion on the (MutableDisposable-cleared)
+    // renderer, so any caller reaching it after dispose() got an uncaught TypeError instead of
+    // a value (xtermjs/xterm.js#6070). CoreBrowserTerminal never nulls out its _renderService
+    // reference on dispose, so this is reachable by anything holding on to the terminal, a
+    // service, or (before #6019) a leaked document-level listener.
+    await ctx.page.evaluate(`window.term.dispose()`);
+    const dimensions: IRenderDimensions = await ctx.page.evaluate(`window.term._core._renderService.dimensions`);
+    deepStrictEqual(typeof dimensions, 'object');
+    deepStrictEqual(typeof dimensions.css.cell.width, 'number');
+
+    // leave the page in a clean state for the next test
+    await openTerminal(ctx);
+  });
+
+  test('a mouseup/mousemove reaching a disposed terminal mid-drag does not throw', async () => {
+    // Companion end-to-end guard for the listener-lifecycle half of the same reports
+    // (xtermjs/xterm.js#6070, #6086): document-level mouseup/mousemove listeners installed for
+    // mouse reporting must not survive dispose() mid-drag. Fixed by #6019 registering them as
+    // MutableDisposables; this exercises that path directly rather than the getter above.
+    const errors: string[] = [];
+    const onPageError = (e: Error): number => errors.push(e.message);
+    ctx.page.on('pageerror', onPageError);
+
+    try {
+      // enable mouse-drag reporting (DECSET 1002), same as an app like vim/tmux would
+      await ctx.proxy.write('\x1b[?1002h');
+
+      const rect: { left: number, top: number, width: number, height: number } = await ctx.page.evaluate(`
+        window.term.element.getBoundingClientRect().toJSON()
+      `);
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+
+      await ctx.page.mouse.move(x, y);
+      await ctx.page.mouse.down({ button: 'left' });
+
+      // dispose while the button is still held, before the paired mouseup can self-remove
+      // the document-level listeners
+      await ctx.page.evaluate(`window.term.dispose()`);
+
+      // the release the disposed terminal never got to see
+      await ctx.page.mouse.up({ button: 'left' });
+      // and a move for good measure, covering the mousemove listener too
+      await ctx.page.mouse.move(x + 10, y + 10);
+    } finally {
+      ctx.page.off('pageerror', onPageError);
+    }
+
+    deepStrictEqual(errors, []);
+
+    // leave the page in a clean state for any tests that might run after this file
+    await openTerminal(ctx);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the second, still-open half of #6070 (the listener-lifecycle half is already fixed on master by #6019). Also relevant to #6086, same defect class at a different call site.

`RenderService.dimensions` reads `this._renderer.value!.dimensions` — a non-null assertion on a `MutableDisposable` that's cleared to `undefined` on dispose. `CoreBrowserTerminal` never nulls out its own `_renderService` field on dispose (it's assigned once, in `_setup()`), so `term._core._renderService` stays reachable after `term.dispose()`. Anything that still holds a reference — the terminal itself, another service, or (pre-#6019) a leaked document-level mouse listener — that calls `.dimensions` on it gets an uncaught `TypeError` from inside the getter instead of a value or a clean no-op.

Every other read of `this._renderer.value` in this file already guards with `?.` or an `if (!this._renderer.value)` early return; this getter was the one unguarded spot, as the issue reporter noted.

## Fix

Cache the last known `IRenderDimensions` (updated in `setRenderer` and `_fireOnCanvasResize`, the two places the live value is read) and have the getter fall back to that cache when there's no live renderer — a zeroed default before a renderer is ever set, otherwise the last real value from before dispose. The public `dimensions` type stays non-optional, so no consumer-facing API change.

## Testing

Added `test/playwright/RenderService.test.ts`:
- `dimensions does not throw after dispose` — disposes a terminal, then reads `_core._renderService.dimensions` directly and asserts it doesn't throw and has the expected shape. Verified this fails with the original `Cannot read properties of undefined (reading 'dimensions')` when the fix is reverted.
- `a mouseup/mousemove reaching a disposed terminal mid-drag does not throw` — end-to-end companion covering the listener-lifecycle half (#6019/#6070/#6086): enables mouse-drag reporting, starts a drag, disposes mid-drag, then releases/moves and asserts no `pageerror` reaches the page.

`npm run build`, `npm run test-unit` (2414 passing), `npm run test-integration -- test/playwright/RenderService.test.ts` (2 passing on Chromium), `npm run lint-changes` all clean.