### PR TITLE
Detect a link that appears under a stationary cursor

### DIFF
--- a/src/browser/Linkifier.test.ts
+++ b/src/browser/Linkifier.test.ts
@@ -9,11 +9,19 @@ import { Linkifier } from './Linkifier';
 import { MockBufferService } from '../common/TestUtils.test';
 import { ILink } from './Types';
 import { LinkProviderService } from './services/LinkProviderService';
+import { IMouseCoordsService, IRenderService } from './services/Services';
+import { Emitter } from '../common/Event';
 import jsdom = require('jsdom');
 
 class TestLinkifier2 extends Linkifier {
   public set currentLink(link: any) {
     this._currentLink = link;
+  }
+
+  // Declaring only the setter would shadow the base class accessor pair, so
+  // reads of currentLink would be undefined however the link was set.
+  public get currentLink(): any {
+    return this._currentLink;
   }
 
   public linkHover(element: HTMLElement, link: ILink, event: MouseEvent): void {
@@ -25,7 +33,23 @@ class TestLinkifier2 extends Linkifier {
   }
 }
 
+/**
+ * Minimal render service stub exposing only what Linkifier listens to in its
+ * constructor (onRenderedViewportChange).
+ */
+class TestRenderService implements Partial<IRenderService> {
+  private readonly _onRenderedViewportChange = new Emitter<{ start: number, end: number }>();
+  public readonly onRenderedViewportChange = this._onRenderedViewportChange.event;
+  public fireRenderedViewportChange(start: number, end: number): void {
+    this._onRenderedViewportChange.fire({ start, end });
+  }
+}
+
 describe('Linkifier2', () => {
+  let dom: jsdom.JSDOM;
+  let element: HTMLElement;
+  let renderService: TestRenderService;
+  let linkProviderService: LinkProviderService;
   let bufferService: IBufferService;
   let linkifier: TestLinkifier2;
 
@@ -59,9 +83,13 @@ describe('Linkifier2', () => {
   };
 
   beforeEach(() => {
-    const dom = new jsdom.JSDOM();
+    dom = new jsdom.JSDOM();
+    element = dom.window.document.createElement('div');
     bufferService = new MockBufferService(100, 10);
-    linkifier = new TestLinkifier2(dom.window.document.createElement('div'), null!, null!, bufferService, new LinkProviderService());
+    renderService = new TestRenderService();
+    linkProviderService = new LinkProviderService();
+    const mouseCoordsService = { getCoords: () => [6, 1] } as unknown as IMouseCoordsService;
+    linkifier = new TestLinkifier2(element, mouseCoordsService, renderService as unknown as IRenderService, bufferService, linkProviderService);
     linkifier.currentLink = {
       link,
       state: {
@@ -124,6 +152,52 @@ describe('Linkifier2', () => {
     });
 
     linkifier.linkLeave({ classList: { add: () => { } } } as any, multiLineLink, {} as any);
+  });
+
+  it('should re-evaluate links when a line changes under a stationary pointer', async () => {
+    linkifier.currentLink = undefined;
+    let provideCalls = 0;
+    const pointerLink: ILink = {
+      text: 'http://example.com/',
+      range: {
+        start: {
+          x: 5,
+          y: 1
+        },
+        end: {
+          x: 7,
+          y: 1
+        }
+      },
+      activate: () => { }
+    };
+    linkProviderService.registerLinkProvider({
+      provideLinks: (y: number, callback: (links: ILink[] | undefined) => void) => {
+        provideCalls++;
+        // First query: the line under the pointer has no link yet. After the line's
+        // content changed (e.g. output scrolled it under the pointer): a link exists.
+        callback(provideCalls === 1 ? undefined : [pointerLink]);
+      }
+    });
+
+    // The pointer hovers the still-empty line, caching the "no link" answer for it
+    element.dispatchEvent(new dom.window.MouseEvent('mousemove'));
+    await new Promise(r => setTimeout(r, 0));
+    assert.equal(provideCalls, 1);
+    assert.isUndefined(linkifier.currentLink);
+
+    // Mouse movement within the same cell must not trigger a new query
+    element.dispatchEvent(new dom.window.MouseEvent('mousemove'));
+    await new Promise(r => setTimeout(r, 0));
+    assert.equal(provideCalls, 1);
+
+    // The viewport renders a change on the line under the stationary pointer
+    renderService.fireRenderedViewportChange(0, 5);
+    // Comfortably past the 50ms debounce so a loaded machine cannot fail this
+    await new Promise(r => setTimeout(r, 250));
+
+    assert.equal(provideCalls, 2, 'providers should be asked again after the line changed under the pointer');
+    assert.isDefined(linkifier.currentLink, 'the link under the stationary pointer should be detected');
   });
 
 });

--- a/src/browser/Linkifier.ts
+++ b/src/browser/Linkifier.ts
@@ -9,7 +9,13 @@ import { IDisposable } from '../common/Types';
 import { IBufferService } from '../common/services/Services';
 import { ILinkProviderService, IMouseCoordsService, IRenderService } from './services/Services';
 import { Emitter } from '../common/Event';
+import { TimeoutTimer } from '../common/Async';
 import { addDisposableListener } from './Dom';
+
+// Time to wait before re-evaluating the line under a stationary cursor after the viewport
+// changed. Debouncing only this path keeps regular mouse moves undelayed while avoiding a
+// re-evaluation per render when output is constantly streaming (#4323).
+const RECHECK_STATIONARY_CURSOR_DEBOUNCE_MS = 50;
 
 export class Linkifier extends Disposable implements ILinkifier2 {
   public get currentLink(): ILinkWithState | undefined { return this._currentLink; }
@@ -22,6 +28,7 @@ export class Linkifier extends Disposable implements ILinkifier2 {
   private _wasResized: boolean = false;
   private _activeProviderReplies: Map<Number, ILinkWithState[] | undefined> | undefined;
   private _activeLine: number = -1;
+  private readonly _recheckStationaryCursor = this._register(new TimeoutTimer());
 
   private readonly _onShowLinkUnderline = this._register(new Emitter<ILinkifierEvent>());
   public readonly onShowLinkUnderline = this._onShowLinkUnderline.event;
@@ -55,6 +62,28 @@ export class Linkifier extends Disposable implements ILinkifier2 {
     this._register(addDisposableListener(this._element, 'mousemove', this._handleMouseMove.bind(this)));
     this._register(addDisposableListener(this._element, 'mousedown', this._handleMouseDown.bind(this)));
     this._register(addDisposableListener(this._element, 'mouseup', this._handleMouseUp.bind(this)));
+    // Listen to viewport changes to detect a link appearing under a stationary cursor, which
+    // would otherwise stay undetected until the cursor moves (#4323). When a link is already
+    // active, the listener registered in _handleNewLink re-evaluates it instead.
+    this._register(this._renderService.onRenderedViewportChange(() => {
+      if (this._currentLink || this._isMouseOut || !this._lastMouseEvent) {
+        return;
+      }
+      this._recheckStationaryCursor.cancelAndSet(() => {
+        // The state may have changed while the timer was pending
+        if (this._currentLink || this._isMouseOut || !this._lastMouseEvent) {
+          return;
+        }
+        const position = this._positionFromMouseEvent(this._lastMouseEvent, this._element);
+        if (!position) {
+          return;
+        }
+        // Invalidate the cached line so the providers are asked again for the line under the
+        // cursor
+        this._activeLine = -1;
+        this._handleHover(position);
+      }, RECHECK_STATIONARY_CURSOR_DEBOUNCE_MS);
+    }));
   }
 
   private _handleMouseMove(event: MouseEvent): void {


### PR DESCRIPTION
Fixes #4323.

## The case

`Linkifier` caches a provider's answer against a viewport row index (`_activeLine`) and only re-asks on mouse move. A row the cursor is resting on, whose providers answered "no link" while it was empty, keeps that answer as output scrolls a link into it — no underline, and a click does nothing until the cursor leaves the row and comes back.

#4298 covers the complementary case (a link that is *already* active when its line changes), but its listener is registered in `_handleNewLink` and pushed onto `_linkCacheDisposables`, so it only exists once a link exists — which is exactly what this case does not have.

## The approach

This follows the sketch in #4323 and the debouncing discussion under it, with one correction: `_handleMouseMove(this._lastMouseEvent)` cannot work today, because two guards short-circuit a cursor that has not moved.

- `_handleMouseMove` returns early when the position equals `_lastBufferCell` (Linkifier.ts:83) — a stationary cursor is the same cell.
- `_handleHover` takes the cached branch when `_activeLine === position.y` (Linkifier.ts:93) — the row *index* is unchanged even though the row's content is not.

So the new listener invalidates `_activeLine` and calls `_handleHover` directly. It:

- is registered in the constructor, not in `_linkCacheDisposables`, and returns immediately when `_currentLink` is set, so it never overlaps the #4298 path;
- returns when the mouse has never been over the terminal or has left it;
- debounces by 50ms, as suggested in the issue thread, so constant output does not mean a provider query per render. **Only this path is debounced** — the mouse-move path is untouched, so underlines still appear without added latency;
- re-checks its guards when the timer fires, since the mouse may have moved in the meantime;
- uses `TimeoutTimer` from `common/Async`, registered as a disposable.

## Verification

- New unit test in `Linkifier.test.ts`. It fails against `master` with `expected 2, actual 1` (the providers are never asked a second time) and passes with the change. It also pins that a mouse move *within the same cell* still does not trigger a query, so the existing short-circuit is not lost.
- Manually reproduced with the repro in #4323 against the demo (`npm start`), driven so the pointer is placed exactly once and never moved again. Before: the link passes under the pointer and `xterm-cursor-pointer` is never set — 0 of 91 samples over the 14s recipe. After: the link activates under the stationary pointer and a click at the unchanged position fires `activate`. Moving the mouse one row in the "before" run makes the link appear, confirming the link itself was there all along.
- `npm run build`, `npm run test-unit` (2404 passing) and `npm run lint` are clean.

Verification boundary: `test-integration` was not run locally. The "before" browser run used approximate pointer coordinates and the "after" run used measured ones, so the two are not pixel-identical; the "before" evidence stands on the link demonstrably occupying the pointer's row during the sampled window.

The test file gains a small render-service stub, because the constructor now subscribes to `onRenderedViewportChange` and the existing tests passed `null!` for it. `TestLinkifier2` also gains a `currentLink` getter — declaring only the setter shadowed the base class accessor pair, so reads were always `undefined`.