### PR TITLE
Fix WebGL addon disposal without core store

### DIFF
--- a/addons/addon-webgl/src/WebglAddon.ts
+++ b/addons/addon-webgl/src/WebglAddon.ts
@@ -88,7 +88,7 @@ export class WebglAddon extends Disposable implements ITerminalAddon, IWebglApi 
     renderService.setRenderer(this._renderer);
 
     this._register(toDisposable(() => {
-      if ((this._terminal as any)._core._store._isDisposed) {
+      if ((this._terminal as any)._core._store?._isDisposed) {
         return;
       }
       const renderService: IRenderService = (this._terminal as any)._core._renderService;

--- a/addons/addon-webgl/test/WebglRenderer.test.ts
+++ b/addons/addon-webgl/test/WebglRenderer.test.ts
@@ -40,4 +40,17 @@ test.describe('WebGL Renderer Integration Tests', async () => {
       } catch (e) {}
     `);
   });
+
+  test('disposes when the terminal core has no store', async () => {
+    await ctx.page.evaluate(() => {
+      const core = (window.term as any)._core;
+      const store = core._store;
+      core._store = undefined;
+      try {
+        window.addon!.dispose();
+      } finally {
+        core._store = store;
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`@xterm/addon-webgl` reads the internal terminal core store while disposing. Supported xterm 5.5 cores do not expose that store, so disposal throws before renderer cleanup.

Fixes #6143.

## Fix

Treat the internal store as optional in the existing disposed-core guard. Cores that expose the store retain the current behavior; older supported cores continue through the existing renderer-restoration cleanup.

## Tests

- `npm run build` — passed
- `npm run esbuild` — passed
- `npm run esbuild-demo-client` — passed
- Chromium regression `disposes when the terminal core has no store` — passed
- `npm run lint-changes` — passed
- `git diff --check` — passed

The regression failed before the source change with `Cannot read properties of undefined (reading '_isDisposed')`.
