### PR TITLE
Align the IME preedit to the renderer cell grid

### DIFF
--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -255,8 +255,11 @@ describe('CompositionHelper', () => {
 
   describe('Composition view layout', () => {
     function cells(): HTMLElement[] {
-      const text = compositionView.firstElementChild!;
-      assert.equal((text as HTMLElement).style.direction, 'ltr');
+      const text = compositionView.firstElementChild! as HTMLElement;
+      // direction alone has no effect on an inline box, the cells are only kept in logical order
+      // inside the view's direction=rtl by the isolate
+      assert.equal(text.style.direction, 'ltr');
+      assert.equal(text.style.unicodeBidi, 'isolate');
       return Array.from(text.children) as HTMLElement[];
     }
 
@@ -292,6 +295,17 @@ describe('CompositionHelper', () => {
       renderService.dimensions.css.cell.width = 7;
       compositionHelper.updateCompositionElements(true);
       assert.deepEqual(cells().map(e => e.style.width), ['7px', '7px']);
+    });
+
+    it('should not re-align text from a composition that has ended', () => {
+      compositionHelper.compositionupdate({ data: 'ab' });
+      compositionHelper.compositionend();
+      // A cell width change outside of a composition is not picked up until the next composition,
+      // which must not bring the previous text back with it
+      renderService.dimensions.css.cell.width = 7;
+      compositionHelper.compositionstart();
+      compositionHelper.updateCompositionElements(true);
+      assert.equal(compositionView.textContent, '');
     });
   });
 });

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -4,31 +4,22 @@
  */
 
 import { assert } from 'chai';
+import jsdom = require('jsdom');
 import { CompositionHelper } from './CompositionHelper';
 import { MockRenderService } from '../TestUtils.test';
-import { MockCoreService, MockBufferService, MockOptionsService } from '../../common/TestUtils.test';
+import { MockCoreService, MockBufferService, MockOptionsService, MockUnicodeService } from '../../common/TestUtils.test';
 
 describe('CompositionHelper', () => {
   let compositionHelper: CompositionHelper;
   let compositionView: HTMLElement;
   let textarea: HTMLTextAreaElement;
+  let renderService: MockRenderService;
   let handledText: string;
 
   beforeEach(() => {
-    compositionView = {
-      classList: {
-        add: () => {},
-        remove: () => {}
-      },
-      getBoundingClientRect: () => {
-        return { width: 0 };
-      },
-      style: {
-        left: 0,
-        top: 0
-      },
-      textContent: ''
-    } as any;
+    const document = new jsdom.JSDOM('').window.document;
+    compositionView = document.createElement('div');
+    compositionView.getBoundingClientRect = () => ({ width: 0, height: 0 }) as any;
     textarea = {
       value: '',
       style: {
@@ -42,7 +33,8 @@ describe('CompositionHelper', () => {
     };
     handledText = '';
     const bufferService = new MockBufferService(10, 5);
-    compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), coreService, new MockRenderService());
+    renderService = new MockRenderService();
+    compositionHelper = new CompositionHelper(textarea, compositionView, bufferService, new MockOptionsService(), coreService, renderService, new MockUnicodeService());
   });
 
   describe('Input', () => {
@@ -258,6 +250,48 @@ describe('CompositionHelper', () => {
           done();
         }, 0);
       }, 0);
+    });
+  });
+
+  describe('Composition view layout', () => {
+    function cells(): HTMLElement[] {
+      const text = compositionView.firstElementChild!;
+      assert.equal((text as HTMLElement).style.direction, 'ltr');
+      return Array.from(text.children) as HTMLElement[];
+    }
+
+    beforeEach(() => {
+      // A cell width the font's own advance width will not agree with, as happens when the webgl
+      // renderer floors the cell width to whole device pixels (see #6161)
+      renderService.dimensions.css.cell.width = 6;
+      compositionHelper.compositionstart();
+    });
+
+    it('should give each cell the renderer\'s cell width', () => {
+      compositionHelper.compositionupdate({ data: 'ab' });
+      assert.deepEqual(cells().map(e => [e.textContent, e.style.width]), [['a', '6px'], ['b', '6px']]);
+    });
+
+    it('should give full width characters two cells worth of width', () => {
+      compositionHelper.compositionupdate({ data: 'あい' });
+      assert.deepEqual(cells().map(e => [e.textContent, e.style.width]), [['あ', '12px'], ['い', '12px']]);
+    });
+
+    it('should keep combining characters in the cell they attach to', () => {
+      compositionHelper.compositionupdate({ data: 'e\u0301a' });
+      assert.deepEqual(cells().map(e => [e.textContent, e.style.width]), [['e\u0301', '6px'], ['a', '6px']]);
+    });
+
+    it('should keep surrogate pairs in a single cell', () => {
+      compositionHelper.compositionupdate({ data: '𠮷' });
+      assert.deepEqual(cells().map(e => [e.textContent, e.style.width]), [['𠮷', '12px']]);
+    });
+
+    it('should re-align the text when the cell width changes', () => {
+      compositionHelper.compositionupdate({ data: 'ab' });
+      renderService.dimensions.css.cell.width = 7;
+      compositionHelper.updateCompositionElements(true);
+      assert.deepEqual(cells().map(e => e.style.width), ['7px', '7px']);
     });
   });
 });

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -4,12 +4,22 @@
  */
 
 import { IRenderService } from '../services/Services';
