### PR TITLE
Reduce max length of an empty buffer on resize

### DIFF
--- a/src/common/buffer/Buffer.test.ts
+++ b/src/common/buffer/Buffer.test.ts
@@ -170,6 +170,24 @@ describe('Buffer', () => {
       });
     });
 
+    describe('row size reduced before the buffer is filled', () => {
+      it('should reduce max length of an empty no-scrollback buffer so it cannot acquire scrollback (#6163)', () => {
+        buffer = new TestBuffer(false, optionsService, bufferService, new MockLogService());
+        assert.equal(buffer.lines.maxLength, INIT_ROWS);
+        buffer.resize(INIT_COLS, INIT_ROWS - 10);
+        assert.equal(buffer.lines.maxLength, INIT_ROWS - 10);
+        buffer.fillViewportRows();
+        assert.equal(buffer.lines.length, INIT_ROWS - 10);
+        assert.isTrue(buffer.lines.isFull);
+      });
+
+      it('should reduce max length of an empty scrollback buffer', () => {
+        assert.equal(buffer.lines.maxLength, INIT_ROWS + INIT_SCROLLBACK);
+        buffer.resize(INIT_COLS, INIT_ROWS - 10);
+        assert.equal(buffer.lines.maxLength, INIT_ROWS - 10 + INIT_SCROLLBACK);
+      });
+    });
+
     describe('row size increased', () => {
       describe('empty buffer', () => {
         it('should add blank lines to end', () => {

--- a/src/common/buffer/Buffer.ts
+++ b/src/common/buffer/Buffer.ts
@@ -167,7 +167,7 @@ export class Buffer extends Disposable implements IBuffer {
     // Increase max length if needed before adjustments to allow space to fill
     // as required.
     const newMaxLength = this._getCorrectBufferLength(newRows);
-    if (newMaxLength > this.lines.maxLength) {
+    if (newMaxLength > this.lines.maxLength || this.lines.length === 0) {
       this.lines.maxLength = newMaxLength;
     }
 


### PR DESCRIPTION
Fixes #6163

- `Buffer.resize` reduced `lines.maxLength` only when `lines.length > 0`; an unfilled buffer kept the old capacity.
- The alternate buffer is empty until first activated, so a shrink before that left it with `maxLength > rows`.
- A no-scrollback buffer with spare capacity pushes lines and raises `ybase` on scroll instead of recycling; a later grow pulls those rows back into view (duplicated rows under tmux after a window resize).
- Fix: set `maxLength` on an empty buffer in both directions.
- Tests: `Buffer.test.ts` — empty no-scrollback buffer is full once filled after a shrink; empty scrollback buffer follows the new row count. Both fail without the fix.
