### PR TITLE
Don't send the composition twice when a keydown finalizes it (#5778)

### DIFF
--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -234,6 +234,26 @@ describe('CompositionHelper', () => {
       }, 0);
     });
 
+    it('Should not send the composition twice when a keydown finalizes it before compositionend (#5778)', (done) => {
+      // Compose 'こんにちは'
+      compositionHelper.compositionstart();
+      compositionHelper.compositionupdate({ data: 'こんにちは' });
+      textarea.value = 'こんにちは';
+      setTimeout(() => { // wait for any textarea updates
+        // A keydown the IME does not consume ends the composition, eg. the macOS eisuu (英数)
+        // input source switch key. keydown() sends the composition immediately.
+        compositionHelper.keydown({ keyCode: 102 } as KeyboardEvent);
+        assert.equal(handledText, 'こんにちは');
+        // The browser then fires compositionend without having cleared the textarea. The deferred
+        // send must skip what keydown already sent.
+        compositionHelper.compositionend();
+        setTimeout(() => { // wait for any textarea updates
+          assert.equal(handledText, 'こんにちは');
+          done();
+        }, 0);
+      }, 0);
+    });
+
     it('Should insert middle composition and subsequent input without appending existing trailing text', (done) => {
       textarea.value = '一二';
       // screenReaderMode keeps textarea content/selection for assistive technologies (eg. screen

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -154,6 +154,10 @@ export class CompositionHelper {
       // Cancel any delayed composition send requests and send the input immediately.
       this._isSendingComposition = false;
       const input = this._textarea.value.substring(this._compositionPosition.start, this._compositionPosition.end);
+      // Record what was sent so the deferred send scheduled by the compositionend that follows
+      // skips it, using the same offset the keyCode 229 path relies on (issue #3191). Without
+      // this the same text is emitted twice (issue #5778).
+      this._dataAlreadySent = input;
       this._coreService.triggerDataEvent(input, true);
     } else {
       // Make a deep copy of the composition position here as a new compositionstart event may

--- a/test/playwright/Composition.test.ts
+++ b/test/playwright/Composition.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+import { test, type CDPSession } from '@playwright/test';
+import { deepStrictEqual } from 'assert';
+import { ITestContext, createTestContext, openTerminal, pollFor, timeout } from './TestUtils';
+
+/**
+ * IME composition driven through the browser's own input pipeline rather than through synthesised
+ * CompositionEvent objects: `Input.imeSetComposition` makes Chromium's renderer produce real
+ * compositionstart/compositionupdate, and `Input.insertText` makes it produce the real
+ * compositionend, so the event ordering asserted here is the ordering an OS IME produces.
+ *
+ * This needs CDP and so is Chromium only, but that is the point: a maintainer with no Japanese or
+ * Korean input method installed can still reproduce composition bugs.
+ */
+
+const COMPOSITION = 'こんにちは';
+/** F7's own output. It is in the expected data because pressing F7 is part of the scenario. */
+const F7 = '\x1b[18~';
+/** Long enough for the deferred setTimeout(0) send in CompositionHelper to have run. */
+const SETTLE_MS = 250;
+
+let ctx: ITestContext;
+test.beforeAll(async ({ browser }) => {
+  ctx = await createTestContext(browser);
+  await openTerminal(ctx);
+});
+test.afterAll(async () => await ctx.page.close());
+
+/** Resolves once `fn` is true, so nothing here waits on a duration to make progress. */
+async function until(fn: () => boolean, what: string, timeoutMs: number = 5000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for ${what}`);
+    }
+    await timeout(10);
+  }
+}
+
+test.describe('Composition', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium', 'Input.imeSetComposition is a CDP method');
+
+  /** Opens a terminal, records onData, and runs `fn` with a CDP session attached. */
+  async function withComposition(fn: (cdp: CDPSession, data: string[]) => Promise<void>): Promise<void> {
+    await openTerminal(ctx);
+    const cdp = await ctx.page.context().newCDPSession(ctx.page);
+    const data: string[] = [];
+    const sub = ctx.proxy.onData(e => { data.push(e); });
+    try {
+      await ctx.page.locator('.xterm-helper-textarea').focus();
+      await fn(cdp, data);
+    } finally {
+      sub.dispose();
+      await cdp.detach();
+    }
+  }
+
+  /** Starts a preedit and waits until the helper textarea actually holds it. */
+  async function compose(cdp: CDPSession): Promise<void> {
+    await cdp.send('Input.imeSetComposition', {
+      text: COMPOSITION,
+      selectionStart: COMPOSITION.length,
+      selectionEnd: COMPOSITION.length
+    });
+    await pollFor(ctx.page, `document.querySelector('.xterm-helper-textarea').value`, COMPOSITION);
+  }
+
+  test('a keydown during composition must not send the composition twice (#5778)', async () => {
+    await withComposition(async (cdp, data) => {
+      await compose(cdp);
+
+      // A key the IME does not consume arrives while composing. On macOS this is the eisuu (英数)
+      // input source switch key, commonly bound to left Command with Karabiner-Elements; any
+      // keyCode outside CompositionHelper's exclusion list takes the same branch, and F7 is one
+      // CDP can dispatch on every platform. CompositionHelper.keydown() sends the composition
+      // immediately here.
+      await ctx.page.keyboard.press('F7');
+      await until(() => data.length >= 2, 'the keydown to send the composition and F7');
+
+      // The IME then commits, and the browser fires compositionend with the composed text still in
+      // the helper textarea. Before this was fixed the composition was emitted a second time.
+      await cdp.send('Input.insertText', { text: COMPOSITION });
+      await timeout(SETTLE_MS);
+
+      deepStrictEqual(data, [COMPOSITION, F7]);
+    });
+  });
+
+  test('a composition withdrawn by the IME is still sent exactly once', async () => {
+    await withComposition(async (cdp, data) => {
+      await compose(cdp);
+      await ctx.page.keyboard.press('F7');
+      await until(() => data.length >= 2, 'the keydown to send the composition and F7');
+
+      // An empty preedit: the IME withdraws the composition instead of committing it, which clears
+      // the helper textarea. The keydown has already sent the text and nothing may follow it.
+      await cdp.send('Input.imeSetComposition', { text: '', selectionStart: 0, selectionEnd: 0 });
+      await timeout(SETTLE_MS);
+
+      deepStrictEqual(data, [COMPOSITION, F7]);
+    });
+  });
+
+  test('a composition committed with no keydown is sent exactly once', async () => {
+    await withComposition(async (cdp, data) => {
+      await compose(cdp);
+      await cdp.send('Input.insertText', { text: COMPOSITION });
+      await until(() => data.length >= 1, 'the committed composition');
+      await timeout(SETTLE_MS);
+
+      deepStrictEqual(data, [COMPOSITION]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5778.

## Problem

When a keydown the IME does not consume arrives during composition — on macOS the eisuu (英数) input source switch key, commonly bound to left Command via Karabiner-Elements — the composed text is sent twice:

1. `CompositionHelper.keydown()` falls through the keyCode exclusion list and calls `_finalizeComposition(false)`, which sends the composition immediately.
2. The browser then fires `compositionend`. The deferred send scheduled by `_finalizeComposition(true)` reads the helper textarea, which was never cleared on this path, and emits the same text again.

The deferred path already carries the offset that would prevent this — `currentCompositionPosition.start += this._dataAlreadySent.length`, added for #3191 — but only `_handleAnyTextareaChanges()` (the keyCode 229 path) ever writes `_dataAlreadySent`. The immediate-finalize path does not record what it sent.

## Fix

Four lines: record the immediately sent text in `_dataAlreadySent`. The deferred send's existing offset then skips it, and if the IME commits more text between the keydown and `compositionend`, only the delta is emitted — the same semantics the 229 path already relies on. No key codes are special-cased, so this also covers kana, Korean 한/영 and other remapped switch keys.

## Reproducing it without an IME installed

The reason this class of bug is hard to act on is that nobody without a Japanese or Korean input method can see it. `Input.imeSetComposition` and `Input.insertText` make Chromium's renderer emit *real* `compositionstart`/`compositionupdate`/`compositionend` — not synthesised `CompositionEvent` objects — so the sequence can be driven from a test.

Measured on this branch's parent (`d3e32b34`) against a page with a plain `new Terminal()`, recording `term.onData`:

| step | before the fix | after |
|---|---|---|
| compose `こんにちは`, press F7, IME commits | `['こんにちは', '\x1b[18~', 'こんにちは']` | `['こんにちは', '\x1b[18~']` |
| compose, press F7, IME **withdraws** the preedit | `['こんにちは', '\x1b[18~']` | unchanged |
| compose, IME commits, **no** keydown | `['こんにちは']` | unchanged |

The first row is #5778 (`こんにちはこんにちは` — the eisuu key itself prints nothing, so the user sees the two runs adjacent). The other two rows are controls: they pass either way, so the new test file is not simply red on any composition.

`test/playwright/Composition.test.ts` is those three rows. It is skipped outside Chromium because `Input.imeSetComposition` is a CDP method; if you would rather that harness not live in the suite, I am happy to drop it and keep only the unit test.

F7 rather than the eisuu key: eisuu is macOS-only and needs Karabiner to produce, while any keyCode outside `{16, 17, 18, 20, 229}` takes the same branch in `keydown()`. `\x1b[18~` in the expected data is F7's own output.

## How this has been tested

Run on macOS 15 (arm64), Node 22:

- `npm run test-unit` — 2404 passing (2403 before the new unit test). With the fix reverted the new test fails with `expected 'こんにちはこんにちは' to equal 'こんにちは'`.
- `npm run test-integration -- --suite=core --project=Chromium` — 422 passed. With the fix reverted **and the demo bundle rebuilt**, the first row above fails and the two controls pass.
- `npm run lint` and `npm run lint-api` — clean.

Every composition event in the test is the browser's own — `Input.imeSetComposition` and `Input.insertText` drive the renderer's IME path, so `compositionstart`/`update`/`end` are produced by Chromium rather than dispatched as synthesised `CompositionEvent` objects. What the test orchestrates is the *ordering* #5778's reporters describe: a keydown while composing, then a commit.

The waits in the integration test poll for observable state; the one fixed delay is the settle before each negative assertion, since "nothing else was emitted" cannot be polled for.

## Relationship to the open composition PRs

- **#6041** proposed the same one-line change and was closed by its own author an hour later with no review or discussion; @shuntagami asked on #5778 whether it could be reconsidered. The fix here is that change, credited to @nimben419, plus the reproduction above.
- **#6060** contains this same assignment inside a larger reconciliation of the deferred textarea, `insertText` and `keypress` routes. If that lands first this PR is redundant and I will close it — the intent here is to offer the smallest reviewable fix for #5778 on its own, and a way to check it.
- **#6089 / #6090** are a different mechanism (a pending send cancelled during fast typing), and this change does not touch it.