-import { IBufferService, ICoreService, IOptionsService } from '../../common/services/Services';
+import { IBufferService, ICoreService, IOptionsService, IUnicodeService, UnicodeCharProperties } from '../../common/services/Services';
+import { UnicodeService } from '../../common/services/UnicodeService';
 import { C0 } from '../../common/data/EscapeSequences';
 
 interface IPosition {
   start: number;
   end: number;
+}
+
+/**
+ * A run of characters that occupies a single cell on the terminal's grid, together with how many
+ * columns that cell spans.
+ */
+interface ICompositionCell {
+  chars: string;
+  width: number;
 }
 
 /**
@@ -52,19 +62,33 @@ export class CompositionHelper {
    */
   private _textareaChangeTimer?: number;
 
+  /**
+   * The text of the composition currently shown in the composition view.
+   */
+  private _compositionText: string;
+
+  /**
+   * The cell width the composition view was last laid out with, used to detect when the grid the
+   * preedit is aligned to has changed.
+   */
+  private _renderedCellWidth: number;
+
   constructor(
     private readonly _textarea: HTMLTextAreaElement,
     private readonly _compositionView: HTMLElement,
     @IBufferService private readonly _bufferService: IBufferService,
     @IOptionsService private readonly _optionsService: IOptionsService,
     @ICoreService private readonly _coreService: ICoreService,
-    @IRenderService private readonly _renderService: IRenderService
+    @IRenderService private readonly _renderService: IRenderService,
+    @IUnicodeService private readonly _unicodeService: IUnicodeService
   ) {
     this._isComposing = false;
     this._isSendingComposition = false;
     this._compositionPosition = { start: 0, end: 0 };
     this._compositionSuffix = '';
     this._dataAlreadySent = '';
+    this._compositionText = '';
+    this._renderedCellWidth = -1;
   }
 
   /**
@@ -79,6 +103,7 @@ export class CompositionHelper {
     this._compositionPosition.start = Math.min(start, end);
     this._compositionPosition.end = Math.max(start, end);
     this._compositionSuffix = this._textarea.value.substring(this._compositionPosition.end);
+    this._compositionText = '';
     this._compositionView.textContent = '';
     this._dataAlreadySent = '';
     this._compositionView.classList.add('active');
@@ -89,9 +114,8 @@ export class CompositionHelper {
    * @param ev The event.
    */
   public compositionupdate(ev: Pick<CompositionEvent, 'data'>): void {
-    // Mark text as LTR, direction=rtl is used in CSS so the end of the text is followed for long
-    // compositions
-    this._compositionView.textContent = `\u200E${ev.data}\u200E`;
+    this._compositionText = ev.data;
+    this._layoutCompositionText();
     this.updateCompositionElements();
     setTimeout(() => {
       const end = this._textarea.selectionEnd ?? this._textarea.value.length;
@@ -250,9 +274,16 @@ export class CompositionHelper {
     if (this._bufferService.buffer.isCursorInViewport) {
       const cursorX = Math.min(this._bufferService.buffer.x, this._bufferService.cols - 1);
 
+      const cellWidth = this._renderService.dimensions.css.cell.width;
       const cellHeight = this._renderService.dimensions.css.cell.height;
-      const cursorTop = this._bufferService.buffer.y * this._renderService.dimensions.css.cell.height;
-      const cursorLeft = cursorX * this._renderService.dimensions.css.cell.width;
+      const cursorTop = this._bufferService.buffer.y * cellHeight;
+      const cursorLeft = cursorX * cellWidth;
+
+      // Re-align the text to the grid if the renderer changed the cell width, eg. because the font
+      // size changed while composing.
+      if (cellWidth !== this._renderedCellWidth) {
+        this._layoutCompositionText();
+      }
 
       this._compositionView.style.left = cursorLeft + 'px';
       this._compositionView.style.top = cursorTop + 'px';
@@ -262,7 +293,7 @@ export class CompositionHelper {
       this._compositionView.style.fontSize = this._optionsService.rawOptions.fontSize + 'px';
       // Limit the composition view width to the space between the cursor and
       // the terminal's right edge, preventing it from overflowing the terminal.
-      const maxWidth = this._bufferService.cols * this._renderService.dimensions.css.cell.width - cursorLeft;
+      const maxWidth = this._bufferService.cols * cellWidth - cursorLeft;
       this._compositionView.style.maxWidth = maxWidth + 'px';
       this._compositionView.style.overflow = 'hidden';
       this._compositionView.style.direction = 'rtl';
@@ -280,5 +311,78 @@ export class CompositionHelper {
     if (!dontRecurse) {
       setTimeout(() => this.updateCompositionElements(true), 0);
     }
+  }
+
+  /**
+   * Lays the composition text out on the same cell grid the terminal is drawn on.
+   *
+   * The composition view is positioned and sized from the renderer's cell dimensions, but the text
+   * inside it used to be laid out by the DOM at the font's own advance widths. Renderers are free
+   * to round the cell width to something else (the webgl renderer floors it to whole device
+   * pixels), so the two disagree and the preedit drifts away from the grid by that difference for
+   * every cell. Giving each cell a box of exactly the renderer's cell width keeps the preedit on
+   * the grid whatever the renderer rounded to.
+   */
+  private _layoutCompositionText(): void {
+    const doc = this._compositionView.ownerDocument;
+    const cellWidth = this._renderService.dimensions.css.cell.width;
+
+    // The composition view uses direction=rtl so the end of the text stays visible for
+    // compositions that are longer than the rest of the row. Isolate the cells inside an ltr run
+    // so that only the overflow follows that direction, not the order of the cells themselves.
+    const textElement = doc.createElement('span');
+    textElement.style.direction = 'ltr';
+    textElement.style.unicodeBidi = 'isolate';
+
+    for (const cell of this._splitIntoCells(this._compositionText)) {
+      const cellElement = doc.createElement('span');
+      cellElement.textContent = cell.chars;
+      cellElement.style.display = 'inline-block';
+      cellElement.style.width = `${cell.width * cellWidth}px`;
+      textElement.appendChild(cellElement);
+    }
+
+    this._compositionView.replaceChildren(textElement);
+    this._renderedCellWidth = cellWidth;
+  }
+
+  /**
+   * Splits text into cells the same way the buffer does, so that each cell can be given the width
+   * the renderer draws it at. Zero width characters (eg. combining marks) are kept in the cell of
+   * the character they attach to, otherwise they would be laid out on their own and would no
+   * longer combine.
+   * @param text The text to split.
+   */
+  private _splitIntoCells(text: string): ICompositionCell[] {
+    const cells: ICompositionCell[] = [];
+    let precedingInfo: UnicodeCharProperties = 0;
+    for (let i = 0; i < text.length; i++) {
+      let code = text.charCodeAt(i);
+      let chars = text.charAt(i);
+      // Convert a valid surrogate pair into a single codepoint, otherwise treat the parts
+      // independently (UCS-2 behavior)
+      if (0xD800 <= code && code <= 0xDBFF && i + 1 < text.length) {
+        const second = text.charCodeAt(i + 1);
+        if (0xDC00 <= second && second <= 0xDFFF) {
+          code = (code - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
+          chars += text.charAt(++i);
+        }
+      }
+      const currentInfo = this._unicodeService.charProperties(code, precedingInfo);
+      const width = UnicodeService.extractWidth(currentInfo);
+      const shouldJoin = UnicodeService.extractShouldJoin(currentInfo);
+      if (cells.length > 0 && (shouldJoin || width === 0)) {
+        const previousCell = cells[cells.length - 1];
+        previousCell.chars += chars;
+        if (shouldJoin) {
+          // The width reported for a joining char is that of the whole cluster
+          previousCell.width = width;
+        }
+      } else {
+        cells.push({ chars, width });
+      }
+      precedingInfo = currentInfo;
+    }
+    return cells;
   }
 }


### PR DESCRIPTION
## Summary

The composition view is positioned and sized from the renderer's cell dimensions, but the text
inside it was laid out by the DOM at the font's own advance widths. The webgl renderer floors the
cell width to whole device pixels, so the two disagree and the preedit drifts off the grid by
`advance - cellWidth` for every cell — a whole pixel per full-width character with the default
`monospace` at 13px on a `devicePixelRatio: 1` display.

`CompositionHelper` now lays the preedit out one cell at a time, giving each cell a box of exactly
the renderer's cell width, the same way `DomRenderer` snaps its rows to the grid with per-span
letter spacing.

Fixes #6161

## Changes

- Split the composition text into cells with `IUnicodeService` (as the buffer does) and render each
  as an `inline-block` span of `width * cellWidth`
- Keep combining marks and other zero-width characters in the cell of the character they attach to,
  so they still combine instead of being laid out on their own
- Wrap the cells in a `direction: ltr; unicode-bidi: isolate` run, replacing the LRM marks that used
  to keep the text LTR inside the `direction: rtl` view
- Re-lay out when the renderer's cell width changes, eg. on a font size change while composing

## Behaviour

| | Before | After |
|---|---|---|
| Preedit advance per cell | the font's own advance | the renderer's cell width |
| `.composition-view` content | one text node wrapped in LRM | one span per cell inside an ltr run |

Applies to every composition input, not only CJK (Vietnamese Telex, Indic scripts, press-and-hold
accents, dictation). The DOM structure change is worth noting for anyone styling
`.composition-view` directly.

## Verification

**Done**

- [x] `npm run test-unit` (2408 passing), `npm run tsc` and `npm run lint` clean. The
      `CompositionHelper` mock view is now a real jsdom element and 5 layout tests were added.
- [x] Chrome 152 + webgl addon, dpr 2, `monospace` at 10.9px (advance 5.45px vs cell width 5px),
      10 full-width characters: preedit width 109px → 100px, max per-cell offset error 9px → 0px.
- [x] A 200 character preedit still clips at its start and ends flush with the view's right edge,
      ie. the `direction: rtl` overflow behaviour is preserved.

**Needs checking**

- [ ] Real IME input on a `devicePixelRatio: 1` display
      1. Open the demo on a non-HiDPI monitor with the webgl renderer
      2. Start a CJK IME and type a several-character preedit
      3. The preedit stays on the cell grid, and the candidate window still sits under it
- [ ] Combining input (eg. Vietnamese Telex, macOS press-and-hold accents) renders the mark on its
      base character rather than in a cell of its own
