### PR TITLE
Restore text overwrite of image tiles

### DIFF
--- a/addons/addon-image/src/ImageStorage.ts
+++ b/addons/addon-image/src/ImageStorage.ts
@@ -427,55 +427,46 @@ export class ImageStorage implements IDisposable {
     const placeholderCalls: { col: number, row: number, count: number }[] = [];
 
     // walk all cells in viewport and collect tiles found
-    // Note: We check _extendedAttrs directly (not just HAS_EXTENDED flag)
-    // because text writes clear the BG flag but leave image tile data intact.
-    // This lets top-layer images survive text overwrites (kitty C=1 behavior).
     for (let row = start; row <= end; ++row) {
       const line = buffer.lines.get(row + buffer.ydisp) as IBufferLineExt;
       if (!line) return;
       for (let col = 0; col < cols; ++col) {
-        let e: IExtendedAttrsImage;
         if (line.getBg(col) & BgFlags.HAS_EXTENDED) {
-          e = line._extendedAttrs[col] ?? EMPTY_ATTRS;
-        } else {
-          const maybeImg = line._extendedAttrs[col] as IExtendedAttrsImage | undefined;
-          if (!maybeImg || maybeImg.imageId === undefined || maybeImg.imageId === -1) {
+          let e: IExtendedAttrsImage = line._extendedAttrs[col] ?? EMPTY_ATTRS;
+          const imageId = e.imageId;
+          if (imageId === undefined || imageId === -1) {
             continue;
           }
-          e = maybeImg;
-        }
-        const imageId = e.imageId;
-        if (imageId === undefined || imageId === -1) {
-          continue;
-        }
-        const imgSpec = this._images.get(imageId);
-        if (e.tileId !== -1) {
-          const startTile = e.tileId;
-          const startCol = col;
-          let count = 1;
-          /**
-           * merge tiles to the right into a single draw call, if:
-           * - not at end of line
-           * - cell has same image id
-           * - cell has consecutive tile id
-           * Also check _extendedAttrs directly for cells where text cleared HAS_EXTENDED.
-           */
-          while (++col < cols) {
-            const nextE = line._extendedAttrs[col] as IExtendedAttrsImage | undefined;
-            if (!nextE || nextE.imageId !== imageId || nextE.tileId !== startTile + count) {
-              break;
+          const imgSpec = this._images.get(imageId);
+          if (e.tileId !== -1) {
+            const startTile = e.tileId;
+            const startCol = col;
+            let count = 1;
+            /**
+             * merge tiles to the right into a single draw call, if:
+             * - not at end of line
+             * - cell has same image id
+             * - cell has consecutive tile id
+             */
+            while (
+              ++col < cols
+              && (line.getBg(col) & BgFlags.HAS_EXTENDED)
+              && (e = line._extendedAttrs[col] ?? EMPTY_ATTRS)
+              && (e.imageId === imageId)
+              && (e.tileId === startTile + count)
+            ) {
+              count++;
             }
-            count++;
-          }
-          col--;
-          if (imgSpec) {
-            if (imgSpec.actual) {
-              drawCalls.push({ imgSpec, tileId: startTile, col: startCol, row, count });
+            col--;
+            if (imgSpec) {
+              if (imgSpec.actual) {
+                drawCalls.push({ imgSpec, tileId: startTile, col: startCol, row, count });
+              }
+            } else if (this._opts.showPlaceholder) {
+              placeholderCalls.push({ col: startCol, row, count });
             }
-          } else if (this._opts.showPlaceholder) {
-            placeholderCalls.push({ col: startCol, row, count });
+            this._fullyCleared = false;
           }
-          this._fullyCleared = false;
         }
       }
     }

--- a/addons/addon-image/test/ImageAddon.test.ts
+++ b/addons/addon-image/test/ImageAddon.test.ts
@@ -435,6 +435,15 @@ test.describe('ImageAddon', () => {
       });
     }
   });
+
+  test.describe('text overwrite removes tiles', () => {
+    test('sixel', async () => {
+      await assertTextClearsTiles(SIXEL_SEQ_0);
+    });
+    test('iip', async () => {
+      await assertTextClearsTiles(TESTDATA_IIP[0][0]);
+    });
+  });
 });
 
 /**
@@ -471,4 +480,21 @@ async function getOrigSize(id: number): Promise<[number, number]> {
 
 async function getImageAtBufferCell(x: number, y: number): Promise<string | undefined> {
   return ctx.page.evaluate<any>(`window.imageAddon.getImageAtBufferCell(${x}, ${y})?.toDataURL('image/png')`);
+}
+
+async function hasTileAtBufferCell(x: number, y: number): Promise<boolean> {
+  return ctx.page.evaluate(`!!window.imageAddon.extractTileAtBufferCell(${x}, ${y})`);
+}
+
+async function assertTextClearsTiles(imageSeq: string): Promise<void> {
+  await ctx.proxy.write('\x1b[H' + imageSeq);
+  await pollFor(ctx.page, '!!window.imageAddon.extractTileAtBufferCell(5, 1)', true);
+  ok(await hasTileAtBufferCell(0, 1));
+  await ctx.proxy.write('\x1b[2;6H#######');
+  for (let x = 5; x < 12; x++) {
+    strictEqual(await hasTileAtBufferCell(x, 1), false);
+  }
+  ok(await hasTileAtBufferCell(0, 1));
+  ok(await hasTileAtBufferCell(13, 1));
+  ok(((await ctx.page.evaluate('window.term.buffer.active.getLine(1).translateToString(true)')) as string).includes('#######'));
 }

--- a/addons/addon-image/test/KittyGraphics.test.ts
+++ b/addons/addon-image/test/KittyGraphics.test.ts
@@ -2213,6 +2213,21 @@ test.describe('Kitty Graphics Protocol', () => {
       await pollFor(ctx.page, 'window._imageAddedCount', 2);
     });
   });
+
+  test.describe('text overwrite removes tiles', () => {
+    test('a=T placement', async () => {
+      await ctx.proxy.write(`\x1b[H\x1b_Ga=T,f=100;${KITTY_MULTICOLOR_200X100_BASE64}\x1b\\`);
+      await pollFor(ctx.page, '!!window.imageAddon.extractTileAtBufferCell(5, 1)', true);
+      ok(await hasTileAtBufferCell(0, 1));
+      await ctx.proxy.write('\x1b[2;6H#######');
+      for (let x = 5; x < 12; x++) {
+        strictEqual(await hasTileAtBufferCell(x, 1), false);
+      }
+      ok(await hasTileAtBufferCell(0, 1));
+      ok(await hasTileAtBufferCell(13, 1));
+      ok(((await ctx.page.evaluate('window.term.buffer.active.getLine(1).translateToString(true)')) as string).includes('#######'));
+    });
+  });
 });
 
 /**
@@ -2261,4 +2276,8 @@ async function getPixels(col: number, row: number, x: number, y: number, w: numb
     if (!ctx2d) return null;
     return Array.from(ctx2d.getImageData(x, y, w, h).data);
   }, [col, row, x, y, w, h]);
+}
+
+async function hasTileAtBufferCell(x: number, y: number): Promise<boolean> {
+  return ctx.page.evaluate(`!!window.imageAddon.extractTileAtBufferCell(${x}, ${y})`);
 }


### PR DESCRIPTION
Resolves: https://github.com/xtermjs/xterm.js/issues/5860
Follow-up: https://github.com/xtermjs/xterm.js/issues/6132

Commit [`21f5156`](https://github.com/xtermjs/xterm.js/commit/21f51564d1713dab5179eaaf15b1d6005152ce83) from #5619 changed `ImageStorage.render()` to keep rendering image data found in `_extendedAttrs` after text had cleared the cell's `HAS_EXTENDED` flag. Because sixel, IIP, and the current Kitty implementation share this cell-backed storage, newly written text remained hidden behind stale image tiles.

- Partially revert only the `ImageStorage.ts` tile walk from `21f5156`.
- Restore `HAS_EXTENDED` as the authoritative indication that a cell contains active image data.
- Stop merging and rendering tiles once text has cleared that flag.
- Preserve the separate `ImageRenderer` z-index and `KittyGraphicsHandler` bottom-layer changes from `21f5156`.
- Add Playwright coverage for sixel, IIP, and Kitty `a=T`, verifying that overwritten cells lose their tiles while neighboring tiles remain intact.

### Remaining Kitty graphics gap

This restores WezTerm-style text overwrite behavior for the current cell-backed Kitty implementation.

Full Kitty placement semantics remain unsupported: Kitty images with `z >= 0` should be tracked independently from the text grid so they can remain above later text. Supporting that correctly requires a separate placement store with placement IDs, rectangles, and z-index ordering—not stale `_extendedAttrs`. This follow-up is tracked in #6132.

`C=1` only disables cursor movement; it does not control image layering.

### Verification

- `npm run lint-changes`
- `npm run test-integration -- --suite=addon-image --project=Chromium`
- Manually verified that writing `#######` over an IIP image removes only the corresponding image tiles.

-----------------------------------------
Inspirations from:

- The authoritative `HAS_EXTENDED` tile walk comes from jerch's original [`ImageStorage.render`](https://github.com/xtermjs/xterm.js/blob/ebfff5efeecfe7ab0079a5d1a83bc7e69963f1ef/addons/xterm-addon-image/src/ImageStorage.ts#L360-L403).
- The restored merge behavior comes from the pre-regression [`ImageStorage.render`](https://github.com/xtermjs/xterm.js/blob/27b01b22ef7976a2026589852bf310636a57612e/addons/addon-image/src/ImageStorage.ts#L417-L460).