### PR TITLE
Snap WebGL block glyphs to shared pixel boundaries

### DIFF
--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.test.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.test.ts
@@ -4,9 +4,132 @@
  */
 
 import { assert } from 'chai';
-import { createPatternCanvas } from './CustomGlyphRasterizer';
+import type { ILogService } from 'common/services/Services';
+import { createPatternCanvas, tryDrawCustomGlyph } from './CustomGlyphRasterizer';
+
+interface IFillRectCall {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function getBlockRectCalls(
+  char: string,
+  deviceCellWidth: number,
+  deviceCellHeight: number,
+  xOffset: number = 0,
+  yOffset: number = 0
+): IFillRectCall[] {
+  const calls: IFillRectCall[] = [];
+  const ctx = {
+    fillRect: (x: number, y: number, width: number, height: number): void => {
+      calls.push({ x, y, width, height });
+    }
+  } as unknown as CanvasRenderingContext2D;
+
+  assert.isTrue(tryDrawCustomGlyph(
+    ctx,
+    char,
+    xOffset,
+    yOffset,
+    deviceCellWidth,
+    deviceCellHeight,
+    deviceCellWidth,
+    deviceCellHeight,
+    15,
+    1,
+    {} as ILogService
+  ));
+  return calls;
+}
+
+function getIntegerCoverage(calls: IFillRectCall[]): Set<string> {
+  const result = new Set<string>();
+  for (const call of calls) {
+    assert.isTrue([call.x, call.y, call.width, call.height].every(Number.isInteger));
+    for (let y = call.y; y < call.y + call.height; y++) {
+      for (let x = call.x; x < call.x + call.width; x++) {
+        result.add(`${x},${y}`);
+      }
+    }
+  }
+  return result;
+}
+
+function getIntersectionArea(a: IFillRectCall, b: IFillRectCall): number {
+  return Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x)) *
+    Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y));
+}
 
 describe('CustomGlyphRasterizer', () => {
+  describe('solid octant block vectors', () => {
+    it('shares integer boundaries between composite and complementary blocks', () => {
+      const [leftFull, upperRight] = getBlockRectCalls('\u259B', 9, 17);
+      assert.isTrue([leftFull, upperRight]
+        .flatMap(e => [e.x, e.y, e.width, e.height])
+        .every(Number.isInteger));
+      assert.equal(leftFull.x + leftFull.width, upperRight.x);
+      assert.equal(leftFull.height, 17);
+      assert.isBelow(upperRight.height, leftFull.height);
+
+      const [left] = getBlockRectCalls('\u258C', 9, 17);
+      const [right] = getBlockRectCalls('\u2590', 9, 17);
+      assert.equal(left.x + left.width, right.x);
+      assert.equal(left.width + right.width, 9);
+
+      const [top] = getBlockRectCalls('\u2580', 9, 17);
+      const [bottom] = getBlockRectCalls('\u2584', 9, 17);
+      assert.equal(top.y + top.height, bottom.y);
+      assert.equal(top.height + bottom.height, 17);
+    });
+
+    it('preserves one-eighth coverage across the sampling threshold', () => {
+      for (const width of [7, 8, 9]) {
+        const [stripe] = getBlockRectCalls('\u{1FB73}', width, 17);
+        assert.isAbove(stripe.width, 0);
+        if (width >= 8) {
+          assert.isTrue(Number.isInteger(stripe.x));
+          assert.isTrue(Number.isInteger(stripe.width));
+        }
+      }
+      const [horizontalStripe] = getBlockRectCalls('\u{1FB79}', 9, 7);
+      assert.isAbove(horizontalStripe.height, 0);
+      assert.isFalse(Number.isInteger(horizontalStripe.y));
+    });
+
+    it('preserves intentional gaps in striped and checkerboard blocks', () => {
+      const stripes = getBlockRectCalls('\u{1FB81}', 9, 9);
+      assert.lengthOf(stripes, 4);
+      getIntegerCoverage(stripes);
+      assert.isTrue(stripes.every(e => e.width === 9 && e.height === 1));
+      for (let i = 1; i < stripes.length; i++) {
+        assert.isBelow(stripes[i - 1].y + stripes[i - 1].height, stripes[i].y);
+      }
+
+      const checker = getBlockRectCalls('\u{1FB95}', 9, 9);
+      const coverage = getIntegerCoverage(checker);
+      for (let i = 0; i < checker.length; i++) {
+        for (let j = i + 1; j < checker.length; j++) {
+          assert.equal(getIntersectionArea(checker[i], checker[j]), 0);
+        }
+      }
+      assert.isAtLeast(coverage.size, 36);
+      assert.isAtMost(coverage.size, 45);
+      for (let y = 0; y < 9; y++) {
+        const count = Array.from({ length: 9 }, (_, x) => coverage.has(`${x},${y}`)).filter(Boolean).length;
+        assert.isAbove(count, 0);
+        assert.isBelow(count, 9);
+      }
+    });
+
+    it('rounds absolute coordinates instead of local dimensions', () => {
+      assert.deepEqual(getBlockRectCalls('\u258C', 9, 17, 2.25, 3.25), [
+        { x: 2, y: 3, width: 5, height: 17 }
+      ]);
+    });
+  });
+
   describe('createPatternCanvas', () => {
     it('prefers an offscreen canvas without using the DOM canvas factory', () => {
       const expectedCanvas = {} as OffscreenCanvas;

--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.test.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.test.ts
@@ -65,18 +65,20 @@ function getIntersectionArea(a: IFillRectCall, b: IFillRectCall): number {
 describe('CustomGlyphRasterizer', () => {
   describe('solid octant block vectors', () => {
     it('shares integer boundaries between composite and complementary blocks', () => {
-      const [leftFull, upperRight] = getBlockRectCalls('\u259B', 9, 17);
-      assert.isTrue([leftFull, upperRight]
-        .flatMap(e => [e.x, e.y, e.width, e.height])
-        .every(Number.isInteger));
-      assert.equal(leftFull.x + leftFull.width, upperRight.x);
-      assert.equal(leftFull.height, 17);
-      assert.isBelow(upperRight.height, leftFull.height);
+      for (const width of [7, 9]) {
+        const [leftFull, upperRight] = getBlockRectCalls('\u259B', width, 17);
+        assert.isTrue([leftFull, upperRight]
+          .flatMap(e => [e.x, e.y, e.width, e.height])
+          .every(Number.isInteger));
+        assert.equal(leftFull.x + leftFull.width, upperRight.x);
+        assert.equal(leftFull.height, 17);
+        assert.isBelow(upperRight.height, leftFull.height);
 
-      const [left] = getBlockRectCalls('\u258C', 9, 17);
-      const [right] = getBlockRectCalls('\u2590', 9, 17);
-      assert.equal(left.x + left.width, right.x);
-      assert.equal(left.width + right.width, 9);
+        const [left] = getBlockRectCalls('\u258C', width, 17);
+        const [right] = getBlockRectCalls('\u2590', width, 17);
+        assert.equal(left.x + left.width, right.x);
+        assert.equal(left.width + right.width, width);
+      }
 
       const [top] = getBlockRectCalls('\u2580', 9, 17);
       const [bottom] = getBlockRectCalls('\u2584', 9, 17);
@@ -93,6 +95,12 @@ describe('CustomGlyphRasterizer', () => {
           assert.isTrue(Number.isInteger(stripe.width));
         }
       }
+      const [unsafeStripe] = getBlockRectCalls('\u{1FB73}', 7, 17);
+      assert.isFalse(Number.isInteger(unsafeStripe.x));
+      assert.isFalse(Number.isInteger(unsafeStripe.width));
+      const [offsetSafeStripe] = getBlockRectCalls('\u{1FB73}', 7, 17, 0.25);
+      assert.deepEqual(offsetSafeStripe, { x: 4, y: 0, width: 1, height: 17 });
+
       const [horizontalStripe] = getBlockRectCalls('\u{1FB79}', 9, 7);
       assert.isAbove(horizontalStripe.height, 0);
       assert.isFalse(Number.isInteger(horizontalStripe.y));
@@ -107,19 +115,21 @@ describe('CustomGlyphRasterizer', () => {
         assert.isBelow(stripes[i - 1].y + stripes[i - 1].height, stripes[i].y);
       }
 
-      const checker = getBlockRectCalls('\u{1FB95}', 9, 9);
-      const coverage = getIntegerCoverage(checker);
-      for (let i = 0; i < checker.length; i++) {
-        for (let j = i + 1; j < checker.length; j++) {
-          assert.equal(getIntersectionArea(checker[i], checker[j]), 0);
+      for (const size of [7, 9]) {
+        const checker = getBlockRectCalls('\u{1FB95}', size, size);
+        const coverage = getIntegerCoverage(checker);
+        for (let i = 0; i < checker.length; i++) {
+          for (let j = i + 1; j < checker.length; j++) {
+            assert.equal(getIntersectionArea(checker[i], checker[j]), 0);
+          }
         }
-      }
-      assert.isAtLeast(coverage.size, 36);
-      assert.isAtMost(coverage.size, 45);
-      for (let y = 0; y < 9; y++) {
-        const count = Array.from({ length: 9 }, (_, x) => coverage.has(`${x},${y}`)).filter(Boolean).length;
-        assert.isAbove(count, 0);
-        assert.isBelow(count, 9);
+        assert.isAtLeast(coverage.size, Math.floor(size * size / 2));
+        assert.isAtMost(coverage.size, Math.ceil(size * size / 2));
+        for (let y = 0; y < size; y++) {
+          const count = Array.from({ length: size }, (_, x) => coverage.has(`${x},${y}`)).filter(Boolean).length;
+          assert.isAbove(count, 0);
+          assert.isBelow(count, size);
+        }
       }
     });
 

--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
@@ -136,8 +136,8 @@ function drawBlockVectorChar(
 ): void {
   const xEighth = deviceCellWidth / 8;
   const yEighth = deviceCellHeight / 8;
-  const snapX = deviceCellWidth >= 8;
-  const snapY = deviceCellHeight >= 8;
+  const snapX = canSnapBlockVectorAxis(charDefinition, xOffset, xEighth, 'x', 'w');
+  const snapY = canSnapBlockVectorAxis(charDefinition, yOffset, yEighth, 'y', 'h');
   for (let i = 0; i < charDefinition.length; i++) {
     const box = charDefinition[i];
     let left = xOffset + box.x * xEighth;
@@ -145,7 +145,7 @@ function drawBlockVectorChar(
     let right = xOffset + (box.x + box.w) * xEighth;
     let bottom = yOffset + (box.y + box.h) * yEighth;
     // Use shared pixel boundaries to avoid antialiasing seams without expanding adjacent boxes.
-    // Preserve fractional coverage when an axis has fewer pixels than octants.
+    // Preserve fractional coverage when snapping would collapse a used boundary.
     if (snapX) {
       left = Math.round(left);
       right = Math.round(right);
@@ -161,6 +161,37 @@ function drawBlockVectorChar(
       bottom - top
     );
   }
+}
+
+function canSnapBlockVectorAxis(
+  charDefinition: ICustomGlyphSolidOctantBlockVector[],
+  offset: number,
+  eighth: number,
+  startKey: 'x' | 'y',
+  sizeKey: 'w' | 'h'
+): boolean {
+  if (eighth >= 1) {
+    return true;
+  }
+
+  let boundaryMask = 0;
+  for (let i = 0; i < charDefinition.length; i++) {
+    const box = charDefinition[i];
+    boundaryMask |= 1 << box[startKey];
+    boundaryMask |= 1 << (box[startKey] + box[sizeKey]);
+  }
+
+  let previous = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i <= 8; i++) {
+    if (boundaryMask & (1 << i)) {
+      const current = Math.round(offset + i * eighth);
+      if (current <= previous) {
+        return false;
+      }
+      previous = current;
+    }
+  }
+  return true;
 }
 
 /**

--- a/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
+++ b/addons/addon-webgl/src/customGlyphs/CustomGlyphRasterizer.ts
@@ -134,15 +134,31 @@ function drawBlockVectorChar(
   deviceCellWidth: number,
   deviceCellHeight: number
 ): void {
+  const xEighth = deviceCellWidth / 8;
+  const yEighth = deviceCellHeight / 8;
+  const snapX = deviceCellWidth >= 8;
+  const snapY = deviceCellHeight >= 8;
   for (let i = 0; i < charDefinition.length; i++) {
     const box = charDefinition[i];
-    const xEighth = deviceCellWidth / 8;
-    const yEighth = deviceCellHeight / 8;
+    let left = xOffset + box.x * xEighth;
+    let top = yOffset + box.y * yEighth;
+    let right = xOffset + (box.x + box.w) * xEighth;
+    let bottom = yOffset + (box.y + box.h) * yEighth;
+    // Use shared pixel boundaries to avoid antialiasing seams without expanding adjacent boxes.
+    // Preserve fractional coverage when an axis has fewer pixels than octants.
+    if (snapX) {
+      left = Math.round(left);
+      right = Math.round(right);
+    }
+    if (snapY) {
+      top = Math.round(top);
+      bottom = Math.round(bottom);
+    }
     ctx.fillRect(
-      xOffset + box.x * xEighth,
-      yOffset + box.y * yEighth,
-      box.w * xEighth,
-      box.h * yEighth
+      left,
+      top,
+      right - left,
+      bottom - top
     );
   }
 }

--- a/addons/addon-webgl/test/WebglCustomGlyphs.test.ts
+++ b/addons/addon-webgl/test/WebglCustomGlyphs.test.ts
@@ -169,7 +169,7 @@ test.describe('WebGL custom glyphs', () => {
         return renderer.dimensions.device.char.width;
       });
       const deviceCharWidth = Math.floor(charWidth);
-      const targetCellWidth = Math.max(9, deviceCharWidth % 2 === 0 ? deviceCharWidth + 1 : deviceCharWidth);
+      const targetCellWidth = 7;
       await ctx.proxy.setOption('letterSpacing', targetCellWidth - deviceCharWidth);
       await ctx.page.evaluate(() => {
         window.addon = new window.WebglAddon({ customGlyphs: true });
@@ -186,27 +186,17 @@ test.describe('WebGL custom glyphs', () => {
       expect(dimensions.width).toBe(targetCellWidth);
       expect(dimensions.width % 2).toBe(1);
 
-      await writeAndWaitForRender(ctx, '\x1b[?25l\x1b[H\u259B\u259A\u{1FB81}\u{1FB95}');
-      const glyphPixels = await getGlyphPixels(ctx, ['\u259B', '\u259A', '\u{1FB81}', '\u{1FB95}']);
+      await writeAndWaitForRender(ctx, '\x1b[?25l\x1b[H\u259B\u259C\u259D\u259A\u{1FB81}\u{1FB95}');
+      const glyphPixels = await getGlyphPixels(ctx, ['\u259B', '\u259C', '\u259D', '\u259A', '\u{1FB81}', '\u{1FB95}']);
       for (const glyph of glyphPixels) {
         expect(glyph.colored, `U+${glyph.code.toString(16).toUpperCase()} must not be empty`).toBeGreaterThan(0);
         expect(glyph.partial, `U+${glyph.code.toString(16).toUpperCase()} must be opaque`).toBe(0);
       }
 
-      const narrowCellWidth = 7;
-      await ctx.proxy.setOption('letterSpacing', narrowCellWidth - deviceCharWidth);
-      const resizedCellWidth = await ctx.page.evaluate(() => {
-        const renderer = window.term._core?._renderService?._renderer?.value as ITestRendererWithAtlasCanvas | undefined;
-        if (!renderer) {
-          throw new Error('WebGL renderer must be available');
-        }
-        return renderer.dimensions.device.cell.width;
-      });
-      expect(resizedCellWidth).toBe(narrowCellWidth);
-
       await writeAndWaitForRender(ctx, '\x1b[H\u{1FB73}');
       const [narrowStripePixels] = await getGlyphPixels(ctx, ['\u{1FB73}']);
       expect(narrowStripePixels.colored, `U+${narrowStripePixels.code.toString(16).toUpperCase()} must not be empty`).toBeGreaterThan(0);
+      expect(narrowStripePixels.partial, `U+${narrowStripePixels.code.toString(16).toUpperCase()} must retain fractional coverage`).toBeGreaterThan(0);
     } finally {
       await ctx.page.close();
     }

--- a/addons/addon-webgl/test/WebglCustomGlyphs.test.ts
+++ b/addons/addon-webgl/test/WebglCustomGlyphs.test.ts
@@ -7,10 +7,82 @@ import test, { expect } from '@playwright/test';
 import { platform } from 'os';
 import { ITestContext, createTestContext, openTerminal } from '../../../test/playwright/TestUtils';
 
+interface ITestRasterizedGlyph {
+  readonly texturePage: number;
+  readonly texturePosition: {
+    readonly x: number;
+    readonly y: number;
+  };
+  readonly size: {
+    readonly x: number;
+    readonly y: number;
+  };
+}
+
+interface ITestGlyphPixels {
+  readonly code: number;
+  readonly colored: number;
+  readonly partial: number;
+}
+
 interface ITestRendererWithAtlasCanvas {
   readonly _charAtlas?: {
     readonly _tmpCanvas?: HTMLCanvasElement;
+    readonly pages: ReadonlyArray<{
+      readonly canvas: HTMLCanvasElement;
+    }>;
+    getRasterizedGlyph(code: number, bg: number, fg: number, ext: number, restrictToCellHeight: boolean, domContainer: HTMLElement | undefined): ITestRasterizedGlyph;
+    getRasterizedGlyphCombinedChar(chars: string, bg: number, fg: number, ext: number, restrictToCellHeight: boolean, domContainer: HTMLElement | undefined): ITestRasterizedGlyph;
   };
+  readonly dimensions: {
+    readonly device: {
+      readonly char: {
+        readonly width: number;
+      };
+      readonly cell: {
+        readonly width: number;
+        readonly height: number;
+      };
+    };
+  };
+}
+
+async function getGlyphPixels(ctx: ITestContext, chars: ReadonlyArray<string>): Promise<ITestGlyphPixels[]> {
+  return ctx.page.evaluate(chars => {
+    const renderer = window.term._core?._renderService?._renderer?.value as ITestRendererWithAtlasCanvas | undefined;
+    const atlas = renderer?._charAtlas;
+    if (!atlas || !window.term.element) {
+      throw new Error('Texture atlas and terminal element must be available');
+    }
+    return chars.map(char => {
+      const code = char.codePointAt(0)!;
+      const glyph = char.length > 1
+        ? atlas.getRasterizedGlyphCombinedChar(char, 0, 0, 0, false, window.term.element)
+        : atlas.getRasterizedGlyph(code, 0, 0, 0, false, window.term.element);
+      const page = atlas.pages[glyph.texturePage];
+      const pageContext = page.canvas.getContext('2d');
+      if (!pageContext) {
+        throw new Error('Texture atlas page context must be available');
+      }
+      const rgba = pageContext.getImageData(
+        glyph.texturePosition.x,
+        glyph.texturePosition.y,
+        glyph.size.x,
+        glyph.size.y
+      ).data;
+      let colored = 0;
+      let partial = 0;
+      for (let i = 3; i < rgba.length; i += 4) {
+        if (rgba[i] > 0) {
+          colored++;
+          if (rgba[i] < 255) {
+            partial++;
+          }
+        }
+      }
+      return { code, colored, partial };
+    });
+  }, chars);
 }
 
 async function writeAndWaitForRender(ctx: ITestContext, data: string): Promise<void> {
@@ -71,6 +143,71 @@ test.describe('WebGL custom glyphs', () => {
       expect(line).toBe('\u2591X');
     } finally {
       ctx.page.off('pageerror', onError);
+      await ctx.page.close();
+    }
+  });
+
+  test('solid block vectors render opaque and preserve narrow stripes', async ({ browser }) => {
+    const ctx = await createTestContext(browser);
+    try {
+      await openTerminal(ctx, {
+        cols: 8,
+        rows: 2,
+        fontSize: 15,
+        minimumContrastRatio: 1,
+        allowTransparency: true,
+        theme: {
+          foreground: '#d78787',
+          background: 'rgba(0, 0, 0, 0)'
+        }
+      });
+      const charWidth = await ctx.page.evaluate(() => {
+        const renderer = window.term._core?._renderService?._renderer?.value as ITestRendererWithAtlasCanvas | undefined;
+        if (!renderer) {
+          throw new Error('Renderer must be available');
+        }
+        return renderer.dimensions.device.char.width;
+      });
+      const deviceCharWidth = Math.floor(charWidth);
+      const targetCellWidth = Math.max(9, deviceCharWidth % 2 === 0 ? deviceCharWidth + 1 : deviceCharWidth);
+      await ctx.proxy.setOption('letterSpacing', targetCellWidth - deviceCharWidth);
+      await ctx.page.evaluate(() => {
+        window.addon = new window.WebglAddon({ customGlyphs: true });
+        window.term.loadAddon(window.addon);
+      });
+
+      const dimensions = await ctx.page.evaluate(() => {
+        const renderer = window.term._core?._renderService?._renderer?.value as ITestRendererWithAtlasCanvas | undefined;
+        if (!renderer) {
+          throw new Error('WebGL renderer must be available');
+        }
+        return renderer.dimensions.device.cell;
+      });
+      expect(dimensions.width).toBe(targetCellWidth);
+      expect(dimensions.width % 2).toBe(1);
+
+      await writeAndWaitForRender(ctx, '\x1b[?25l\x1b[H\u259B\u259A\u{1FB81}\u{1FB95}');
+      const glyphPixels = await getGlyphPixels(ctx, ['\u259B', '\u259A', '\u{1FB81}', '\u{1FB95}']);
+      for (const glyph of glyphPixels) {
+        expect(glyph.colored, `U+${glyph.code.toString(16).toUpperCase()} must not be empty`).toBeGreaterThan(0);
+        expect(glyph.partial, `U+${glyph.code.toString(16).toUpperCase()} must be opaque`).toBe(0);
+      }
+
+      const narrowCellWidth = 7;
+      await ctx.proxy.setOption('letterSpacing', narrowCellWidth - deviceCharWidth);
+      const resizedCellWidth = await ctx.page.evaluate(() => {
+        const renderer = window.term._core?._renderService?._renderer?.value as ITestRendererWithAtlasCanvas | undefined;
+        if (!renderer) {
+          throw new Error('WebGL renderer must be available');
+        }
+        return renderer.dimensions.device.cell.width;
+      });
+      expect(resizedCellWidth).toBe(narrowCellWidth);
+
+      await writeAndWaitForRender(ctx, '\x1b[H\u{1FB73}');
+      const [narrowStripePixels] = await getGlyphPixels(ctx, ['\u{1FB73}']);
+      expect(narrowStripePixels.colored, `U+${narrowStripePixels.code.toString(16).toUpperCase()} must not be empty`).toBeGreaterThan(0);
+    } finally {
       await ctx.page.close();
     }
   });


### PR DESCRIPTION
## Why

Solid octant block glyphs are drawn from rectangles positioned on an
eighth-cell grid. When a device-cell dimension is not divisible by eight,
fractional rectangle edges are antialiased in the WebGL texture atlas. This can
leave softened edges or visible seams in composite quadrant glyphs, including
at common seven-pixel cell widths.

For example:

```text
 ▐▛███▛█
▝▜██████▀
  ▝▝ ▝▝
```

Snapping every rectangle outward closes seams but can expand intentional gaps.
Always snapping shared boundaries can instead collapse narrow one-eighth
features when a cell dimension contains fewer than eight pixels.

## What changed

- Snap shared absolute octant boundaries to integer device pixels.
- Below eight pixels, snap an axis only when every boundary used by that glyph
  remains distinct after rounding.
- Preserve fractional coordinates when snapping would collapse a thin stroke or
  intentional gap.
- Keep other custom glyph types and renderers unchanged.
- Add geometry and WebGL atlas regression coverage.

## Testing

- Covered composite quadrants and complementary halves at seven- and nine-pixel
  cell widths.
- Covered one-eighth stripes, fractional offsets, sparse stripes, and
  checkerboard topology.
- Verified that safe seven-pixel glyphs contain no partially transparent atlas
  pixels while an unsafe seven-pixel one-eighth stripe remains visible with
  fractional coverage.
- Verified the focused addon-webgl Chromium integration test and changed-file
  lint.
