### PR TITLE
webgl: stop the link render layer from acquiring a texture atlas

### DIFF
--- a/addons/addon-webgl/src/renderLayer/BaseRenderLayer.ts
+++ b/addons/addon-webgl/src/renderLayer/BaseRenderLayer.ts
@@ -3,8 +3,6 @@
  * @license MIT
  */
 
-import { ReadonlyColorSet } from 'browser/Types';
-import { acquireTextureAtlas } from '../CharAtlasCache';
 import { IRenderDimensions } from 'browser/renderer/shared/Types';
 import { ICoreBrowserService, IThemeService } from 'browser/services/Services';
 import { Disposable, toDisposable } from 'common/Lifecycle';
@@ -14,7 +12,6 @@ import { Terminal } from '@xterm/xterm';
 import { IRenderLayer } from './Types';
 import { throwIfFalsy } from 'browser/renderer/shared/RendererUtils';
 import { TEXT_BASELINE } from '../Constants';
-import type { ITextureAtlas } from '../Types';
 
 export abstract class BaseRenderLayer extends Disposable implements IRenderLayer {
   private _canvas: HTMLCanvasElement;
@@ -25,8 +22,6 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
   private _deviceCellHeight: number = 0;
   private _deviceCharLeft: number = 0;
   private _deviceCharTop: number = 0;
-
-  protected _charAtlas: ITextureAtlas | undefined;
 
   constructor(
     terminal: Terminal,
@@ -44,8 +39,7 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     this._canvas.style.zIndex = zIndex.toString();
     this._initCanvas();
     this._container.appendChild(this._canvas);
-    this._register(this._themeService.onChangeColors(e => {
-      this._refreshCharAtlas(terminal, e);
+    this._register(this._themeService.onChangeColors(() => {
       this.reset(terminal);
     }));
     this._register(toDisposable(() => {
@@ -81,23 +75,8 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     this._initCanvas();
     this._container.replaceChild(this._canvas, oldCanvas);
 
-    // Regenerate char atlas and force a full redraw
-    this._refreshCharAtlas(terminal, this._themeService.colors);
+    // Force a full redraw
     this.handleGridChanged(terminal, 0, terminal.rows - 1);
-  }
-
-  /**
-   * Refreshes the char atlas, aquiring a new one if necessary.
-   * @param terminal The terminal.
-   * @param colorSet The color set to use for the char atlas.
-   */
-  private _refreshCharAtlas(terminal: Terminal, colorSet: ReadonlyColorSet): void {
-    if (this._deviceCharWidth <= 0 && this._deviceCharHeight <= 0) {
-      return;
-    }
-
-    this._charAtlas = acquireTextureAtlas(terminal, this._optionsService.rawOptions, colorSet, this._deviceCellWidth, this._deviceCellHeight, this._deviceCharWidth, this._deviceCharHeight, this._coreBrowserService.dpr, 2048);
-    this._charAtlas.warmUp();
   }
 
   public resize(terminal: Terminal, dim: IRenderDimensions): void {
@@ -116,8 +95,6 @@ export abstract class BaseRenderLayer extends Disposable implements IRenderLayer
     if (!this._alpha) {
       this._clearAll();
     }
-
-    this._refreshCharAtlas(terminal, this._themeService.colors);
   }
 
   public abstract reset(terminal: Terminal): void;

--- a/addons/addon-webgl/test/WebglLinkLayerAtlas.test.ts
+++ b/addons/addon-webgl/test/WebglLinkLayerAtlas.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import test, { expect } from '@playwright/test';
+import type { Terminal, ITerminalInitOnlyOptions, ITerminalOptions } from '@xterm/xterm';
+import type { IWebglAddonOptions, WebglAddon } from '@xterm/addon-webgl';
+import { ITestContext, createTestContext, openTerminal } from '../../../test/playwright/TestUtils';
+
+type TestTerminalConstructor = new (options?: ITerminalOptions & ITerminalInitOnlyOptions) => ITestTerminal;
+type TestWebglAddonConstructor = new (options?: IWebglAddonOptions) => ITestWebglAddon;
+
+interface ITestTextureAtlas {
+  dispose(): void;
+  __probeTag?: string;
+  __probeDisposeCount?: number;
+}
+
+interface ITestRenderer {
+  _charAtlas?: ITestTextureAtlas;
+}
+
+interface ITestRenderService {
+  _renderer?: {
+    value?: ITestRenderer;
+  };
+}
+
+interface ITestTerminal extends Terminal {
+  _core?: {
+    _renderService?: ITestRenderService;
+  };
+}
+
+interface ITestWebglAddon extends WebglAddon {
+  _renderer?: ITestRenderer;
+}
+
+declare global {
+  interface Window { // eslint-disable-line @typescript-eslint/naming-convention
+    Terminal: TestTerminalConstructor;
+    WebglAddon: TestWebglAddonConstructor;
+    term: ITestTerminal;
+    addon?: ITestWebglAddon;
+  }
+}
+
+async function loadWebglStrict(ctx: ITestContext): Promise<void> {
+  await ctx.page.evaluate(() => {
+    window.addon = new window.WebglAddon({ preserveDrawingBuffer: true });
+    window.term.loadAddon(window.addon);
+  });
+  const isWebglRenderer = await ctx.page.evaluate(() => {
+    return !!window.addon && window.term?._core?._renderService?._renderer?.value === window.addon._renderer;
+  });
+  expect(isWebglRenderer, 'WebGL renderer must be active').toBe(true);
+}
+
+async function writeAndWaitForRender(ctx: ITestContext, data: string): Promise<void> {
+  const renderPromise = new Promise<void>(resolve => {
+    const disposable = ctx.proxy.onRender(() => {
+      disposable.dispose();
+      resolve();
+    });
+  });
+  await ctx.proxy.write(data);
+  await renderPromise;
+}
+
+/**
+ * Tags the renderer's current atlas and wraps its dispose so a later check can
+ * tell whether the same atlas instance is still in use and whether anything
+ * disposed it along the way.
+ */
+async function tagCurrentAtlas(ctx: ITestContext): Promise<void> {
+  const tagged = await ctx.page.evaluate(() => {
+    const atlas = window.term._core?._renderService?._renderer?.value?._charAtlas;
+    if (!atlas) {
+      return false;
+    }
+    atlas.__probeTag = 'original';
+    atlas.__probeDisposeCount = 0;
+    const originalDispose = atlas.dispose.bind(atlas);
+    atlas.dispose = () => {
+      atlas.__probeDisposeCount = (atlas.__probeDisposeCount ?? 0) + 1;
+      originalDispose();
+    };
+    return true;
+  });
+  expect(tagged, 'the WebGL renderer must have acquired a texture atlas').toBe(true);
+}
+
+async function readAtlasProbe(ctx: ITestContext): Promise<{ sameInstance: boolean, disposeCount: number | undefined }> {
+  return ctx.page.evaluate(() => {
+    const atlas = window.term._core?._renderService?._renderer?.value?._charAtlas;
+    return {
+      sameInstance: atlas?.__probeTag === 'original',
+      disposeCount: atlas?.__probeDisposeCount
+    };
+  });
+}
+
+test.describe('link layer must not churn the shared texture atlas', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium');
+  test.describe.configure({ timeout: 60000 });
+
+  test('resizing keeps the renderer on the same atlas instance', async ({ browser }) => {
+    // The link render layer used to acquire an atlas with a hard-coded device
+    // max texture size. Once that field became part of atlas cache equality, a
+    // sole-owner terminal would release its real atlas on every layer resize
+    // and the renderer would rebuild it straight after, so each terminal resize
+    // discarded a full atlas (and every embedder resize on tab switch did too).
+    const ctx = await createTestContext(browser);
+    try {
+      await openTerminal(ctx, { cols: 80, rows: 24 });
+      await loadWebglStrict(ctx);
+      await writeAndWaitForRender(ctx, 'hello https://example.com world');
+      await tagCurrentAtlas(ctx);
+
+      for (const [cols, rows] of [[100, 30], [80, 24], [120, 40], [80, 24]]) {
+        await ctx.proxy.resize(cols, rows);
+        await writeAndWaitForRender(ctx, `\x1b[${rows};1Hresized ${cols}x${rows}`);
+      }
+
+      const probe = await readAtlasProbe(ctx);
+      expect(probe.disposeCount, 'the atlas must not be disposed by a resize').toBe(0);
+      expect(probe.sameInstance, 'the renderer must still hold the atlas it started with').toBe(true);
+    } finally {
+      await ctx.page.close();
+    }
+  });
+
+  test('changing theme colors keeps the renderer on the same atlas instance when the palette is unchanged', async ({ browser }) => {
+    const ctx = await createTestContext(browser);
+    try {
+      await openTerminal(ctx, { cols: 80, rows: 24 });
+      await loadWebglStrict(ctx);
+      await writeAndWaitForRender(ctx, 'hello world');
+      await tagCurrentAtlas(ctx);
+
+      // Re-assigning the same theme fires onChangeColors, which the link layer
+      // also listens to; the atlas config is unchanged so it must be reused.
+      await ctx.page.evaluate(() => {
+        window.term.options.theme = { ...window.term.options.theme };
+      });
+      await writeAndWaitForRender(ctx, ' again');
+
+      const probe = await readAtlasProbe(ctx);
+      expect(probe.disposeCount, 'the atlas must not be disposed by an unchanged theme').toBe(0);
+      expect(probe.sameInstance, 'the renderer must still hold the atlas it started with').toBe(true);
+    } finally {
+      await ctx.page.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`BaseRenderLayer` in the WebGL addon acquires a texture atlas on every resize, colour change and transparency change, passing a hard-coded `2048` as the device max texture size. Nothing in the layer reads that atlas: `LinkRenderLayer`, its only subclass, draws underlines with `fillRect` and never touches `_charAtlas`.

Since #5929 added `deviceMaxTextureSize` to `configEquals`, that acquisition stopped being a cache hit. On any GPU whose `MAX_TEXTURE_SIZE` is not 2048, the layer's config never equals the renderer's, so `acquireTextureAtlas`:

1. finds the terminal owning the real atlas, sees a differing config, and releases it — calling `atlas.dispose()` when the terminal is the sole owner;
2. builds a fresh atlas with `deviceMaxTextureSize: 2048` and warms it up;
3. is then called again from `WebglRenderer._refreshCharAtlas` with the real size, which disposes the 2048 atlas and rebuilds the real one.

`WebglRenderer.handleResize` calls `layer.resize()` before its own `_refreshCharAtlas()`, so every terminal resize pays this in full. Embedders that resize on tab switch (VS Code does, via `TerminalInstance._resize` → `xterm.resize`) pay it on every tab switch.

Each cycle discards two atlases' worth of 512×512 page canvases and a warm-up of 93 glyphs. On a VS Code session with ~30 CJK-heavy terminals, the GPU process's IOSurface count climbs with tab switches and heavy output and only comes back on a full atlas evict; this PR removes one of the sources feeding that.

## Changes

- `BaseRenderLayer.ts`: remove `_charAtlas`, `_refreshCharAtlas` and its three call sites (constructor colour listener, `_setTransparency`, `resize`), plus the now-unused imports. −24 lines, no behaviour change for the link layer, which never used the atlas.
- `test/WebglLinkLayerAtlas.test.ts`: two Playwright tests that tag the renderer's atlas and wrap its `dispose`, then assert the same instance survives (a) four resizes and (b) an unchanged theme reassignment, with `dispose` never called. Both fail on master with the atlas replaced.

## Testing

- `npm run test-unit`: 2403 passing
- `npm run lint`: clean
- `npm run test-integration --suite=addon-webgl` (Chromium): 64 passed, 9 skipped (Firefox/WebKit projects)
- A/B on the new tests: 2 failed on master, 2 passed with this change

## Why this is low risk

The removed code produced a value nothing consumed. `acquireTextureAtlas` / `removeTerminalFromCache` pairing stays with `WebglRenderer`, which already owns both sides. `LinkRenderLayer` keeps its own canvas and its `onChangeColors` → `reset()` path.

Related: #5929 (made the mismatch observable), #6074 (atlas growth from per-cell background colours, a separate source), microsoft/vscode#329118 (maintainer trace attributing renderer load to rapid atlas invalidation).
