### PR TITLE
Fix pattern custom glyph rendering across documents

### DIFF
--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.test.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { assert } from 'chai';
+import { createPatternCanvas } from './CustomGlyphRasterizer';
+
+describe('CustomGlyphRasterizer', () => {
+  describe('createPatternCanvas', () => {
+    it('prefers an offscreen canvas without using the DOM canvas factory', () => {
+      const expectedCanvas = {} as OffscreenCanvas;
+      const calls: string[] = [];
+
+      const canvas = createPatternCanvas(
+        2,
+        3,
+        (width, height) => {
+          calls.push(`offscreen:${width}x${height}`);
+          return expectedCanvas;
+        },
+        () => {
+          calls.push('dom');
+          return {} as HTMLCanvasElement;
+        }
+      );
+
+      assert.deepEqual({ canvas, calls }, {
+        canvas: expectedCanvas,
+        calls: ['offscreen:2x3']
+      });
+    });
+
+    it('uses the main-realm DOM canvas factory when OffscreenCanvas is unavailable', () => {
+      const expectedCanvas = {} as HTMLCanvasElement;
+      const calls: string[] = [];
+
+      const canvas = createPatternCanvas(
+        4,
+        5,
+        undefined,
+        (width, height) => {
+          calls.push(`dom:${width}x${height}`);
+          return expectedCanvas;
+        }
+      );
+
+      assert.deepEqual({ canvas, calls }, {
+        canvas: expectedCanvas,
+        calls: ['dom:4x5']
+      });
+    });
+  });
+});

--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
@@ -8,6 +8,29 @@ import type { ILogService } from 'common/services/Services';
 import { customGlyphDefinitions } from './CustomGlyphDefinitions';
 import { CustomGlyphDefinitionType, CustomGlyphScaleType, CustomGlyphVectorType, type CustomGlyphDefinitionPart, type CustomGlyphPathDrawFunctionDefinition, type CustomGlyphPatternDefinition, type ICustomGlyphSolidOctantBlockVector, type ICustomGlyphVectorShape } from './Types';
 
