### PR TITLE
Fix final-space handling of translateToString cache

### DIFF
--- a/src/common/buffer/BufferLine.test.ts
+++ b/src/common/buffer/BufferLine.test.ts
@@ -848,13 +848,13 @@ describe('BufferLine', function(): void {
 
       // Once non-trimmed is cached, trimmed should be derived via trimEnd().
       assert.equal(line.translateToString(true, undefined, undefined, undefined), 'abc');
-      assert.equal(line.cachedString, 'abc  ');
-      assert.equal(line.isCachedStringTrimmed, false);
+      assert.equal(line.cachedString, 'abc');
+      assert.equal(line.isCachedStringTrimmed, true);
 
       line.cachedString = 'cached-non-trimmed  ';
       line.isCachedStringTrimmed = false;
       assert.equal(line.translateToString(false, undefined, undefined, undefined), 'cached-non-trimmed  ');
-      assert.equal(line.translateToString(true, undefined, undefined, undefined), 'cached-non-trimmed');
+      assert.equal(line.translateToString(true, undefined, undefined, undefined), 'abc');
 
       line.cachedString = 'cached-trimmed';
       line.isCachedStringTrimmed = true;
@@ -866,6 +866,10 @@ describe('BufferLine', function(): void {
       // Any optional translation argument should bypass cache.
       assert.equal(line.translateToString(false, 0, 2, undefined), 'ab');
       assert.equal(line.translateToString(true, 0, 2, undefined), 'ab');
+
+      line.setCell(3, createCellData(1, ' ', 1));
+      assert.equal(line.translateToString(false, undefined, undefined, undefined), 'abc  ');
+      assert.equal(line.translateToString(true, undefined, undefined, undefined), 'abc ');
     });
 
     it('should invalidate cached canonical strings on line mutations', () => {

--- a/src/common/buffer/BufferLine.ts
+++ b/src/common/buffer/BufferLine.ts
@@ -550,13 +550,8 @@ export class BufferLine implements IBufferLine {
    */
   public translateToString(trimRight?: boolean, startCol?: number, endCol?: number, outColumns?: number[]): string {
     const isCanonical = (startCol === undefined || startCol === 0) && endCol === undefined && outColumns === undefined;
-    if (isCanonical && this._cacheValid) {
-      if (trimRight) {
-        return this._cacheTrimmed ? this._cache : this._cache.trimEnd();
-      }
-      if (!this._cacheTrimmed) {
-        return this._cache;
-      }
+    if (isCanonical && this._cacheValid && trimRight === this._cacheTrimmed) {
+      return this._cache;
     }
     startCol = startCol ?? 0;
     endCol = endCol ?? this.length;


### PR DESCRIPTION
This `trimEnd` call in in `translateToString`:
```
  if (isCanonical && this._cacheValid) {
    if (trimRight) {
      return this._cacheTrimmed ? this._cache : this._cache.trimEnd();
```
incorrectly trims off significant (explicitly witten) whitespace at the end of a line.

It fails if you add these lines to the end of the `'should cache canonical string translations'` test in `BufferLine.test.ts`:
```
      line.setCell(3, createCellData(1, ' ', 1));
      assert.equal(line.translateToString(false, undefined, undefined, undefined), 'abc  ');
      assert.equal(line.translateToString(true, undefined, undefined, undefined), 'abc ');
```
My proposed fix is to simplify the test in `translateToString` to just:
```
    if (isCanonical && this._cacheValid && trimRight === this._cacheTrimmed) {
      return this._cache;
    }
```

Relatedly: I believe only the `trimRight == true` case is useful. The only examples of `trimRight == false` I could find were in test case except for one place in the `addon-search` which is trying to get the translated string for the "logical line"; that should be redone if string caching is done at the `LogicalIne` level, as I believe it should.