+type PatternCanvas = HTMLCanvasElement | OffscreenCanvas;
+type PatternCanvasFactory = (width: number, height: number) => PatternCanvas;
+
+const createOffscreenPatternCanvas: PatternCanvasFactory | undefined = typeof OffscreenCanvas === 'undefined'
+  ? undefined
+  : (width, height) => new OffscreenCanvas(width, height);
+
+const createDomPatternCanvas: PatternCanvasFactory = (width, height) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+};
+
+export function createPatternCanvas(
+  width: number,
+  height: number,
+  offscreenCanvasFactory: PatternCanvasFactory | undefined = createOffscreenPatternCanvas,
+  domCanvasFactory: PatternCanvasFactory = createDomPatternCanvas
+): PatternCanvas {
+  return offscreenCanvasFactory?.(width, height) ?? domCanvasFactory(width, height);
+}
+
 /**
  * Try drawing a custom block element or box drawing character, returning whether it was
  * successfully drawn.
@@ -458,9 +481,9 @@ function drawPatternChar(
   if (!pattern) {
     const width = charDefinition[0].length;
     const height = charDefinition.length;
-    const tmpCanvas = ctx.canvas.ownerDocument.createElement('canvas');
-    tmpCanvas.width = width;
-    tmpCanvas.height = height;
+    // The atlas canvas can be adopted into another document, so temporary resources must not use
+    // its mutable ownerDocument.
+    const tmpCanvas = createPatternCanvas(width, height);
     const tmpCtx = throwIfFalsy(tmpCanvas.getContext('2d'));
     const imageData = new ImageData(width, height);
 

--- a/addons/addon-webgl/test/WebglCustomGlyphs.test.ts
+++ b/addons/addon-webgl/test/WebglCustomGlyphs.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import test, { expect } from '@playwright/test';
+import { platform } from 'os';
+import { ITestContext, createTestContext, openTerminal } from '../../../test/playwright/TestUtils';
+
+interface ITestRendererWithAtlasCanvas {
+  readonly _charAtlas?: {
+    readonly _tmpCanvas?: HTMLCanvasElement;
+  };
+}
+
+async function writeAndWaitForRender(ctx: ITestContext, data: string): Promise<void> {
+  const renderPromise = new Promise<void>(resolve => {
+    const disposable = ctx.proxy.onRender(() => {
+      disposable.dispose();
+      resolve();
+    });
+  });
+  await ctx.proxy.write(data);
+  await renderPromise;
+}
+
+test.describe('WebGL custom glyphs', () => {
+  if (platform() === 'linux') {
+    test.skip(({ browserName }) => browserName === 'firefox' || browserName === 'webkit');
+  }
+
+  test('pattern glyphs render after the terminal is adopted into another document', async ({ browser }) => {
+    const ctx = await createTestContext(browser);
+    const errors: string[] = [];
+    const onError = (error: Error): void => { errors.push(error.message); };
+    ctx.page.on('pageerror', onError);
+    try {
+      await openTerminal(ctx);
+      await ctx.page.evaluate(`
+        window.addon = new window.WebglAddon({ customGlyphs: true });
+        window.term.loadAddon(window.addon);
+      `);
+      await ctx.page.evaluate(() => {
+        const frame = document.createElement('iframe');
+        document.body.appendChild(frame);
+        const auxiliaryDocument = frame.contentDocument;
+        if (!auxiliaryDocument?.body || !window.term.element) {
+          throw new Error('Auxiliary document and terminal element must be available');
+        }
+        const renderer = window.term._core?._renderService?._renderer?.value as ITestRendererWithAtlasCanvas | undefined;
+        const atlasCanvas = renderer?._charAtlas?._tmpCanvas;
+        if (!atlasCanvas) {
+          throw new Error('Texture atlas canvas must be available');
+        }
+        // Model the atlas state after an uncached glyph has attached the measurement canvas.
+        window.term.element.appendChild(atlasCanvas);
+        auxiliaryDocument.body.appendChild(window.term.element);
+        if (atlasCanvas.ownerDocument !== auxiliaryDocument) {
+          throw new Error('Texture atlas canvas must be adopted into the auxiliary document');
+        }
+        auxiliaryDocument.createElement = () => {
+          throw new Error('Not allowed to create elements in the auxiliary document');
+        };
+      });
+
+      await writeAndWaitForRender(ctx, '\u2591');
+      await writeAndWaitForRender(ctx, 'X');
+
+      const line = await ctx.page.evaluate(() => window.term.buffer.active.getLine(0)?.translateToString(true));
+      expect(errors, `renderer must not create pattern canvases in the auxiliary document: ${errors[0] ?? ''}`).toEqual([]);
+      expect(line).toBe('\u2591X');
+    } finally {
+      ctx.page.off('pageerror', onError);
+      await ctx.page.close();
+    }
+  });
+});


### PR DESCRIPTION
Resolves: https://github.com/xtermjs/xterm.js/issues/6129
Related: https://github.com/microsoft/vscode/issues/327958
Follow-up to: https://github.com/microsoft/vscode/pull/330777

`drawPatternChar` created its temporary pattern canvas through `ctx.canvas.ownerDocument`. When a terminal was moved into an auxiliary/dedicated window, the rendering canvas could belong to a document that rejects element creation. Rendering pattern glyphs such as `░`, `▒`, or `▓` would then throw and stop the WebGL render loop.

- Use `OffscreenCanvas` for the temporary pattern source when available.
- Fall back to a DOM canvas created from the main JavaScript realm instead of the rendering canvas's mutable `ownerDocument`.
- Keep the visible terminal canvas, WebGL renderer, texture atlas, and other custom-glyph paths unchanged.
- Add unit coverage for the offscreen and DOM fallback paths.
- Add a WebGL regression that moves the atlas canvas into an auxiliary document, renders `U+2591`, and verifies subsequent rendering continues.

This benefits VS Code and other xterm.js embedders that host terminals in dedicated windows.

For VS Code, this allows the workaround from microsoft/vscode#330777 to be removed after the fixed xterm version is consumed. Custom glyphs can then remain enabled when a terminal moves into a dedicated window and back into the main window.

### Validation

- `npm run build`
- Focused `CustomGlyphRasterizer` unit tests
- `WebglCustomGlyphs.test.ts`: verifies that `U+2591` and a following glyph render after the atlas canvas moves into an auxiliary document
- oxlint and ESLint on all changed files

The `WebglCustomGlyphs.test.ts` regression was also run against the previous implementation by restoring `ctx.canvas.ownerDocument.createElement('canvas')`. With that implementation, the test failed with the original `drawPatternChar` → auxiliary-document `createElement` exception. It passes with this change.

-----------------------------------------
Inspirations from:

- The `OffscreenCanvas` preference with a DOM fallback follows the existing [`WidthCache`](https://github.com/xtermjs/xterm.js/blob/6a49e1aa61e28793bcaad634d29ce5862b358542/src/browser/renderer/dom/WidthCache.ts#L145-L158) approach.